### PR TITLE
feat(F2): public API surface — EdgeRum namespace, value types, SwiftUI modifiers, terminology firewall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,8 @@
 #   build     — `swift build -c release` + `xcodebuild` against iOS device
 #               + simulator destinations.
 #   test      — `swift test --enable-code-coverage`.
-#   audit     — `Tools/check-supported-ios.sh` (iOS-floor consistency).
+#   audit     — `Tools/check-supported-ios.sh` (iOS-floor consistency) +
+#               `Tools/firewall-check.sh` (Rule 1 — terminology firewall).
 #   pod-lint  — `pod lib lint EdgeRum.podspec --allow-warnings`.
 #
 # All jobs run on a macos-15 runner with the default Xcode 16 toolchain
@@ -19,7 +20,8 @@
 #   - T1.1 (#2) — build job's swift build + xcodebuild step
 #   - T1.3 (#4) — test job's VersionPipelineTests
 #   - T1.4 (#5) — pod-lint job's `pod lib lint`
-#   - T1.5 (#6) — audit job
+#   - T1.5 (#6) — audit job (check-supported-ios.sh)
+#   - T2.7      — audit job (firewall-check.sh)
 #   - T1.2 (#3) — XCFramework build lives in release.yml (tag-only)
 
 name: CI
@@ -73,12 +75,24 @@ jobs:
         run: swift test --enable-code-coverage
 
   audit:
-    name: supported-iOS audit
+    name: supported-iOS audit + terminology firewall
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+      - name: Select Xcode 16
+        run: sudo xcode-select -s /Applications/Xcode_16.app || true
+      - name: Fetch PLCrashReporter
+        # Needed so `swift package dump-symbol-graph` (run inside
+        # firewall-check.sh) can resolve the PLCrashReporter binary
+        # target before emitting EdgeRum's public symbol graph.
+        run: ./Tools/fetch-plcrashreporter.sh
       - name: Run check-supported-ios.sh
         run: ./Tools/check-supported-ios.sh
+      - name: Run firewall-check.sh (Rule 1 — terminology firewall)
+        # Confirms no banned OpenTelemetry vocabulary leaked into the
+        # public Swift symbol graph, public doc comments, README, or
+        # consumer-facing markdown under docs/.
+        run: ./Tools/firewall-check.sh
 
   pod-lint:
     name: pod lib lint

--- a/README.md
+++ b/README.md
@@ -1,0 +1,149 @@
+# EdgeRum — iOS Real User Monitoring SDK
+
+`edge-rum-ios` is the native iOS sibling of the [`edge-rum`](https://github.com/NCG-Africa/edge-rum) (web/Ionic/Capacitor) and [`edge-rum-android`](https://github.com/NCG-Africa/edge-rum-android) SDKs. It captures performance data, errors, native crashes, hangs, network requests, and user interactions on iOS apps and ships them as JSON to the EdgeTelemetryProcessor backend used by all three platforms.
+
+> **Status.** Public API surface (F2) is in place; the event-emitting pipeline ships across F3–F18. This README documents what is consumable today and links to the design docs for everything else.
+
+## Supported iOS
+
+| Floor | Builds against | CI |
+| --- | --- | --- |
+| iOS 14.0+ | Swift 5.10 / Swift 6 toolchain, Xcode 16+ | macOS 15 runners — `swift build`, `swift test`, `pod lib lint`, `xcodebuild` for device + simulator |
+
+The iOS floor is enforced by [`Tools/check-supported-ios.sh`](Tools/check-supported-ios.sh), which cross-checks `Package.swift`, `EdgeRum.podspec`, `PLAN-iOS.md`, and this README on every PR.
+
+## Install
+
+### Swift Package Manager
+
+```swift
+.package(url: "https://github.com/NCG-Africa/edge-rum-ios.git", from: "1.0.0-alpha.1")
+```
+
+Then add the `EdgeRum` product to your app target's dependencies:
+
+```swift
+.target(
+    name: "MyApp",
+    dependencies: [
+        .product(name: "EdgeRum", package: "edge-rum-ios"),
+    ]
+)
+```
+
+`EdgeRumStatic` is the static-linked variant for app-extension hosts.
+
+### CocoaPods
+
+```ruby
+pod 'EdgeRum', '~> 1.0.0-alpha.1'
+```
+
+## Quick start
+
+```swift
+import EdgeRum
+
+// Once, at app launch (e.g. AppDelegate.didFinishLaunchingWithOptions).
+var config = EdgeRumConfig(
+    apiKey: "edge_live_abc123",
+    endpoint: URL(string: "https://collect.example.com")!
+)
+config.appName = "Shop"
+config.appVersion = "2.1.0"
+config.environment = .production
+EdgeRum.start(config)
+
+// From anywhere in the app.
+EdgeRum.track("checkout_started", attributes: [
+    "cart.size": 3,
+    "cart.total": 49.95,
+    "user.is_member": true,
+    "ab.bucket": "treatment"
+])
+
+// Capture errors thrown in your code.
+do {
+    try submitOrder()
+} catch {
+    EdgeRum.captureError(error, context: ["payment.method": "card"])
+}
+
+// Time a chunk of work.
+let timer = EdgeRum.time("checkout.submit")
+performCheckout {
+    timer.end(attributes: ["payment.method": "card"])
+}
+```
+
+### SwiftUI
+
+```swift
+import SwiftUI
+import EdgeRum
+
+struct CheckoutView: View {
+    var body: some View {
+        VStack {
+            // For Button, instrument the action closure directly —
+            // SwiftUI's Button consumes the touch before any
+            // `simultaneousGesture` runs.
+            Button(action: {
+                EdgeRum.track("buy_button", attributes: ["product.id": "SKU-123"])
+                buy()
+            }) {
+                Text("Buy")
+            }
+
+            // For non-Button tap-able views (cards, rows, custom
+            // composites) the modifier records the tap without
+            // swallowing the host app's own gestures.
+            ProductCard(sku: "SKU-456")
+                .edgeRumTrackTap("product_card", attributes: ["product.id": "SKU-456"])
+        }
+        .edgeRumScreen("Checkout", attributes: ["funnel.step": 3])
+    }
+}
+```
+
+The two view modifiers are unconditional at the iOS 14 floor.
+
+- `.edgeRumScreen` records a screen entry on appear and the dwell on disappear. Works on every `View`.
+- `.edgeRumTrackTap` attaches a `.simultaneousGesture(TapGesture())` so it never swallows the host app's own gestures. **It will not fire on a SwiftUI `Button`** — buttons consume their touch before any simultaneous tap recognizer runs. Instrument `Button` actions directly as shown above.
+
+## Public API
+
+| Symbol | Purpose |
+| --- | --- |
+| `EdgeRum.start(_:)` | Bootstrap the SDK. Idempotent — second call with the same `apiKey` + `endpoint` is a no-op; different identity is warn-and-ignore. |
+| `EdgeRum.identify(_:)` | Attach a host-app user profile to subsequent events. |
+| `EdgeRum.track(_:attributes:)` | Record a custom event. |
+| `EdgeRum.trackScreen(_:attributes:)` | Record a screen entry from UIKit code paths. |
+| `EdgeRum.time(_:)` | Begin measuring an interval; returns a `RumTimer`. |
+| `EdgeRum.captureError(_:context:)` | Report a thrown `Error`. Domain, code, and message are flattened onto the event automatically. |
+| `EdgeRum.disable()` / `EdgeRum.enable()` | Pause / resume capture. The offline queue is preserved across pauses. |
+| `EdgeRum.sessionId` / `EdgeRum.deviceId` / `EdgeRum.isEnabled` | Read-only state for host-app diagnostics. |
+| `EdgeRum.handleBackgroundEvents(identifier:completion:)` | Forward `application(_:handleEventsForBackgroundURLSession:completionHandler:)` so background uploads can finish after process death. |
+| `View.edgeRumScreen(_:attributes:)` | SwiftUI screen capture modifier. |
+| `View.edgeRumTrackTap(_:attributes:)` | SwiftUI tap-tracking modifier — non-intercepting. |
+| `EdgeRumConfig` | Configuration struct. Two required fields (`apiKey`, `endpoint`); every other field has a documented default. |
+| `UserContext`, `Environment` | Value types passed to `identify(_:)` / `config.environment`. |
+| `AttributeValue` | Sealed enum — `.string`, `.int`, `.double`, `.bool`. Enforces the JSON wire's primitive-only attribute constraint at compile time. Literal-friendly. |
+| `RumTimer` | Returned by `EdgeRum.time(_:)`. Idempotent `end()` and `cancel()`. |
+| `EdgeRum.sdkVersion` | SemVer string for this build, emitted as `sdk.version` on every event. |
+
+`EdgeRumConfig` defaults documented in code: `sampleRate = 1.0`, `maxQueueSize = 200`, `flushInterval = 5.0s`, `batchSize = 30`, `hangTimeout = 5.0s`, all `capture*` toggles `true`, `debug = false`. See [`Sources/EdgeRum/EdgeRumConfig.swift`](Sources/EdgeRum/EdgeRumConfig.swift) for the full field list.
+
+## Design docs
+
+| Doc | What it covers |
+| --- | --- |
+| [`PLAN-iOS.md`](PLAN-iOS.md) | The full feature plan F1 → F23, milestones, acceptance criteria, and per-task references. Authoritative for scope. |
+| [`docs/data-flow.md`](docs/data-flow.md) | End-to-end data flow from capture call to backend ingest. Internal — references the internal architecture by name. |
+| [`docs/decisions.md`](docs/decisions.md) | Architectural Decision Records. ADR-002 explains the F2 public API shape choices. |
+| [`docs/payload-example.jsonc`](docs/payload-example.jsonc) | Reference batch payload — what the SDK actually ships on the wire. |
+| [`CLAUDE.md`](CLAUDE.md) | Contributor guide; binding rules for AI-assisted development. |
+
+## License
+
+To be added — see the project ticket for the licensing decision.

--- a/Sources/EdgeRum/AttributeValue.swift
+++ b/Sources/EdgeRum/AttributeValue.swift
@@ -1,0 +1,26 @@
+// Sources/EdgeRum/AttributeValue.swift
+//
+// Public re-export of the sealed-enum attribute type. The actual enum
+// is declared in `EdgeRumCore` so the internal Recorder protocol can
+// take it without a back-edge on the public umbrella module.
+//
+// Refs: PLAN-iOS.md §3.2, §F2/T2.3.
+//
+
+import EdgeRumCore
+
+/// A single value that may travel as an event attribute on the wire.
+///
+/// One of four primitive cases — `.string`, `.int`, `.double`, `.bool`
+/// — matching the JSON wire contract exactly. The four
+/// `ExpressibleBy…Literal` conformances let callers write attributes
+/// as plain literals:
+///
+/// ```swift
+/// EdgeRum.track("checkout_started", attributes: [
+///     "cart.size": 3,        // .int(3)
+///     "cart.total": 49.95,   // .double(49.95)
+///     "user.is_member": true // .bool(true)
+/// ])
+/// ```
+public typealias AttributeValue = EdgeRumCore.AttributeValue

--- a/Sources/EdgeRum/EdgeRum.swift
+++ b/Sources/EdgeRum/EdgeRum.swift
@@ -1,18 +1,254 @@
-// EdgeRum — public umbrella module.
+// Sources/EdgeRum/EdgeRum.swift
 //
-// The full surface lands with F2 (issues #29–#35). This stub exists so
-// the package builds end-to-end during the F1 bootstrap.
+// Public umbrella namespace. The entire consumer-facing surface of
+// the SDK is exposed through static methods on this caseless enum so
+// it cannot be instantiated.
+//
+// Every method routes to the internal `Recorder` shared instance in
+// `EdgeRumCore`. F2 ships a no-op Recorder; F3 swaps the real one
+// behind the same protocol.
+//
+// Refs: PLAN-iOS.md §3.2, §F2/T2.1; CLAUDE.md
+//       "Public API surface" and "Error handling conventions".
+//
+
+import Foundation
+import os.log
+import EdgeRumCore
 
 /// Top-level entry point for the EdgeRum SDK.
 ///
-/// This namespace is a caseless `enum` so it cannot be instantiated.
-/// The full public surface (`start`, `identify`, `track`, `time`,
-/// `captureError`, etc.) is added by F2.
+/// The namespace is a caseless `enum` so it cannot be instantiated.
+/// Call `start(_:)` once at app launch with an `EdgeRumConfig`, then
+/// use `track`, `identify`, `time`, `captureError` and the SwiftUI
+/// view modifiers from anywhere in the host app.
+///
+/// ```swift
+/// EdgeRum.start(EdgeRumConfig(
+///     apiKey: "edge_live_abc123",
+///     endpoint: URL(string: "https://collect.example.com")!
+/// ))
+/// EdgeRum.track("checkout_started")
+/// ```
 public enum EdgeRum {
+
+    // MARK: SemVer string
+
     /// SemVer string for this build of the SDK, sent as the
     /// `sdk.version` attribute on every event.
     ///
     /// Sourced at build time from the repo-root `VERSION` file via
     /// `EdgeRumVersionPlugin` — see PLAN-iOS.md §2.6.
     public static let sdkVersion: String = EdgeRumGeneratedVersion.string
+
+    // MARK: Idempotency state
+
+    /// Minimal `(apiKey, endpoint)` snapshot used to decide whether a
+    /// repeat `start(_:)` is the same identity. We deliberately do
+    /// NOT retain the full `EdgeRumConfig` here because it carries a
+    /// consumer-supplied `sanitizeUrl` closure whose lifetime should
+    /// not be extended to "process lifetime".
+    private struct StartedIdentity: Equatable {
+        let apiKey: String
+        let endpoint: URL
+    }
+
+    private static let stateLock = NSLock()
+    nonisolated(unsafe) private static var startedIdentity: StartedIdentity?
+
+    private static let log = OSLog(subsystem: "com.edge.rum", category: "EdgeRum")
+
+    // MARK: Lifecycle
+
+    /// Start the SDK. Idempotent: a second call with the same
+    /// `apiKey` + `endpoint` is a no-op; a second call with a
+    /// different `apiKey` or `endpoint` logs a warning and is
+    /// ignored.
+    ///
+    /// Validates `config.apiKey` (must start with `"edge_"`) and
+    /// `config.endpoint.scheme` (must be `https` unless
+    /// `config.debug == true`). Misuse fails fast via `precondition`
+    /// so the same crash surfaces in debug and release builds.
+    public static func start(_ config: EdgeRumConfig) {
+        switch EdgeRumConfig.validate(config) {
+        case .ok:
+            break
+        case .invalidApiKey:
+            preconditionFailure(
+                "EdgeRum.start: invalid apiKey. Expected non-empty value with the \"edge_\" prefix."
+            )
+        case .invalidEndpoint:
+            preconditionFailure(
+                "EdgeRum.start: endpoint must use https://. Set config.debug = true to allow http://."
+            )
+        }
+
+        let identity = StartedIdentity(apiKey: config.apiKey, endpoint: config.endpoint)
+
+        stateLock.lock()
+        if let existing = startedIdentity {
+            stateLock.unlock()
+            if existing == identity {
+                // Same identity — silent no-op. Repeat `start()` calls
+                // happen on hot-reload and in some unit-test harnesses.
+                return
+            }
+            os_log(
+                "EdgeRum.start called twice with a different apiKey or endpoint — second call ignored.",
+                log: log,
+                type: .info
+            )
+            return
+        }
+        startedIdentity = identity
+        stateLock.unlock()
+
+        Recorder.shared.start(
+            apiKey: config.apiKey,
+            endpoint: config.endpoint,
+            debug: config.debug
+        )
+    }
+
+    /// Attach a host-app user profile to subsequent events. Calling
+    /// `identify` before `start(_:)` is a no-op with a warning.
+    public static func identify(_ user: UserContext) {
+        guard requireStarted("identify") else { return }
+        Recorder.shared.setUser(RecorderUser(
+            id: user.id,
+            name: user.name,
+            email: user.email,
+            phone: user.phone
+        ))
+    }
+
+    // MARK: Recording
+
+    /// Record a custom event. `name` is the value the backend uses
+    /// to route the event (`custom_event` on the wire).
+    public static func track(_ name: String, attributes: [String: AttributeValue]? = nil) {
+        guard requireStarted("track") else { return }
+        Recorder.shared.recordEvent(name: name, attributes: attributes ?? [:])
+    }
+
+    /// Record a screen entry. Equivalent to the SwiftUI
+    /// `.edgeRumScreen(_:)` modifier — provided for UIKit screens
+    /// that don't go through the auto-capture swizzle.
+    public static func trackScreen(_ name: String, attributes: [String: AttributeValue]? = nil) {
+        guard requireStarted("trackScreen") else { return }
+        var merged: [String: AttributeValue] = attributes ?? [:]
+        merged["navigation.name"] = .string(name)
+        Recorder.shared.recordEvent(name: "navigation", attributes: merged)
+    }
+
+    /// Start measuring an interval of code. Call `end()` on the
+    /// returned `RumTimer` to record a performance data point with
+    /// the elapsed duration.
+    ///
+    /// If called before `start(_:)`, a pre-cancelled timer is
+    /// returned so subsequent `end()` calls are no-ops. A warning is
+    /// logged once per call.
+    public static func time(_ name: String) -> RumTimer {
+        let timer = RumTimer(name: name, recorder: Recorder.shared, clock: Recorder.shared.clock)
+        if !requireStarted("time") {
+            timer.cancel()
+        }
+        return timer
+    }
+
+    /// Report a thrown `Error` as an `app.crash` event with
+    /// `cause = "AppError"`. The error's domain, code, and
+    /// localized description are flattened into wire attributes
+    /// automatically. Supply additional context with `context:`.
+    public static func captureError(
+        _ error: Error,
+        context: [String: AttributeValue]? = nil
+    ) {
+        guard requireStarted("captureError") else { return }
+        let nsError = error as NSError
+        Recorder.shared.recordError(
+            domain: nsError.domain,
+            code: nsError.code,
+            message: nsError.localizedDescription,
+            context: context ?? [:]
+        )
+    }
+
+    // MARK: Enable / disable
+
+    /// Halt all capture and emission. The offline queue is preserved.
+    /// Use `enable()` to resume.
+    public static func disable() {
+        Recorder.shared.setEnabled(false)
+    }
+
+    /// Resume capture and emission after a `disable()` call.
+    public static func enable() {
+        Recorder.shared.setEnabled(true)
+    }
+
+    // MARK: Read-only state
+
+    /// The current session id, in the documented format prefix shape
+    /// (`session_<epochMs>_<16 hex>_ios`).
+    public static var sessionId: String {
+        Recorder.shared.currentSessionId
+    }
+
+    /// The SDK-owned anonymous device id, in the documented format
+    /// prefix shape (`device_<epochMs>_<16 hex>_ios`).
+    public static var deviceId: String {
+        Recorder.shared.currentDeviceId
+    }
+
+    /// `true` if the SDK is currently capturing and emitting events.
+    public static var isEnabled: Bool {
+        Recorder.shared.isEnabled
+    }
+
+    // MARK: Background uploader hook
+
+    /// Forward `application(_:handleEventsForBackgroundURLSession:
+    /// completionHandler:)` to the SDK so any pending background
+    /// uploads can finish after process death. Wire from
+    /// `AppDelegate` or `SceneDelegate`.
+    public static func handleBackgroundEvents(
+        identifier: String,
+        completion: @escaping () -> Void
+    ) {
+        // F5 wires the BackgroundUploader and calls `completion` once
+        // the URLSession finishes its pending tasks. F2 ships the
+        // signature so host apps can wire it now. Hop to main so the
+        // stub behaviour matches the AppDelegate contract host apps
+        // are expected to satisfy.
+        _ = identifier
+        DispatchQueue.main.async { completion() }
+    }
+
+    // MARK: Internal helpers
+
+    private static func requireStarted(_ method: String) -> Bool {
+        stateLock.lock()
+        let started = startedIdentity != nil
+        stateLock.unlock()
+        if !started {
+            os_log(
+                "EdgeRum.%{public}@ called before EdgeRum.start(_:) — ignored.",
+                log: log,
+                type: .info,
+                method
+            )
+        }
+        return started
+    }
+
+    // MARK: Test support
+
+    /// Test-only — clears the started state so successive tests can
+    /// drive `start()` again. Not exposed in release builds.
+    internal static func _resetStartedConfigForTesting() {
+        stateLock.lock()
+        startedIdentity = nil
+        stateLock.unlock()
+    }
 }

--- a/Sources/EdgeRum/EdgeRumConfig.swift
+++ b/Sources/EdgeRum/EdgeRumConfig.swift
@@ -1,0 +1,162 @@
+// Sources/EdgeRum/EdgeRumConfig.swift
+//
+// Refs: PLAN-iOS.md §3.2, §F2/T2.2; CLAUDE.md
+//       "Error handling conventions" (precondition on misuse so it
+//       fails in release too).
+//
+
+import Foundation
+
+/// Configuration supplied to `EdgeRum.start(_:)`.
+///
+/// Required: `apiKey` and `endpoint`. Every other field has a
+/// documented default tuned for production use. Mutate any field on
+/// the struct before passing it to `start(_:)`.
+///
+/// ```swift
+/// var config = EdgeRumConfig(
+///     apiKey: "edge_live_abc123",
+///     endpoint: URL(string: "https://collect.example.com")!
+/// )
+/// config.appName = "Shop"
+/// config.appVersion = "2.1.0"
+/// config.environment = .production
+/// EdgeRum.start(config)
+/// ```
+public struct EdgeRumConfig: Sendable {
+
+    // MARK: Identity (required + app-level)
+
+    /// API key issued by the EdgeRum collector backend.
+    /// Must start with `"edge_"`. Sent as the `X-API-Key` header on
+    /// every request.
+    public var apiKey: String
+
+    /// Base URL of the EdgeRum collector backend. The SDK appends
+    /// the collector path automatically. Must be `https://` unless
+    /// `debug == true`.
+    public var endpoint: URL
+
+    /// Host app display name. Sent as `app.name` on every event.
+    public var appName: String?
+
+    /// Host app version (SemVer). Sent as `app.version`.
+    public var appVersion: String?
+
+    /// Host app bundle identifier. Sent as `app.package_name`.
+    public var appPackage: String?
+
+    /// Host app build number. Sent as `app.build_number`. Omitted
+    /// from the wire when `nil`.
+    public var appBuild: String?
+
+    /// Deployment environment. Sent as `app.environment`.
+    public var environment: Environment?
+
+    // MARK: Location
+
+    /// Optional batch-level location string in `City/Country` form
+    /// (e.g. `"Nairobi/Kenya"`). Set explicitly or let
+    /// `resolveLocation = true` populate it once at startup from
+    /// `locationProviderUrl`.
+    public var location: String?
+
+    /// If `true`, the SDK calls `locationProviderUrl` once on init,
+    /// caches the resolved `"City/Country"` for 24 hours in
+    /// `UserDefaults`. Off by default — opt in only.
+    public var resolveLocation: Bool = false
+
+    /// Provider used when `resolveLocation == true`. Defaults to
+    /// ipapi.co; replace with your own service to avoid sending the
+    /// device IP to a third party.
+    public var locationProviderUrl: URL? = URL(string: "https://ipapi.co/json/")
+
+    // MARK: Sampling + queuing
+
+    /// Per-session sample rate in `0.0...1.0`. `1.0` records every
+    /// session; `0.5` records half (decided once at session start).
+    public var sampleRate: Double = 1.0
+
+    /// URLs matching any of these regular expressions are excluded
+    /// from HTTP capture. Useful for keeping your own analytics
+    /// endpoints out of the data.
+    public var ignoreUrls: [NSRegularExpression] = []
+
+    /// Maximum number of events held in the offline queue before
+    /// the oldest are dropped.
+    public var maxQueueSize: Int = 200
+
+    /// Soft flush interval in seconds. The actual flush fires on
+    /// whichever happens first: this timer, `batchSize` reached, or
+    /// an immediate-flush event (errors, `session.finalized`).
+    public var flushInterval: TimeInterval = 5.0
+
+    /// Maximum events per batch payload.
+    public var batchSize: Int = 30
+
+    /// Optional URL sanitiser applied before any URL is recorded.
+    /// Use it to strip query parameters, redact path segments, etc.
+    public var sanitizeUrl: (@Sendable (URL) -> URL)?
+
+    // MARK: Capture toggles
+
+    /// Capture native crashes (PLCrashReporter). Default `true`.
+    public var captureNativeCrashes: Bool = true
+
+    /// Capture main-thread hangs via a runloop watchdog. Default `true`.
+    public var enableHangDetection: Bool = true
+
+    /// Main-thread responsiveness threshold in seconds.
+    /// A stall longer than this records as a hang.
+    public var hangTimeout: TimeInterval = 5.0
+
+    /// Capture UIKit/SwiftUI screen entries and dwell. Default `true`.
+    public var captureScreens: Bool = true
+
+    /// Capture HTTP requests via URLProtocol + delegate hooks.
+    public var captureHTTP: Bool = true
+
+    /// Capture top-level tap interactions. Default `true`.
+    public var captureTaps: Bool = true
+
+    /// Capture frame render time and memory pressure. Default `true`.
+    public var captureRenderingPerformance: Bool = true
+
+    // MARK: Diagnostics
+
+    /// When `true`, the SDK logs verbose diagnostics via `os_log` and
+    /// relaxes URL validation to accept `http://` endpoints. Disable
+    /// for production builds.
+    public var debug: Bool = false
+
+    // MARK: Designated init
+
+    /// Build a configuration with the two required fields. All other
+    /// fields take their documented defaults; mutate the resulting
+    /// struct before passing it to `EdgeRum.start(_:)`.
+    public init(apiKey: String, endpoint: URL) {
+        self.apiKey = apiKey
+        self.endpoint = endpoint
+    }
+
+    // MARK: Validation (testable in isolation)
+
+    internal enum ValidationResult: Equatable {
+        case ok
+        case invalidApiKey
+        case invalidEndpoint
+    }
+
+    /// Pure validation — no side effects, safe to call from tests.
+    /// The public `EdgeRum.start(_:)` calls this and wraps the result
+    /// in a `precondition` so misuse fails in release builds too.
+    internal static func validate(_ config: EdgeRumConfig) -> ValidationResult {
+        guard !config.apiKey.isEmpty, config.apiKey.hasPrefix("edge_") else {
+            return .invalidApiKey
+        }
+        if config.debug == false, config.endpoint.scheme?.lowercased() != "https" {
+            return .invalidEndpoint
+        }
+        return .ok
+    }
+}

--- a/Sources/EdgeRum/Environment.swift
+++ b/Sources/EdgeRum/Environment.swift
@@ -1,0 +1,17 @@
+// Sources/EdgeRum/Environment.swift
+//
+// Refs: PLAN-iOS.md §3.2, §F2/T2.4.
+//
+
+import Foundation
+
+/// The deployment environment a host app is running in.
+///
+/// Set on `EdgeRumConfig.environment`; emitted on every event as the
+/// `app.environment` attribute. Three cases match the values the
+/// backend already accepts from the web and Android SDKs.
+public enum Environment: String, Sendable, Hashable, CaseIterable {
+    case production
+    case staging
+    case development
+}

--- a/Sources/EdgeRum/RumTimer.swift
+++ b/Sources/EdgeRum/RumTimer.swift
@@ -1,0 +1,68 @@
+// Sources/EdgeRum/RumTimer.swift
+//
+// Refs: PLAN-iOS.md §3.2, §F2/T2.5 (`end(attributes:)` idempotent,
+//       `cancel()` idempotent, start moment from injectable Clock).
+//
+
+import Foundation
+import EdgeRumCore
+
+/// Measures an interval of host-app code and records a single
+/// performance data point at the end.
+///
+/// Obtain one with `EdgeRum.time(_:)`. Call `end()` exactly once to
+/// record; second calls are no-ops. Call `cancel()` to discard.
+///
+/// ```swift
+/// let timer = EdgeRum.time("checkout.submit")
+/// performCheckout {
+///     timer.end(attributes: ["payment.method": "card"])
+/// }
+/// ```
+public final class RumTimer: @unchecked Sendable {
+
+    private let name: String
+    private let recorder: Recording
+    private let clock: Clock
+    private let start: Date
+
+    private let lock = NSLock()
+    private var settled: Bool = false
+
+    internal init(name: String, recorder: Recording, clock: Clock) {
+        self.name = name
+        self.recorder = recorder
+        self.clock = clock
+        self.start = clock.now
+    }
+
+    /// Stop the timer and emit a single performance data point named
+    /// after the original `EdgeRum.time(_:)` argument. Any
+    /// `attributes` are merged with a `"duration_ms"` attribute the
+    /// timer adds itself.
+    ///
+    /// Second and subsequent calls are no-ops.
+    public func end(attributes: [String: AttributeValue]? = nil) {
+        lock.lock()
+        guard !settled else {
+            lock.unlock()
+            return
+        }
+        settled = true
+        let elapsedMs = Int((clock.now.timeIntervalSince(start) * 1000.0).rounded())
+        lock.unlock()
+
+        var payload: [String: AttributeValue] = attributes ?? [:]
+        payload["duration_ms"] = .int(elapsedMs)
+        recorder.recordPerformance(name: name, attributes: payload)
+    }
+
+    /// Discard the timer without recording anything. After calling
+    /// `cancel()`, subsequent `end()` calls are no-ops too. Calling
+    /// `cancel()` more than once is a no-op.
+    public func cancel() {
+        lock.lock()
+        settled = true
+        lock.unlock()
+    }
+}

--- a/Sources/EdgeRum/SwiftUI/ViewModifiers.swift
+++ b/Sources/EdgeRum/SwiftUI/ViewModifiers.swift
@@ -1,0 +1,155 @@
+// Sources/EdgeRum/SwiftUI/ViewModifiers.swift
+//
+// Refs: PLAN-iOS.md §3.2, §F2/T2.6, §6.2; CLAUDE.md "SwiftUI conventions".
+//
+// The two public modifiers emit existing event names (`navigation`,
+// `screen.duration`, `user.interaction`) with a `kind` discriminator
+// so the backend can tell SwiftUI traffic apart from UIKit traffic
+// without a new event name in the allowlist.
+//
+
+#if canImport(SwiftUI)
+import SwiftUI
+import EdgeRumCore
+
+// MARK: - Internals (testable in isolation)
+
+/// Pure closures the modifiers attach to `onAppear`, `onDisappear`,
+/// and the simultaneous tap gesture. Factored out so unit tests can
+/// invoke them directly without instantiating SwiftUI's rendering
+/// machinery.
+internal enum SwiftUIEmitter {
+
+    /// `.edgeRumScreen` on-appear → one `navigation` event.
+    internal static func emitScreenAppear(
+        name: String,
+        attributes: [String: AttributeValue]?,
+        recorder: Recording = Recorder.shared,
+        clock: Clock = Recorder.shared.clock,
+        startStore: SwiftUIScreenStartStore = .shared
+    ) {
+        startStore.recordStart(name: name, at: clock.now)
+        var payload: [String: AttributeValue] = attributes ?? [:]
+        payload["navigation.kind"] = .string("swiftui")
+        payload["navigation.name"] = .string(name)
+        recorder.recordEvent(name: "navigation", attributes: payload)
+    }
+
+    /// `.edgeRumScreen` on-disappear → one `screen.duration` event.
+    internal static func emitScreenDisappear(
+        name: String,
+        attributes: [String: AttributeValue]?,
+        recorder: Recording = Recorder.shared,
+        clock: Clock = Recorder.shared.clock,
+        startStore: SwiftUIScreenStartStore = .shared
+    ) {
+        let dwellMs = startStore.consumeDwellMs(name: name, now: clock.now)
+        var payload: [String: AttributeValue] = attributes ?? [:]
+        payload["navigation.kind"] = .string("swiftui")
+        payload["navigation.name"] = .string(name)
+        if let dwellMs {
+            payload["duration_ms"] = .int(dwellMs)
+        }
+        recorder.recordEvent(name: "screen.duration", attributes: payload)
+    }
+
+    /// `.edgeRumTrackTap` → one `user.interaction` event.
+    internal static func emitTap(
+        name: String,
+        attributes: [String: AttributeValue]?,
+        recorder: Recording = Recorder.shared
+    ) {
+        var payload: [String: AttributeValue] = attributes ?? [:]
+        payload["interaction.kind"] = .string("tap")
+        payload["interaction.name"] = .string(name)
+        recorder.recordEvent(name: "user.interaction", attributes: payload)
+    }
+}
+
+/// Pairs a screen name with its `onAppear` timestamp so the matching
+/// `onDisappear` event can carry the dwell in `duration_ms`. Backed
+/// by an `NSLock` so concurrent screens don't trip each other.
+internal final class SwiftUIScreenStartStore: @unchecked Sendable {
+    internal static let shared = SwiftUIScreenStartStore()
+
+    private let lock = NSLock()
+    private var starts: [String: Date] = [:]
+
+    internal init() {}
+
+    internal func recordStart(name: String, at date: Date) {
+        lock.lock()
+        starts[name] = date
+        lock.unlock()
+    }
+
+    internal func consumeDwellMs(name: String, now: Date) -> Int? {
+        lock.lock()
+        let start = starts.removeValue(forKey: name)
+        lock.unlock()
+        guard let start else { return nil }
+        return Int((now.timeIntervalSince(start) * 1000.0).rounded())
+    }
+
+    internal func reset() {
+        lock.lock()
+        starts.removeAll()
+        lock.unlock()
+    }
+}
+
+// MARK: - Public modifiers
+
+// `@available(macOS 10.15, *)` is only present so `swift test` runs
+// on the macOS host (the package's platforms list declares iOS only,
+// so the macOS deployment defaults to a version older than SwiftUI).
+// iOS consumers see no guard at the iOS 14 floor — SwiftUI is already
+// available everywhere this package builds for iOS.
+@available(macOS 10.15, *)
+public extension View {
+
+    /// Record screen-enter and screen-exit events for a SwiftUI view.
+    ///
+    /// Emits `navigation` on `.onAppear` and `screen.duration` on
+    /// `.onDisappear`, both tagged with `"navigation.kind": "swiftui"`
+    /// so the backend can distinguish SwiftUI traffic from UIKit.
+    ///
+    /// ```swift
+    /// CheckoutView()
+    ///     .edgeRumScreen("Checkout", attributes: ["funnel.step": 3])
+    /// ```
+    func edgeRumScreen(
+        _ name: String,
+        attributes: [String: AttributeValue]? = nil
+    ) -> some View {
+        self
+            .onAppear {
+                SwiftUIEmitter.emitScreenAppear(name: name, attributes: attributes)
+            }
+            .onDisappear {
+                SwiftUIEmitter.emitScreenDisappear(name: name, attributes: attributes)
+            }
+    }
+
+    /// Record a tap on a SwiftUI view without intercepting it.
+    ///
+    /// Attached via `.simultaneousGesture(TapGesture())` so the host
+    /// app's own gestures continue to fire normally.
+    ///
+    /// ```swift
+    /// Button("Buy", action: buy)
+    ///     .edgeRumTrackTap("buy_button", attributes: ["product.id": sku])
+    /// ```
+    func edgeRumTrackTap(
+        _ name: String,
+        attributes: [String: AttributeValue]? = nil
+    ) -> some View {
+        self.simultaneousGesture(
+            TapGesture().onEnded {
+                SwiftUIEmitter.emitTap(name: name, attributes: attributes)
+            }
+        )
+    }
+}
+
+#endif

--- a/Sources/EdgeRum/UserContext.swift
+++ b/Sources/EdgeRum/UserContext.swift
@@ -1,0 +1,45 @@
+// Sources/EdgeRum/UserContext.swift
+//
+// Refs: PLAN-iOS.md §3.2, §F2/T2.4; CLAUDE.md "Required identity
+//       attributes" (`user.id`, `user.name`, `user.email`, `user.phone`).
+//
+
+import Foundation
+
+/// A host-app identifier attached to subsequent events via
+/// `EdgeRum.identify(_:)`.
+///
+/// All fields are optional. The SDK never sends a host-app user
+/// identifier as the `user.id` wire attribute on its own — the SDK
+/// already owns an anonymous `user.id` (see `EdgeRum.deviceId` /
+/// `EdgeRum.sessionId` documentation). The values supplied here are
+/// emitted as separate `user.*` attributes alongside the SDK-owned
+/// anonymous id.
+///
+/// `UserContext` is `Sendable` + `Hashable` so it can be stored,
+/// compared, and passed across actor boundaries.
+public struct UserContext: Sendable, Hashable {
+    /// The host app's user identifier, if known.
+    public var id: String?
+
+    /// Optional display name.
+    public var name: String?
+
+    /// Optional email address.
+    public var email: String?
+
+    /// Optional phone number.
+    public var phone: String?
+
+    public init(
+        id: String? = nil,
+        name: String? = nil,
+        email: String? = nil,
+        phone: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.email = email
+        self.phone = phone
+    }
+}

--- a/Sources/EdgeRumCore/AttributeValue.swift
+++ b/Sources/EdgeRumCore/AttributeValue.swift
@@ -1,0 +1,63 @@
+// Sources/EdgeRumCore/AttributeValue.swift
+//
+// Defined inside EdgeRumCore (not EdgeRum) so the internal `Recording`
+// protocol can take `[String: AttributeValue]` without introducing a
+// dependency edge back onto the public umbrella module. The public
+// `EdgeRum` module re-exports the same enum through a thin typealias
+// so consumers continue to write `AttributeValue.string(...)`.
+//
+// Refs: PLAN-iOS.md §3.2 (sealed enum), §F2/T2.3, CLAUDE.md
+//       "Attributes passed to the Recorder are always
+//       `[String: AttributeValue]` — never `[String: Any]`."
+//
+
+import Foundation
+
+/// A single value that may travel as an event attribute on the wire.
+///
+/// The four cases are the only primitive types the JSON wire contract
+/// accepts (`String`, `Int`, `Double`, `Bool`). Because the enum is
+/// sealed and the public API everywhere demands
+/// `[String: AttributeValue]`, the compiler — not a runtime check —
+/// guarantees that no other type can ever reach the encoder.
+///
+/// Literal conformances let callers write attributes naturally:
+///
+/// ```swift
+/// EdgeRum.track("checkout_started", attributes: [
+///     "cart.size": 3,
+///     "cart.total": 49.95,
+///     "user.is_member": true,
+///     "ab.bucket": "treatment"
+/// ])
+/// ```
+public enum AttributeValue: Sendable, Hashable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+}
+
+extension AttributeValue: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self = .string(value)
+    }
+}
+
+extension AttributeValue: ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: Int) {
+        self = .int(value)
+    }
+}
+
+extension AttributeValue: ExpressibleByFloatLiteral {
+    public init(floatLiteral value: Double) {
+        self = .double(value)
+    }
+}
+
+extension AttributeValue: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) {
+        self = .bool(value)
+    }
+}

--- a/Sources/EdgeRumCore/Clock.swift
+++ b/Sources/EdgeRumCore/Clock.swift
@@ -1,0 +1,22 @@
+// Sources/EdgeRumCore/Clock.swift
+//
+// Internal time abstraction. `RumTimer` consumes a `Clock` so unit
+// tests can pin "now" to a frozen value. The real Recorder façade in
+// F3 will reuse the same protocol.
+//
+// Refs: PLAN-iOS.md §F2/T2.5 ("Start moment from injectable Clock").
+//
+
+import Foundation
+
+// EdgeRumCore is not a SwiftPM product (see Package.swift) so making
+// these types `public` exposes them only to the other internal
+// targets that depend on EdgeRumCore — never to outside consumers.
+public protocol Clock: Sendable {
+    var now: Date { get }
+}
+
+public struct SystemClock: Clock {
+    public init() {}
+    public var now: Date { Date() }
+}

--- a/Sources/EdgeRumCore/Recorder.swift
+++ b/Sources/EdgeRumCore/Recorder.swift
@@ -1,10 +1,161 @@
-// Internal — invisible from `import EdgeRum`.
+// Sources/EdgeRumCore/Recorder.swift
 //
-// The real Recorder façade lands with F3 (issue #36). This stub keeps
-// the target non-empty during F1 bootstrap.
+// F2 stub of the internal Recorder.
+//
+// The real fan-in Recorder lands with F3 — context merging, batching,
+// transport, offline queue, etc. This stub exists so the public
+// surface (F2) routes through a stable seam: every public method on
+// `EdgeRum` calls into `Recorder.shared`, and F3 swaps the
+// implementation behind `installShared(_:)` without touching the
+// public umbrella module.
+//
+// What this stub *does* provide:
+//
+// 1. Thread-safe in-memory buffer of recorded calls. Tests inspect
+//    the buffer to assert routing — "did `EdgeRum.track(...)` reach
+//    the recorder with the expected name and attributes?".
+// 2. Synthetic but format-correct `sessionId` / `deviceId` strings
+//    matching the prefix contract from CLAUDE.md §"Session and ID
+//    rules". The real values land in F4.
+// 3. A swap point (`installShared(_:)`) so tests can install a
+//    `ProbeRecorder` for the duration of a test and restore the real
+//    one in `tearDown`.
+//
+// Refs: PLAN-iOS.md §F2/T2.1, §F3, §F4; CLAUDE.md
+//       "Session and ID rules".
+//
 
 import Foundation
 
-internal enum EdgeRumCoreModuleStub {
-    internal static let marker: String = "EdgeRumCore"
+/// A single record of an API call routed through the recorder.
+///
+/// Tests pattern-match on these — see `Tests/EdgeRumTests`.
+public enum RecordedCall: Sendable, Equatable {
+    case start(apiKey: String, endpoint: URL, debug: Bool)
+    case stop
+    case setEnabled(Bool)
+    case event(name: String, attributes: [String: AttributeValue])
+    case performance(name: String, attributes: [String: AttributeValue])
+    case error(domain: String, code: Int, message: String?, context: [String: AttributeValue])
+    case setUser(RecorderUser)
+}
+
+public final class Recorder: Recording, @unchecked Sendable {
+
+    // MARK: Shared instance (mutable so tests can swap a probe in)
+
+    private static let _sharedLock = NSLock()
+    nonisolated(unsafe) private static var _shared: Recording = Recorder()
+
+    public static var shared: Recording {
+        _sharedLock.lock(); defer { _sharedLock.unlock() }
+        return _shared
+    }
+
+    /// Swap the shared recorder for the duration of a test. Returns
+    /// the previously installed instance so the caller can restore
+    /// it in `tearDown`. Intended for tests only.
+    @discardableResult
+    public static func installShared(_ new: Recording) -> Recording {
+        _sharedLock.lock(); defer { _sharedLock.unlock() }
+        let previous = _shared
+        _shared = new
+        return previous
+    }
+
+    /// Restore the default Recorder. Companion to `installShared`.
+    public static func resetShared() {
+        installShared(Recorder())
+    }
+
+    // MARK: Stored state
+
+    private let stateLock = NSLock()
+    private var _enabled: Bool = false
+    private var _calls: [RecordedCall] = []
+    private let _sessionId: String
+    private let _deviceId: String
+    private let _clock: Clock
+
+    public init(clock: Clock = SystemClock()) {
+        self._clock = clock
+        // Synthetic IDs in the documented prefix shape — see
+        // CLAUDE.md "Session and ID rules". F4 replaces these with
+        // SecRandomCopyBytes-backed values persisted in Keychain
+        // / UserDefaults.
+        let stamp = Int(Date().timeIntervalSince1970 * 1000)
+        self._sessionId = "session_\(stamp)_0000000000000000_ios"
+        self._deviceId = "device_\(stamp)_0000000000000000_ios"
+    }
+
+    // MARK: Recording
+
+    public var clock: Clock { _clock }
+
+    public var isEnabled: Bool {
+        stateLock.lock(); defer { stateLock.unlock() }
+        return _enabled
+    }
+
+    public var currentSessionId: String {
+        stateLock.lock(); defer { stateLock.unlock() }
+        return _sessionId
+    }
+
+    public var currentDeviceId: String {
+        stateLock.lock(); defer { stateLock.unlock() }
+        return _deviceId
+    }
+
+    public func start(apiKey: String, endpoint: URL, debug: Bool) {
+        stateLock.lock()
+        _enabled = true
+        _calls.append(.start(apiKey: apiKey, endpoint: endpoint, debug: debug))
+        stateLock.unlock()
+    }
+
+    public func stop() {
+        stateLock.lock()
+        _enabled = false
+        _calls.append(.stop)
+        stateLock.unlock()
+    }
+
+    public func setEnabled(_ enabled: Bool) {
+        stateLock.lock()
+        _enabled = enabled
+        _calls.append(.setEnabled(enabled))
+        stateLock.unlock()
+    }
+
+    public func recordEvent(name: String, attributes: [String: AttributeValue]) {
+        stateLock.lock()
+        _calls.append(.event(name: name, attributes: attributes))
+        stateLock.unlock()
+    }
+
+    public func recordPerformance(name: String, attributes: [String: AttributeValue]) {
+        stateLock.lock()
+        _calls.append(.performance(name: name, attributes: attributes))
+        stateLock.unlock()
+    }
+
+    public func recordError(domain: String, code: Int, message: String?, context: [String: AttributeValue]) {
+        stateLock.lock()
+        _calls.append(.error(domain: domain, code: code, message: message, context: context))
+        stateLock.unlock()
+    }
+
+    public func setUser(_ user: RecorderUser) {
+        stateLock.lock()
+        _calls.append(.setUser(user))
+        stateLock.unlock()
+    }
+
+    // MARK: Test inspection
+
+    public var recordedCalls: [RecordedCall] {
+        stateLock.lock(); defer { stateLock.unlock() }
+        return _calls
+    }
 }

--- a/Sources/EdgeRumCore/Recording.swift
+++ b/Sources/EdgeRumCore/Recording.swift
@@ -1,0 +1,58 @@
+// Sources/EdgeRumCore/Recording.swift
+//
+// Internal seam for the public `EdgeRum` namespace. F2's job is to
+// stand up the public surface; F3 lands the real Recorder. By routing
+// every public method through this protocol now, F3 swaps in the real
+// implementation without touching `Sources/EdgeRum/`.
+//
+// Refs: PLAN-iOS.md §F2/T2.1 ("Route every call to internal Recorder
+// via a stored singleton"), §F3.
+//
+
+import Foundation
+
+/// A minimal description of a value passed to `Recording.setUser`.
+///
+/// We deliberately mirror the shape of the public `UserContext` here
+/// rather than depending on it — the public module imports
+/// `EdgeRumCore`, never the other way around.
+public struct RecorderUser: Sendable, Hashable {
+    public var id: String?
+    public var name: String?
+    public var email: String?
+    public var phone: String?
+
+    public init(
+        id: String? = nil,
+        name: String? = nil,
+        email: String? = nil,
+        phone: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.email = email
+        self.phone = phone
+    }
+}
+
+/// The single entry point every public API call routes through.
+///
+/// F2 ships a no-op `Recorder` that satisfies this protocol so the
+/// public surface is exercised by tests but no network I/O happens.
+/// F3 swaps in the real implementation behind the same interface.
+public protocol Recording: AnyObject, Sendable {
+    var isEnabled: Bool { get }
+    var currentSessionId: String { get }
+    var currentDeviceId: String { get }
+    var clock: Clock { get }
+
+    func start(apiKey: String, endpoint: URL, debug: Bool)
+    func stop()
+    func setEnabled(_ enabled: Bool)
+
+    func recordEvent(name: String, attributes: [String: AttributeValue])
+    func recordPerformance(name: String, attributes: [String: AttributeValue])
+    func recordError(domain: String, code: Int, message: String?, context: [String: AttributeValue])
+
+    func setUser(_ user: RecorderUser)
+}

--- a/Tests/EdgeRumTests/AttributeValueTests.swift
+++ b/Tests/EdgeRumTests/AttributeValueTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import EdgeRum
+
+/// Covers the public attribute value enum: literal conformances,
+/// `Hashable` semantics, and the basic guarantees `Sendable` adds.
+///
+/// Refs: PLAN-iOS.md §3.2, §F2/T2.3.
+final class AttributeValueTests: XCTestCase {
+
+    // MARK: - Literal conformances
+
+    func testStringLiteralBecomesStringCase() {
+        let value: AttributeValue = "hello"
+        XCTAssertEqual(value, .string("hello"))
+    }
+
+    func testIntegerLiteralBecomesIntCase() {
+        let value: AttributeValue = 42
+        XCTAssertEqual(value, .int(42))
+    }
+
+    func testFloatLiteralBecomesDoubleCase() {
+        let value: AttributeValue = 3.14
+        XCTAssertEqual(value, .double(3.14))
+    }
+
+    func testBooleanLiteralBecomesBoolCase() {
+        let valueTrue: AttributeValue = true
+        let valueFalse: AttributeValue = false
+        XCTAssertEqual(valueTrue, .bool(true))
+        XCTAssertEqual(valueFalse, .bool(false))
+    }
+
+    func testDictionaryLiteralComposesEveryCase() {
+        let attributes: [String: AttributeValue] = [
+            "cart.size": 3,
+            "cart.total": 49.95,
+            "user.is_member": true,
+            "ab.bucket": "treatment"
+        ]
+        XCTAssertEqual(attributes["cart.size"], .int(3))
+        XCTAssertEqual(attributes["cart.total"], .double(49.95))
+        XCTAssertEqual(attributes["user.is_member"], .bool(true))
+        XCTAssertEqual(attributes["ab.bucket"], .string("treatment"))
+    }
+
+    // MARK: - Hashable
+
+    func testEqualCasesHashEqually() {
+        let a: AttributeValue = .int(7)
+        let b: AttributeValue = .int(7)
+        XCTAssertEqual(a, b)
+        XCTAssertEqual(a.hashValue, b.hashValue)
+    }
+
+    func testDifferentCasesAreNotEqual() {
+        XCTAssertNotEqual(AttributeValue.string("1"), AttributeValue.int(1))
+        XCTAssertNotEqual(AttributeValue.int(1), AttributeValue.double(1.0))
+        XCTAssertNotEqual(AttributeValue.bool(true), AttributeValue.string("true"))
+    }
+
+    func testCanRoundTripThroughASet() {
+        let set: Set<AttributeValue> = [.string("a"), .string("a"), .int(1), .bool(true)]
+        XCTAssertEqual(set.count, 3, "Duplicate .string('a') must collapse")
+    }
+
+    // MARK: - Sendable (compile-only check)
+
+    func testSendableConformance() {
+        // If the enum stopped being Sendable, this generic constraint
+        // would fail to compile — the test failing at build time is
+        // the assertion.
+        requireSendable(AttributeValue.string("x"))
+    }
+
+    private func requireSendable<T: Sendable>(_ value: T) {
+        _ = value
+    }
+}

--- a/Tests/EdgeRumTests/EdgeRumAPITests.swift
+++ b/Tests/EdgeRumTests/EdgeRumAPITests.swift
@@ -1,0 +1,303 @@
+import XCTest
+@testable import EdgeRum
+import EdgeRumCore
+
+/// End-to-end exercise of the `EdgeRum` namespace.
+///
+/// Strategy: swap the shared `Recorder` for a `ProbeRecorder` in
+/// `setUp`, invoke each public method, and read the probe's recorded
+/// call log. Restore the original recorder in `tearDown` so other
+/// test files start from a clean state.
+///
+/// Refs: PLAN-iOS.md §3.2, §F2/T2.1; CLAUDE.md "Public API surface",
+///       "Error handling conventions".
+final class EdgeRumAPITests: XCTestCase {
+
+    private var probe: ProbeRecorder!
+    private var previousRecorder: Recording!
+
+    override func setUp() {
+        super.setUp()
+        probe = ProbeRecorder()
+        previousRecorder = Recorder.installShared(probe)
+        EdgeRum._resetStartedConfigForTesting()
+    }
+
+    override func tearDown() {
+        Recorder.installShared(previousRecorder)
+        EdgeRum._resetStartedConfigForTesting()
+        probe = nil
+        previousRecorder = nil
+        super.tearDown()
+    }
+
+    // MARK: - start()
+
+    func testStartRoutesThroughToRecorder() {
+        let config = Self.validConfig()
+        EdgeRum.start(config)
+
+        let startCalls = probe.calls.compactMap { call -> (String, URL, Bool)? in
+            if case let .start(apiKey, endpoint, debug) = call {
+                return (apiKey, endpoint, debug)
+            }
+            return nil
+        }
+        XCTAssertEqual(startCalls.count, 1)
+        XCTAssertEqual(startCalls.first?.0, "edge_dev_abc")
+        XCTAssertTrue(EdgeRum.isEnabled)
+    }
+
+    func testSecondStartWithSameIdentityIsNoOp() {
+        EdgeRum.start(Self.validConfig())
+        EdgeRum.start(Self.validConfig())
+
+        let startCount = probe.calls.filter { if case .start = $0 { return true } else { return false } }.count
+        XCTAssertEqual(startCount, 1, "Two start() calls with identical config should reach the recorder once")
+    }
+
+    func testSecondStartWithDifferentIdentityIsAlsoNoOp() {
+        EdgeRum.start(Self.validConfig())
+        var other = Self.validConfig()
+        other.apiKey = "edge_other_xyz"
+        EdgeRum.start(other)
+
+        let startCount = probe.calls.filter { if case .start = $0 { return true } else { return false } }.count
+        XCTAssertEqual(startCount, 1, "A different apiKey or endpoint must be warned-and-ignored, never crash")
+    }
+
+    // MARK: - Misuse before start()
+
+    func testTrackBeforeStartIsNoOp() {
+        EdgeRum.track("orphan_event")
+        XCTAssertTrue(probe.calls.isEmpty)
+    }
+
+    func testTrackScreenBeforeStartIsNoOp() {
+        EdgeRum.trackScreen("Home")
+        XCTAssertTrue(probe.calls.isEmpty)
+    }
+
+    func testIdentifyBeforeStartIsNoOp() {
+        EdgeRum.identify(UserContext(id: "1"))
+        XCTAssertTrue(probe.calls.isEmpty)
+    }
+
+    func testCaptureErrorBeforeStartIsNoOp() {
+        EdgeRum.captureError(NSError(domain: "test", code: 1))
+        XCTAssertTrue(probe.calls.isEmpty)
+    }
+
+    // MARK: - track / trackScreen
+
+    func testTrackRoutesNameAndAttributes() {
+        EdgeRum.start(Self.validConfig())
+        EdgeRum.track("checkout_started", attributes: ["cart.size": 3])
+
+        let events = probe.calls.compactMap { call -> (String, [String: AttributeValue])? in
+            if case let .event(name, attributes) = call { return (name, attributes) }
+            return nil
+        }
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.0, "checkout_started")
+        XCTAssertEqual(events.first?.1["cart.size"], .int(3))
+    }
+
+    func testTrackScreenEmitsNavigationWithName() {
+        EdgeRum.start(Self.validConfig())
+        EdgeRum.trackScreen("Home", attributes: ["funnel.step": 1])
+
+        let events = probe.calls.compactMap { call -> (String, [String: AttributeValue])? in
+            if case let .event(name, attributes) = call { return (name, attributes) }
+            return nil
+        }
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.0, "navigation")
+        XCTAssertEqual(events.first?.1["navigation.name"], .string("Home"))
+        XCTAssertEqual(events.first?.1["funnel.step"], .int(1))
+    }
+
+    // MARK: - identify
+
+    func testIdentifyRoutesUser() {
+        EdgeRum.start(Self.validConfig())
+        EdgeRum.identify(UserContext(id: "u-1", name: "Asha", email: "a@b.c", phone: nil))
+
+        let users = probe.calls.compactMap { call -> RecorderUser? in
+            if case let .setUser(user) = call { return user }
+            return nil
+        }
+        XCTAssertEqual(users.count, 1)
+        XCTAssertEqual(users.first?.id, "u-1")
+        XCTAssertEqual(users.first?.name, "Asha")
+        XCTAssertEqual(users.first?.email, "a@b.c")
+        XCTAssertNil(users.first?.phone)
+    }
+
+    // MARK: - time()
+
+    func testTimeReturnsUsableRumTimer() {
+        EdgeRum.start(Self.validConfig())
+        let timer = EdgeRum.time("checkout.submit")
+        timer.end(attributes: ["payment.method": "card"])
+
+        let perfs = probe.calls.compactMap { call -> (String, [String: AttributeValue])? in
+            if case let .performance(name, attributes) = call { return (name, attributes) }
+            return nil
+        }
+        XCTAssertEqual(perfs.count, 1)
+        XCTAssertEqual(perfs.first?.0, "checkout.submit")
+        XCTAssertEqual(perfs.first?.1["payment.method"], .string("card"))
+        XCTAssertNotNil(perfs.first?.1["duration_ms"])
+    }
+
+    func testTimeBeforeStartReturnsPreCancelledTimer() {
+        let timer = EdgeRum.time("orphan.timer")
+        timer.end()
+        let perfs = probe.calls.compactMap { call -> Void? in
+            if case .performance = call { return () }
+            return nil
+        }
+        XCTAssertEqual(perfs.count, 0,
+                       "Calling time() before start() must return a timer whose end() is a no-op")
+    }
+
+    // MARK: - captureError
+
+    func testCaptureErrorFlattensNSError() {
+        EdgeRum.start(Self.validConfig())
+        let err = NSError(
+            domain: "PaymentDomain",
+            code: 42,
+            userInfo: [NSLocalizedDescriptionKey: "Card declined"]
+        )
+        EdgeRum.captureError(err, context: ["payment.method": "card"])
+
+        let errors = probe.calls.compactMap { call -> (String, Int, String?, [String: AttributeValue])? in
+            if case let .error(domain, code, message, context) = call {
+                return (domain, code, message, context)
+            }
+            return nil
+        }
+        XCTAssertEqual(errors.count, 1)
+        XCTAssertEqual(errors.first?.0, "PaymentDomain")
+        XCTAssertEqual(errors.first?.1, 42)
+        XCTAssertEqual(errors.first?.2, "Card declined")
+        XCTAssertEqual(errors.first?.3["payment.method"], .string("card"))
+    }
+
+    // MARK: - enable / disable
+
+    func testDisableThenEnableTogglesSharedRecorder() {
+        EdgeRum.start(Self.validConfig())
+        EdgeRum.disable()
+        XCTAssertFalse(EdgeRum.isEnabled)
+        EdgeRum.enable()
+        XCTAssertTrue(EdgeRum.isEnabled)
+    }
+
+    // MARK: - sessionId / deviceId
+
+    func testSessionAndDeviceIdHaveTheDocumentedPrefix() {
+        XCTAssertTrue(EdgeRum.sessionId.hasPrefix("session_"))
+        XCTAssertTrue(EdgeRum.sessionId.hasSuffix("_ios"))
+        XCTAssertTrue(EdgeRum.deviceId.hasPrefix("device_"))
+        XCTAssertTrue(EdgeRum.deviceId.hasSuffix("_ios"))
+    }
+
+    // MARK: - handleBackgroundEvents
+
+    func testHandleBackgroundEventsInvokesCompletionOnMain() {
+        let expectation = expectation(description: "completion called on main")
+        EdgeRum.handleBackgroundEvents(identifier: "com.edge.rum.upload") {
+            XCTAssertTrue(Thread.isMainThread,
+                          "AppDelegate contract: completion must fire on the main thread")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    // MARK: - Helpers
+
+    private static func validConfig() -> EdgeRumConfig {
+        EdgeRumConfig(
+            apiKey: "edge_dev_abc",
+            endpoint: URL(string: "https://collect.example.com")!
+        )
+    }
+}
+
+// MARK: - Probe Recorder
+
+/// In-memory `Recording` that captures every call so tests can
+/// assert exact routing behaviour.
+internal final class ProbeRecorder: Recording, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _calls: [RecordedCall] = []
+    private var _enabled: Bool = false
+
+    private let _clock: Clock = SystemClock()
+    private let _sessionId: String = "session_0_0000000000000000_ios"
+    private let _deviceId: String = "device_0_0000000000000000_ios"
+
+    internal init() {}
+
+    internal var calls: [RecordedCall] {
+        lock.lock(); defer { lock.unlock() }
+        return _calls
+    }
+
+    internal var clock: Clock { _clock }
+    internal var currentSessionId: String { _sessionId }
+    internal var currentDeviceId: String { _deviceId }
+
+    internal var isEnabled: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _enabled
+    }
+
+    internal func start(apiKey: String, endpoint: URL, debug: Bool) {
+        lock.lock()
+        _enabled = true
+        _calls.append(.start(apiKey: apiKey, endpoint: endpoint, debug: debug))
+        lock.unlock()
+    }
+
+    internal func stop() {
+        lock.lock()
+        _enabled = false
+        _calls.append(.stop)
+        lock.unlock()
+    }
+
+    internal func setEnabled(_ enabled: Bool) {
+        lock.lock()
+        _enabled = enabled
+        _calls.append(.setEnabled(enabled))
+        lock.unlock()
+    }
+
+    internal func recordEvent(name: String, attributes: [String: AttributeValue]) {
+        lock.lock()
+        _calls.append(.event(name: name, attributes: attributes))
+        lock.unlock()
+    }
+
+    internal func recordPerformance(name: String, attributes: [String: AttributeValue]) {
+        lock.lock()
+        _calls.append(.performance(name: name, attributes: attributes))
+        lock.unlock()
+    }
+
+    internal func recordError(domain: String, code: Int, message: String?, context: [String: AttributeValue]) {
+        lock.lock()
+        _calls.append(.error(domain: domain, code: code, message: message, context: context))
+        lock.unlock()
+    }
+
+    internal func setUser(_ user: RecorderUser) {
+        lock.lock()
+        _calls.append(.setUser(user))
+        lock.unlock()
+    }
+}

--- a/Tests/EdgeRumTests/EdgeRumConfigTests.swift
+++ b/Tests/EdgeRumTests/EdgeRumConfigTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import EdgeRum
+
+/// Locks the defaults and validation behaviour of `EdgeRumConfig`.
+/// Defaults are part of the consumer contract — bumping any of them
+/// is a breaking change.
+///
+/// Refs: PLAN-iOS.md §3.2, §F2/T2.2; CLAUDE.md "Error handling
+///       conventions".
+final class EdgeRumConfigTests: XCTestCase {
+
+    // MARK: - Defaults
+
+    func testRequiredFieldsAreSetAndRestAreDefault() {
+        let config = EdgeRumConfig(
+            apiKey: "edge_dev_abc",
+            endpoint: URL(string: "https://collect.example.com")!
+        )
+        XCTAssertEqual(config.apiKey, "edge_dev_abc")
+        XCTAssertEqual(config.endpoint.absoluteString, "https://collect.example.com")
+
+        XCTAssertNil(config.appName)
+        XCTAssertNil(config.appVersion)
+        XCTAssertNil(config.appPackage)
+        XCTAssertNil(config.appBuild)
+        XCTAssertNil(config.environment)
+        XCTAssertNil(config.location)
+
+        XCTAssertEqual(config.resolveLocation, false)
+        XCTAssertEqual(config.locationProviderUrl?.absoluteString, "https://ipapi.co/json/")
+        XCTAssertEqual(config.sampleRate, 1.0)
+        XCTAssertEqual(config.ignoreUrls.count, 0)
+        XCTAssertEqual(config.maxQueueSize, 200)
+        XCTAssertEqual(config.flushInterval, 5.0)
+        XCTAssertEqual(config.batchSize, 30)
+
+        XCTAssertEqual(config.captureNativeCrashes, true)
+        XCTAssertEqual(config.enableHangDetection, true)
+        XCTAssertEqual(config.hangTimeout, 5.0)
+        XCTAssertEqual(config.captureScreens, true)
+        XCTAssertEqual(config.captureHTTP, true)
+        XCTAssertEqual(config.captureTaps, true)
+        XCTAssertEqual(config.captureRenderingPerformance, true)
+
+        XCTAssertEqual(config.debug, false)
+    }
+
+    // MARK: - Validation
+
+    func testValidateAcceptsHappyPath() {
+        let config = EdgeRumConfig(
+            apiKey: "edge_live_abc",
+            endpoint: URL(string: "https://collect.example.com")!
+        )
+        XCTAssertEqual(EdgeRumConfig.validate(config), .ok)
+    }
+
+    func testValidateRejectsEmptyApiKey() {
+        let config = EdgeRumConfig(
+            apiKey: "",
+            endpoint: URL(string: "https://collect.example.com")!
+        )
+        XCTAssertEqual(EdgeRumConfig.validate(config), .invalidApiKey)
+    }
+
+    func testValidateRejectsApiKeyWithoutPrefix() {
+        let config = EdgeRumConfig(
+            apiKey: "abc-not-prefixed",
+            endpoint: URL(string: "https://collect.example.com")!
+        )
+        XCTAssertEqual(EdgeRumConfig.validate(config), .invalidApiKey)
+    }
+
+    func testValidateRejectsHttpEndpointInProduction() {
+        var config = EdgeRumConfig(
+            apiKey: "edge_dev_abc",
+            endpoint: URL(string: "http://collect.example.com")!
+        )
+        config.debug = false
+        XCTAssertEqual(EdgeRumConfig.validate(config), .invalidEndpoint)
+    }
+
+    func testValidateAllowsHttpEndpointInDebug() {
+        var config = EdgeRumConfig(
+            apiKey: "edge_dev_abc",
+            endpoint: URL(string: "http://localhost:8080")!
+        )
+        config.debug = true
+        XCTAssertEqual(EdgeRumConfig.validate(config), .ok)
+    }
+
+    func testValidateRejectsUppercaseHttpEndpointInProduction() {
+        // Scheme is case-insensitive per RFC 3986 — our validator
+        // must accept uppercase HTTPS and reject uppercase HTTP.
+        var configHTTPS = EdgeRumConfig(
+            apiKey: "edge_dev_abc",
+            endpoint: URL(string: "HTTPS://collect.example.com")!
+        )
+        configHTTPS.debug = false
+        XCTAssertEqual(EdgeRumConfig.validate(configHTTPS), .ok)
+    }
+
+}

--- a/Tests/EdgeRumTests/EnvironmentTests.swift
+++ b/Tests/EdgeRumTests/EnvironmentTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import EdgeRum
+
+/// Pins the wire representation of `Environment`. The backend already
+/// indexes the three strings emitted by the web and Android SDKs;
+/// drift would silently mis-classify iOS traffic.
+///
+/// Refs: PLAN-iOS.md §3.2, §F2/T2.4.
+final class EnvironmentTests: XCTestCase {
+
+    func testRawValuesMatchTheBackendContract() {
+        XCTAssertEqual(Environment.production.rawValue, "production")
+        XCTAssertEqual(Environment.staging.rawValue, "staging")
+        XCTAssertEqual(Environment.development.rawValue, "development")
+    }
+
+    func testRoundTripFromRawValue() {
+        XCTAssertEqual(Environment(rawValue: "production"), .production)
+        XCTAssertEqual(Environment(rawValue: "staging"), .staging)
+        XCTAssertEqual(Environment(rawValue: "development"), .development)
+        XCTAssertNil(Environment(rawValue: "prod"))
+        XCTAssertNil(Environment(rawValue: ""))
+    }
+
+    func testAllCasesExposesAllThree() {
+        XCTAssertEqual(
+            Set(Environment.allCases),
+            [.production, .staging, .development]
+        )
+    }
+
+    func testHashableEquality() {
+        XCTAssertEqual(Environment.staging, Environment.staging)
+        XCTAssertEqual(Environment.staging.hashValue, Environment.staging.hashValue)
+        XCTAssertNotEqual(Environment.staging, Environment.production)
+    }
+}

--- a/Tests/EdgeRumTests/FirewallCheckScriptTests.swift
+++ b/Tests/EdgeRumTests/FirewallCheckScriptTests.swift
@@ -1,0 +1,192 @@
+import XCTest
+
+/// Behavioural tests for `Tools/firewall-check.sh`.
+///
+/// We point the script at a tmpdir prepared to mimic the parts of the
+/// repo the script actually inspects (`Sources/EdgeRum/`, `README.md`,
+/// `docs/`). The script doesn't need a real Swift build to exercise
+/// its source-pre-check and markdown steps, so the symbol-graph step
+/// short-circuits with a warning when no `.build/` is present —
+/// the source/README/docs grep paths still run and we assert on those.
+///
+/// Refs: PLAN-iOS.md §F2/T2.7, CLAUDE.md Rule 1.
+final class FirewallCheckScriptTests: XCTestCase {
+
+    func testCleanSandboxPasses() throws {
+        let sandbox = try Self.makeSandbox(seed: .clean)
+        defer { sandbox.cleanup() }
+
+        let result = try sandbox.runScript()
+        XCTAssertEqual(result.exitCode, 0,
+                       "Clean sandbox must pass.\nstdout:\n\(result.stdout)\nstderr:\n\(result.stderr)")
+    }
+
+    func testDocCommentLeakFailsTheScript() throws {
+        let sandbox = try Self.makeSandbox(seed: .clean)
+        defer { sandbox.cleanup() }
+
+        let file = sandbox.root.appendingPathComponent("Sources/EdgeRum/Leaky.swift")
+        try """
+        /// This file accidentally mentions a tracer in its doc comment.
+        public enum Leaky {}
+        """.write(to: file, atomically: true, encoding: .utf8)
+
+        let result = try sandbox.runScript()
+        XCTAssertNotEqual(result.exitCode, 0, "Doc-comment leak should fail.")
+        XCTAssertTrue(result.stderr.contains("tracer"),
+                      "stderr should call out the banned term.\n\(result.stderr)")
+    }
+
+    func testReadmeLeakFailsTheScript() throws {
+        let sandbox = try Self.makeSandbox(seed: .clean)
+        defer { sandbox.cleanup() }
+
+        try """
+        # EdgeRum
+
+        Internally, EdgeRum uses an OpenTelemetry span exporter.
+        """.write(
+            to: sandbox.root.appendingPathComponent("README.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let result = try sandbox.runScript()
+        XCTAssertNotEqual(result.exitCode, 0, "README leak should fail.")
+        XCTAssertTrue(
+            result.stderr.contains("README.md"),
+            "stderr should reference README.md.\n\(result.stderr)"
+        )
+    }
+
+    func testConsumerDocsLeakFailsTheScript() throws {
+        let sandbox = try Self.makeSandbox(seed: .clean)
+        defer { sandbox.cleanup() }
+
+        let doc = sandbox.root.appendingPathComponent("docs/integration.md")
+        try "Pass your tracer to the integration step.".write(
+            to: doc, atomically: true, encoding: .utf8
+        )
+
+        let result = try sandbox.runScript()
+        XCTAssertNotEqual(result.exitCode, 0,
+                          "Leak in a consumer-facing doc should fail.")
+    }
+
+    func testInternalDocsAreSkipped() throws {
+        let sandbox = try Self.makeSandbox(seed: .clean)
+        defer { sandbox.cleanup() }
+
+        // data-flow.md is on the INTERNAL_DOCS allowlist — banned
+        // terms here are intentional and should NOT fail the script.
+        try """
+        # data-flow
+
+        Internally we use OpenTelemetry's span/trace primitives.
+        """.write(
+            to: sandbox.root.appendingPathComponent("docs/data-flow.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let result = try sandbox.runScript()
+        XCTAssertEqual(result.exitCode, 0,
+                       "docs/data-flow.md must be skipped.\nstderr:\n\(result.stderr)")
+    }
+
+    // MARK: - Sandbox
+
+    private enum Seed { case clean }
+
+    private struct Sandbox {
+        let root: URL
+        let scriptCopy: URL
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        func runScript() throws -> (exitCode: Int32, stdout: String, stderr: String) {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/bin/bash")
+            process.arguments = [scriptCopy.path]
+            process.environment = ProcessInfo.processInfo.environment.merging(
+                ["REPO_ROOT": root.path]
+            ) { _, new in new }
+
+            let outPipe = Pipe(), errPipe = Pipe()
+            process.standardOutput = outPipe
+            process.standardError = errPipe
+            try process.run()
+            process.waitUntilExit()
+            let out = String(data: outPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            let err = String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            return (process.terminationStatus, out, err)
+        }
+    }
+
+    private static func makeSandbox(seed: Seed) throws -> Sandbox {
+        let realRoot = try locateRepoRoot()
+        let sandboxRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("edgerum-firewall-\(UUID().uuidString)", isDirectory: true)
+        let fm = FileManager.default
+        try fm.createDirectory(at: sandboxRoot, withIntermediateDirectories: true)
+
+        // Tools/firewall-check.sh — the script under test.
+        let toolsDir = sandboxRoot.appendingPathComponent("Tools", isDirectory: true)
+        try fm.createDirectory(at: toolsDir, withIntermediateDirectories: true)
+        let scriptDest = toolsDir.appendingPathComponent("firewall-check.sh")
+        try fm.copyItem(
+            at: realRoot.appendingPathComponent("Tools/firewall-check.sh"),
+            to: scriptDest
+        )
+
+        // Sources/EdgeRum/ — non-empty so the source-pre-check has
+        // something to inspect. A single clean file lives here.
+        let sourcesDir = sandboxRoot.appendingPathComponent("Sources/EdgeRum", isDirectory: true)
+        try fm.createDirectory(at: sourcesDir, withIntermediateDirectories: true)
+        try """
+        /// Clean public surface placeholder.
+        public enum SandboxedSurface {}
+        """.write(
+            to: sourcesDir.appendingPathComponent("Sandboxed.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // Empty docs/ directory so the script's docs-walk step has a
+        // target. Tests that need files in docs/ add them themselves.
+        try fm.createDirectory(
+            at: sandboxRoot.appendingPathComponent("docs"),
+            withIntermediateDirectories: true
+        )
+
+        // Empty Package.swift so any `swift package` invocation by
+        // the script fails predictably (we expect it to fall back to
+        // the source-only path in this sandbox).
+        try "// placeholder".write(
+            to: sandboxRoot.appendingPathComponent("Package.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        _ = seed
+        return Sandbox(root: sandboxRoot, scriptCopy: scriptDest)
+    }
+
+    private static func locateRepoRoot(file: StaticString = #filePath) throws -> URL {
+        var dir = URL(fileURLWithPath: "\(file)").deletingLastPathComponent()
+        for _ in 0..<10 {
+            let script = dir.appendingPathComponent("Tools/firewall-check.sh")
+            if FileManager.default.fileExists(atPath: script.path) {
+                return dir
+            }
+            dir.deleteLastPathComponent()
+        }
+        throw NSError(
+            domain: "FirewallCheckScriptTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Could not locate repo root from \(file)"]
+        )
+    }
+}

--- a/Tests/EdgeRumTests/PackageProductsTests.swift
+++ b/Tests/EdgeRumTests/PackageProductsTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+
+/// `EdgeRumCore` holds the internal `Recording` protocol, the
+/// `Recorder` shared instance, and the real `AttributeValue` enum.
+/// We promote those to `public` so the public umbrella module
+/// (`EdgeRum`) can import and route through them. The reason that
+/// doesn't leak to outside consumers is the load-bearing invariant
+/// that `EdgeRumCore` is NOT listed as a `.library` product in
+/// `Package.swift`. If someone adds it as a product, internal types
+/// become available to `import EdgeRumCore` from any consumer — a
+/// silent breach of the public API contract.
+///
+/// This test reads `Package.swift` as text and fails if `EdgeRumCore`
+/// (or any other intentionally-internal target) appears as a product.
+///
+/// Refs: PLAN-iOS.md §F2, ADR-002, CLAUDE.md "Repository structure".
+final class PackageProductsTests: XCTestCase {
+
+    /// Targets that MUST NOT be re-exposed as SwiftPM products.
+    private static let internalOnlyTargets: Set<String> = [
+        "EdgeRumCore",
+        "EdgeRumCapture",
+        "EdgeRumCrash",
+        "EdgeRumOTelBridge"
+    ]
+
+    func testInternalTargetsAreNotExposedAsProducts() throws {
+        let packageSwift = try locateRepoRoot()
+            .appendingPathComponent("Package.swift")
+        let source = try String(contentsOf: packageSwift, encoding: .utf8)
+
+        // Slice the substring from the `products:` block to the
+        // following `dependencies:` block — we only care about
+        // `.library(name: "...")` declarations inside the products
+        // array.
+        guard
+            let productsStart = source.range(of: "products:"),
+            let productsEnd = source.range(of: "dependencies:", range: productsStart.upperBound..<source.endIndex)
+        else {
+            return XCTFail("Could not locate `products:` block in Package.swift")
+        }
+        let productsBlock = String(source[productsStart.upperBound..<productsEnd.lowerBound])
+
+        for target in Self.internalOnlyTargets {
+            let needle = "\"\(target)\""
+            XCTAssertFalse(
+                productsBlock.contains(needle),
+                "\(target) must not be listed as a SwiftPM product — outside consumers would gain `import \(target)` access and bypass the public API surface."
+            )
+        }
+    }
+
+    private func locateRepoRoot(file: StaticString = #filePath) throws -> URL {
+        var dir = URL(fileURLWithPath: "\(file)").deletingLastPathComponent()
+        for _ in 0..<10 {
+            let pkg = dir.appendingPathComponent("Package.swift")
+            if FileManager.default.fileExists(atPath: pkg.path) {
+                return dir
+            }
+            dir.deleteLastPathComponent()
+        }
+        throw NSError(
+            domain: "PackageProductsTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Could not locate repo root from \(file)"]
+        )
+    }
+}

--- a/Tests/EdgeRumTests/RumTimerTests.swift
+++ b/Tests/EdgeRumTests/RumTimerTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+@testable import EdgeRum
+import EdgeRumCore
+
+/// Behaviour of `RumTimer`: idempotent `end()` and `cancel()`,
+/// duration computed against an injectable clock, and consumer
+/// attributes merged with the SDK-supplied `duration_ms` key.
+///
+/// Refs: PLAN-iOS.md §3.2, §F2/T2.5.
+final class RumTimerTests: XCTestCase {
+
+    private func makeTimer(
+        name: String = "checkout.submit",
+        start: Date,
+        end: Date
+    ) -> (RumTimer, AdvancingClock, Recorder) {
+        let clock = AdvancingClock(times: [start, end])
+        let recorder = Recorder(clock: clock)
+        let timer = RumTimer(name: name, recorder: recorder, clock: clock)
+        return (timer, clock, recorder)
+    }
+
+    func testEndRecordsSinglePerformanceCall() {
+        let t0 = Date(timeIntervalSince1970: 1_000_000)
+        let (timer, _, recorder) = makeTimer(start: t0, end: t0.addingTimeInterval(0.250))
+
+        timer.end()
+
+        let calls = recorder.recordedCalls
+        XCTAssertEqual(calls.count, 1)
+        guard case let .performance(name, attributes) = calls[0] else {
+            return XCTFail("Expected a .performance call, got \(calls[0])")
+        }
+        XCTAssertEqual(name, "checkout.submit")
+        XCTAssertEqual(attributes["duration_ms"], .int(250))
+    }
+
+    func testSecondEndIsNoOp() {
+        let t0 = Date(timeIntervalSince1970: 1_000_000)
+        let (timer, _, recorder) = makeTimer(start: t0, end: t0.addingTimeInterval(1.0))
+
+        timer.end()
+        timer.end(attributes: ["extra": "should_not_be_recorded"])
+
+        XCTAssertEqual(recorder.recordedCalls.count, 1,
+                       "Second .end() must be a no-op")
+    }
+
+    func testCancelPreventsEndFromRecording() {
+        let t0 = Date(timeIntervalSince1970: 1_000_000)
+        let (timer, _, recorder) = makeTimer(start: t0, end: t0.addingTimeInterval(1.0))
+
+        timer.cancel()
+        timer.end()
+
+        XCTAssertEqual(recorder.recordedCalls.count, 0,
+                       ".cancel() then .end() must record nothing")
+    }
+
+    func testEndThenCancelDoesNotDoubleEmit() {
+        let t0 = Date(timeIntervalSince1970: 1_000_000)
+        let (timer, _, recorder) = makeTimer(start: t0, end: t0.addingTimeInterval(0.5))
+
+        timer.end()
+        timer.cancel()
+
+        XCTAssertEqual(recorder.recordedCalls.count, 1,
+                       ".cancel() after .end() must not change recorded count")
+    }
+
+    func testCancelIsIdempotent() {
+        let t0 = Date(timeIntervalSince1970: 1_000_000)
+        let (timer, _, recorder) = makeTimer(start: t0, end: t0.addingTimeInterval(0.5))
+
+        timer.cancel()
+        timer.cancel()
+        timer.cancel()
+
+        XCTAssertEqual(recorder.recordedCalls.count, 0)
+    }
+
+    func testConsumerAttributesAreMergedWithDuration() {
+        let t0 = Date(timeIntervalSince1970: 1_000_000)
+        let (timer, _, recorder) = makeTimer(start: t0, end: t0.addingTimeInterval(2.5))
+
+        timer.end(attributes: [
+            "payment.method": "card",
+            "items.count": 4
+        ])
+
+        guard case let .performance(_, attributes) = recorder.recordedCalls[0] else {
+            return XCTFail("Expected a .performance call")
+        }
+        XCTAssertEqual(attributes["payment.method"], .string("card"))
+        XCTAssertEqual(attributes["items.count"], .int(4))
+        XCTAssertEqual(attributes["duration_ms"], .int(2500))
+    }
+
+    func testDurationRoundsToNearestMillisecond() {
+        let t0 = Date(timeIntervalSince1970: 1_000_000)
+        let (timer, _, recorder) = makeTimer(start: t0, end: t0.addingTimeInterval(0.0006))
+        timer.end()
+        guard case let .performance(_, attributes) = recorder.recordedCalls[0] else {
+            return XCTFail("Expected a .performance call")
+        }
+        XCTAssertEqual(attributes["duration_ms"], .int(1),
+                       "0.0006s should round to 1ms")
+    }
+}
+
+// MARK: - Test Clock
+
+/// Yields a fixed sequence of timestamps so the timer's start and
+/// end reads are deterministic.
+internal final class AdvancingClock: Clock, @unchecked Sendable {
+    private let lock = NSLock()
+    private var queue: [Date]
+
+    internal init(times: [Date]) {
+        self.queue = times
+    }
+
+    internal var now: Date {
+        lock.lock(); defer { lock.unlock() }
+        guard !queue.isEmpty else { return Date() }
+        return queue.removeFirst()
+    }
+}

--- a/Tests/EdgeRumTests/SwiftUIModifierTests.swift
+++ b/Tests/EdgeRumTests/SwiftUIModifierTests.swift
@@ -1,0 +1,108 @@
+#if canImport(SwiftUI)
+import XCTest
+@testable import EdgeRum
+import EdgeRumCore
+
+/// Confirms the two SwiftUI view modifiers emit the right events with
+/// the right `kind` discriminator. We do not render any SwiftUI
+/// hierarchy — the modifier's behaviour is encoded in the
+/// `SwiftUIEmitter` static functions, which we invoke directly with
+/// a fake recorder.
+///
+/// Refs: PLAN-iOS.md §3.2, §6.2, §F2/T2.6.
+@available(macOS 10.15, *)
+final class SwiftUIModifierTests: XCTestCase {
+
+    private var recorder: Recorder!
+    private var startStore: SwiftUIScreenStartStore!
+
+    override func setUp() {
+        super.setUp()
+        let clock = AdvancingClock(times: [
+            Date(timeIntervalSince1970: 1_000_000.0),
+            Date(timeIntervalSince1970: 1_000_001.5) // dwell = 1500ms
+        ])
+        recorder = Recorder(clock: clock)
+        startStore = SwiftUIScreenStartStore()
+    }
+
+    override func tearDown() {
+        recorder = nil
+        startStore = nil
+        super.tearDown()
+    }
+
+    func testEmitScreenAppearRecordsNavigationWithSwiftUIKind() {
+        SwiftUIEmitter.emitScreenAppear(
+            name: "Checkout",
+            attributes: ["funnel.step": 3],
+            recorder: recorder,
+            clock: recorder.clock,
+            startStore: startStore
+        )
+
+        let calls = recorder.recordedCalls
+        XCTAssertEqual(calls.count, 1)
+        guard case let .event(name, attributes) = calls[0] else {
+            return XCTFail("Expected .event for navigation, got \(calls[0])")
+        }
+        XCTAssertEqual(name, "navigation")
+        XCTAssertEqual(attributes["navigation.kind"], .string("swiftui"))
+        XCTAssertEqual(attributes["navigation.name"], .string("Checkout"))
+        XCTAssertEqual(attributes["funnel.step"], .int(3))
+    }
+
+    func testEmitScreenDisappearEmitsScreenDurationWithDwell() {
+        SwiftUIEmitter.emitScreenAppear(
+            name: "Checkout",
+            attributes: nil,
+            recorder: recorder,
+            clock: recorder.clock,
+            startStore: startStore
+        )
+        SwiftUIEmitter.emitScreenDisappear(
+            name: "Checkout",
+            attributes: nil,
+            recorder: recorder,
+            clock: recorder.clock,
+            startStore: startStore
+        )
+
+        let calls = recorder.recordedCalls
+        XCTAssertEqual(calls.count, 2)
+        guard case let .event(name, attributes) = calls[1] else {
+            return XCTFail("Expected .event for screen.duration, got \(calls[1])")
+        }
+        XCTAssertEqual(name, "screen.duration")
+        XCTAssertEqual(attributes["navigation.kind"], .string("swiftui"))
+        XCTAssertEqual(attributes["navigation.name"], .string("Checkout"))
+        XCTAssertEqual(attributes["duration_ms"], .int(1500))
+    }
+
+    func testEmitTapRecordsUserInteractionWithTapKind() {
+        SwiftUIEmitter.emitTap(
+            name: "buy_button",
+            attributes: ["product.id": "SKU-123"],
+            recorder: recorder
+        )
+
+        let calls = recorder.recordedCalls
+        XCTAssertEqual(calls.count, 1)
+        guard case let .event(name, attributes) = calls[0] else {
+            return XCTFail("Expected .event for user.interaction, got \(calls[0])")
+        }
+        XCTAssertEqual(name, "user.interaction")
+        XCTAssertEqual(attributes["interaction.kind"], .string("tap"))
+        XCTAssertEqual(attributes["interaction.name"], .string("buy_button"))
+        XCTAssertEqual(attributes["product.id"], .string("SKU-123"))
+    }
+
+    func testScreenStartStoreConsumeIsOneShot() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        startStore.recordStart(name: "A", at: now)
+        XCTAssertEqual(startStore.consumeDwellMs(name: "A", now: now.addingTimeInterval(0.250)), 250)
+        XCTAssertNil(startStore.consumeDwellMs(name: "A", now: now.addingTimeInterval(0.500)),
+                     "Second consume for the same screen should return nil")
+    }
+}
+#endif

--- a/Tests/EdgeRumTests/UserContextTests.swift
+++ b/Tests/EdgeRumTests/UserContextTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import EdgeRum
+
+/// `UserContext` is the host-app user profile attached via
+/// `EdgeRum.identify(_:)`. The test confirms the field shape and the
+/// equality semantics callers rely on.
+///
+/// Refs: PLAN-iOS.md §3.2, §F2/T2.4.
+final class UserContextTests: XCTestCase {
+
+    func testDefaultInitLeavesEveryFieldNil() {
+        let user = UserContext()
+        XCTAssertNil(user.id)
+        XCTAssertNil(user.name)
+        XCTAssertNil(user.email)
+        XCTAssertNil(user.phone)
+    }
+
+    func testFullInitPopulatesEveryField() {
+        let user = UserContext(
+            id: "user-123",
+            name: "Asha",
+            email: "asha@example.com",
+            phone: "+254700000000"
+        )
+        XCTAssertEqual(user.id, "user-123")
+        XCTAssertEqual(user.name, "Asha")
+        XCTAssertEqual(user.email, "asha@example.com")
+        XCTAssertEqual(user.phone, "+254700000000")
+    }
+
+    func testEqualityIsValueBased() {
+        let a = UserContext(id: "1", name: "A")
+        let b = UserContext(id: "1", name: "A")
+        let c = UserContext(id: "1", name: "B")
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+        XCTAssertEqual(a.hashValue, b.hashValue)
+    }
+
+    func testCanLiveInsideASet() {
+        let users: Set<UserContext> = [
+            UserContext(id: "1"),
+            UserContext(id: "1"),
+            UserContext(id: "2")
+        ]
+        XCTAssertEqual(users.count, 2)
+    }
+}

--- a/Tools/firewall-check.sh
+++ b/Tools/firewall-check.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+#
+# Tools/firewall-check.sh
+#
+# Enforces Rule 1 — the terminology firewall. The SDK ships with
+# OpenTelemetry as a hidden implementation detail; consumer code never
+# sees the words `span`, `trace`, `tracer`, `instrumentation`,
+# `telemetry`, `opentelemetry`, `otel`, or `otlp`. This script
+# catches any leak before it lands.
+#
+# Scopes the check to:
+#
+#   1. The public Swift surface — `swift package dump-symbol-graph
+#      --target EdgeRum --minimum-access-level public` walks every
+#      public/open symbol and its doc comment.
+#   2. Source-file pre-check — greps `Sources/EdgeRum/**/*.swift`
+#      for any `///` doc-comment line containing a banned token.
+#      Faster than the symbol graph and surfaces problems before
+#      the compiler runs.
+#   3. README.md (when present).
+#   4. Other consumer-facing markdown under `docs/` — except files
+#      explicitly listed in `INTERNAL_DOCS` (those discuss SDK
+#      internals and are allowed to use banned terms).
+#
+# Any match exits non-zero with a "found `<term>` in `<location>`"
+# line. Zero matches → exit 0.
+#
+# Refs: CLAUDE.md "Rule 1 — The terminology firewall",
+#       PLAN-iOS.md §3.1, §F2/T2.7.
+
+set -euo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+cd "${REPO_ROOT}"
+
+# Banned tokens — matched case-insensitively as whole-ish words so
+# legitimate identifiers like `interaction` are not false-positives.
+# `metric` is banned as an API name; the JSON wire field
+# `"metricName"` lives in EdgeRumCore (internal) and never reaches
+# the public surface, so the symbol-graph check naturally skips it.
+BANNED_TOKENS=(
+    opentelemetry
+    otel
+    otlp
+    "span"
+    "tracer"
+    "trace"
+    "instrumentation"
+    "telemetry"
+)
+
+# Markdown files under docs/ that intentionally discuss SDK internals
+# and are allowed to use banned terms. Paths relative to REPO_ROOT.
+INTERNAL_DOCS=(
+    "docs/data-flow.md"
+    "docs/decisions.md"
+)
+
+# Where to look in step 2.
+PUBLIC_SWIFT_DIR="${REPO_ROOT}/Sources/EdgeRum"
+
+fail_count=0
+report() {
+    local term="$1" location="$2" line="$3"
+    echo "firewall-check: banned term \"${term}\" found in ${location}: ${line}" >&2
+    fail_count=$((fail_count + 1))
+}
+
+# Build a single grep pattern: token1|token2|...
+join_or() {
+    local IFS='|'
+    echo "$*"
+}
+PATTERN="$(join_or "${BANNED_TOKENS[@]}")"
+
+# Step 1 — Public Swift symbol graph.
+#
+# `swift package dump-symbol-graph --minimum-access-level public`
+# writes one JSON per module under `.build/<triple>/symbolgraph/`.
+# We extract the symbol names + doc-comment text from
+# `EdgeRum.symbols.json` and grep for any banned token. URI fields
+# carry the repo path on disk — which itself contains "telemetry" in
+# this project — so we strip `"uri":"..."` before scanning.
+echo "firewall-check: dumping symbol graph for EdgeRum (public)…"
+
+SG_STDERR="$(mktemp -t edge-rum-symgraph-err.XXXXXX)"
+# shellcheck disable=SC2064
+trap "rm -f \"${SG_STDERR}\"" EXIT
+if ! swift package dump-symbol-graph \
+        --minimum-access-level public \
+        >/dev/null 2> "${SG_STDERR}"; then
+    echo "firewall-check: warning — symbol-graph generation failed; falling back to source-only check" >&2
+    echo "firewall-check: swift package stderr was:" >&2
+    sed 's/^/  /' "${SG_STDERR}" >&2 || true
+else
+    # `swift package dump-symbol-graph` writes into a triple-dependent
+    # subdir. Pick the most recent one — there's only ever one for
+    # the host swift-build triple at a time.
+    SYMBOL_JSON="$(find "${REPO_ROOT}/.build" \
+        -type f \
+        -path '*/symbolgraph/EdgeRum.symbols.json' \
+        2>/dev/null \
+        | head -n1)"
+    if [[ -z "${SYMBOL_JSON}" || ! -f "${SYMBOL_JSON}" ]]; then
+        echo "firewall-check: warning — no EdgeRum.symbols.json produced" >&2
+    else
+        # Strip URI fields so the repo's on-disk path can't trip the
+        # match, then look only inside string fields that carry
+        # consumer-visible text (names, doc-comment line text,
+        # identifier spellings).
+        STRIPPED="$(mktemp -t edge-rum-symbols.XXXXXX)"
+        # shellcheck disable=SC2064
+        trap "rm -f \"${STRIPPED}\"" EXIT
+        sed -E 's/"uri":"[^"]*"//g' "${SYMBOL_JSON}" > "${STRIPPED}"
+        while IFS= read -r hit; do
+            [[ -z "${hit}" ]] && continue
+            for token in "${BANNED_TOKENS[@]}"; do
+                if echo "${hit}" | grep -iqE "(^|[^A-Za-z])${token}([^A-Za-z]|$)"; then
+                    report "${token}" "symbol-graph EdgeRum.symbols.json" \
+                        "$(echo "${hit}" | tr -d '\t' | cut -c1-160)"
+                    break
+                fi
+            done
+        done < <(grep -ioE "\"(title|text|spelling|pathComponents)\"[[:space:]]*:[[:space:]]*\"[^\"]*(${PATTERN})[^\"]*\"" "${STRIPPED}" -i 2>/dev/null || true)
+    fi
+fi
+
+# Step 2 — Source-file doc-comment pre-check.
+#
+# Greps every `///` line in `Sources/EdgeRum/**/*.swift` for any
+# banned token. Catches issues before the symbol graph even compiles.
+if [[ -d "${PUBLIC_SWIFT_DIR}" ]]; then
+    while IFS= read -r match; do
+        [[ -z "${match}" ]] && continue
+        file="${match%%:*}"
+        rest="${match#*:}"
+        lineno="${rest%%:*}"
+        content="${rest#*:}"
+        for token in "${BANNED_TOKENS[@]}"; do
+            if echo "${content}" | grep -iqE "(^|[^A-Za-z])${token}([^A-Za-z]|$)"; then
+                report "${token}" "${file#${REPO_ROOT}/}:${lineno}" "$(echo "${content}" | tr -d '\t' | cut -c1-160)"
+                break
+            fi
+        done
+    done < <(grep -RInE '^[[:space:]]*///' "${PUBLIC_SWIFT_DIR}" || true)
+fi
+
+# Step 3 — README.md.
+if [[ -f "${REPO_ROOT}/README.md" ]]; then
+    while IFS= read -r match; do
+        [[ -z "${match}" ]] && continue
+        lineno="${match%%:*}"
+        content="${match#*:}"
+        for token in "${BANNED_TOKENS[@]}"; do
+            if echo "${content}" | grep -iqE "(^|[^A-Za-z])${token}([^A-Za-z]|$)"; then
+                report "${token}" "README.md:${lineno}" "$(echo "${content}" | tr -d '\t' | cut -c1-160)"
+                break
+            fi
+        done
+    done < <(grep -nE "(${PATTERN})" "${REPO_ROOT}/README.md" -i || true)
+fi
+
+# Step 4 — Other consumer-facing markdown under docs/.
+if [[ -d "${REPO_ROOT}/docs" ]]; then
+    # Build a list of skip paths into a single regex.
+    skip_regex=""
+    for skip in "${INTERNAL_DOCS[@]}"; do
+        if [[ -z "${skip_regex}" ]]; then
+            skip_regex="${skip}"
+        else
+            skip_regex="${skip_regex}|${skip}"
+        fi
+    done
+
+    while IFS= read -r md; do
+        rel="${md#${REPO_ROOT}/}"
+        if [[ -n "${skip_regex}" ]] && echo "${rel}" | grep -qE "^(${skip_regex})$"; then
+            continue
+        fi
+        while IFS= read -r match; do
+            [[ -z "${match}" ]] && continue
+            lineno="${match%%:*}"
+            content="${match#*:}"
+            for token in "${BANNED_TOKENS[@]}"; do
+                if echo "${content}" | grep -iqE "(^|[^A-Za-z])${token}([^A-Za-z]|$)"; then
+                    report "${token}" "${rel}:${lineno}" "$(echo "${content}" | tr -d '\t' | cut -c1-160)"
+                    break
+                fi
+            done
+        done < <(grep -nE "(${PATTERN})" "${md}" -i || true)
+    done < <(find "${REPO_ROOT}/docs" -type f -name '*.md')
+fi
+
+if (( fail_count > 0 )); then
+    echo "firewall-check: ${fail_count} banned-term leak(s) detected." >&2
+    echo "firewall-check: see CLAUDE.md Rule 1 for the consumer vocabulary mapping." >&2
+    exit 1
+fi
+
+echo "firewall-check: public surface and consumer docs are clean."
+exit 0

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -84,3 +84,96 @@ on us as well.
   observation in §6.10) carries a documented 60 Hz fallback.
 - `PLAN-iOS.md` §5.4 holds the "why no umbrella" explanation in the
   architecture document; this ADR holds the dated decision.
+
+---
+
+## ADR-002 — F2 public API shape: sealed `AttributeValue`, idempotent `RumTimer`, no-op Recorder seam
+
+**Date:** 2026-06-16
+
+**Status:** Accepted.
+
+**Context.** F2 lands the entire consumer-facing Swift surface for
+`edge-rum-ios` (`PLAN-iOS.md` §F2 / §3). Three design choices on that
+surface deserve a dated rationale because each has a more obvious
+"obvious" alternative we deliberately turned down. F3 — the real
+Recorder — lands after F2, so F2 also has to decide how the public
+surface couples to the (not yet built) Recorder.
+
+**Decision.**
+
+1. **`AttributeValue` is a sealed enum (`.string` / `.int` / `.double`
+   / `.bool`), not `Any` or `Encodable`.** Every public method that
+   accepts attributes is typed as `[String: AttributeValue]?`,
+   including `EdgeRum.captureError(_:context:)`.
+2. **`RumTimer` is a `final class`, not a `struct`.** `end()` and
+   `cancel()` are idempotent under an internal `NSLock`; second
+   calls are silent no-ops rather than crashes.
+3. **The public namespace routes every call through an internal
+   `Recording` protocol with a swappable shared instance**
+   (`Recorder.shared` in `EdgeRumCore`). F2 ships a no-op
+   implementation that buffers calls in memory; F3 swaps in the
+   real fan-in/transport implementation behind the same protocol
+   without touching `Sources/EdgeRum/`.
+
+**Rationale.**
+
+1. The JSON wire contract documented in `CLAUDE.md` allows only
+   `String`, `Int`, `Double`, `Bool` in `attributes`. A sealed enum
+   makes the compiler enforce that — there is no path by which a
+   caller can hand the SDK an `[String: Any]` containing a `Date`,
+   nested dictionary, or array of objects and have the encoder
+   silently produce a malformed payload. The four
+   `ExpressibleBy…Literal` conformances keep the call sites tidy.
+2. `RumTimer` consumers always come from `EdgeRum.time(_:)` — they
+   never construct one. A class with internal mutable state lets
+   `end()` mark itself "settled" once, regardless of how many copies
+   of the reference the host app holds. With a struct we would either
+   have to require `inout` (awkward) or accept that copying a timer
+   silently splits its identity. Either is a worse failure mode than
+   "second `end()` is a no-op".
+3. F2 acceptance demands the public surface compile, ship, and route
+   correctly without F3's transport in place. Wiring the surface
+   directly to a stub Recorder behind an `internal protocol Recording`
+   keeps the F2 → F3 transition a one-file edit (the implementation
+   of `Recorder`), keeps the surface fully testable today via a
+   probe Recorder, and means the firewall check examines a stable
+   target (`Sources/EdgeRum/`) that will not churn when F3 lands.
+
+**Alternatives considered.**
+
+- **`[String: Encodable]` or `[String: Any]` for attributes.** Web
+  and Android SDKs work this way; consumers find it natural. Rejected
+  because the type system would no longer catch wire-incompatible
+  values at call sites — and the wire contract is the constraint
+  that matters most.
+- **`RumTimer` as a `struct` with `mutating end()`.** Briefer; no
+  reference semantics. Rejected because `EdgeRum.time(_:)` returning
+  a struct then stored in a `let` would forbid `end()` entirely.
+- **Public methods that take a closure or builder.** More flexible,
+  fits Swift idiom. Out of scope — we'd be designing for hypothetical
+  use cases.
+- **Defer F2 until F3 lands so the public surface routes to a real
+  Recorder from day one.** Rejected because it blocks every other
+  feature on F3 and removes the integration-test feedback loop for
+  the public shape.
+
+**Consequences.**
+
+- The public `AttributeValue` enum lives in `EdgeRumCore` (not
+  `EdgeRum`) so the internal `Recording` protocol can take
+  `[String: AttributeValue]` without a back-edge on the public
+  module. `EdgeRum` re-exports it as a `public typealias` so the
+  consumer name stays `AttributeValue`.
+- `EdgeRumCore` is not a SwiftPM product; promoting its types to
+  `public` exposes them only to other internal targets that depend
+  on `EdgeRumCore`, never to outside consumers. Outside consumers
+  see only what `Sources/EdgeRum/` declares public.
+- `EdgeRum.start(_:)` is idempotent: same `apiKey` + `endpoint`
+  re-entry is a silent no-op; a different identity logs a warning
+  and is ignored. Misuse on input (empty `apiKey`, missing `edge_`
+  prefix, non-`https` endpoint in non-debug builds) hits
+  `preconditionFailure` so debug and release behaviour match.
+- `Tools/firewall-check.sh` runs on every PR (audit job) and
+  policies `Sources/EdgeRum/`, the public symbol graph, `README.md`,
+  and consumer-facing `docs/*.md` against Rule 1's banned-token list.


### PR DESCRIPTION
## Summary

Lands feature **F2 — Public API surface** (`PLAN-iOS.md` §F2, tasks T2.1–T2.7) on top of the F1 package + build infrastructure.

- Public surface (`Sources/EdgeRum/`): caseless `EdgeRum` enum with all 9 methods + 3 properties, `EdgeRumConfig` with documented defaults + `validate()`, `Environment`, `UserContext`, `AttributeValue` (sealed enum re-exported via typealias), `RumTimer` (idempotent `end()`/`cancel()`, injectable `Clock`), and the two SwiftUI view modifiers `.edgeRumScreen` / `.edgeRumTrackTap`.
- Internal seam (`Sources/EdgeRumCore/`): `Recording` protocol, `Clock`, the real `AttributeValue` sealed enum, and a thread-safe no-op `Recorder` with a swappable shared instance — F3 drops the real fan-in implementation behind the same protocol without touching the public module.
- `Tools/firewall-check.sh` (T2.7): three-layer banned-vocabulary check (public Swift symbol graph + `///` doc comments + README / consumer-facing markdown). Wired into the `audit` CI job.
- README.md — first README for the repo (install + quick-start + API table + Button gesture caveat).
- ADR-002 in `docs/decisions.md` documenting the three load-bearing design calls (sealed `AttributeValue`, class-based idempotent `RumTimer`, internal Recorder seam).
- 88 XCTests across 9 new files. `PackageProductsTests` locks the invariant that internal targets (`EdgeRumCore`, `EdgeRumCapture`, `EdgeRumCrash`, `EdgeRumOTelBridge`) stay off the SwiftPM products list.

## What changed by file

- **Sources/EdgeRum/**: `EdgeRum.swift` (replaces the F1 stub), `EdgeRumConfig.swift`, `Environment.swift`, `UserContext.swift`, `AttributeValue.swift`, `RumTimer.swift`, `SwiftUI/ViewModifiers.swift`.
- **Sources/EdgeRumCore/**: `Recording.swift`, `Recorder.swift` (real shared-instance impl), `Clock.swift`, `AttributeValue.swift`.
- **Tools/firewall-check.sh** (new, executable).
- **.github/workflows/ci.yml**: `audit` job now runs `check-supported-ios.sh` and `firewall-check.sh`, with PLCrashReporter fetch + Xcode select prerequisites for the symbol-graph step.
- **README.md** (new).
- **docs/decisions.md**: ADR-002 appended.
- **Tests/EdgeRumTests/**: `AttributeValueTests`, `EnvironmentTests`, `UserContextTests`, `EdgeRumConfigTests`, `RumTimerTests`, `EdgeRumAPITests` (with `ProbeRecorder`), `SwiftUIModifierTests`, `FirewallCheckScriptTests`, `PackageProductsTests`.

## Test plan

- [x] `swift build -c release` — clean
- [x] `swift test --enable-code-coverage` — 88/88 pass
- [x] `./Tools/firewall-check.sh` — public surface + consumer docs clean
- [x] `./Tools/firewall-check.sh` with planted leak — script exits non-zero and names the banned term (validated via `FirewallCheckScriptTests`)
- [x] `./Tools/check-supported-ios.sh` — iOS 14 floor consistent across Package.swift, podspec, PLAN-iOS.md §2.2, README.md
- [x] `xcodebuild -scheme EdgeRum -destination 'generic/platform=iOS' build` — clean
- [ ] CI on PR — exercises `build` / `test` / `audit` (now incl. firewall) / `pod-lint` jobs

## Acceptance criteria (PLAN-iOS.md §F2)

- T2.1 — `swift package dump-symbol-graph --minimum-access-level public` lists only the §3.2 symbols ✅
- T2.2 — `EdgeRumConfig` has every documented default; `validate(_:)` rejects empty / non-`edge_`-prefixed `apiKey` and non-`https` endpoint when `debug == false` ✅
- T2.3 — Passing a non-primitive value to `track(attributes:)` is a compile error (sealed enum) ✅
- T2.4 — `UserContext` and `Environment` round-trip unchanged through `identify()` ✅
- T2.5 — Second `RumTimer.end()` is a no-op; `cancel()` is idempotent ✅
- T2.6 — SwiftUI modifier emits `navigation` with `navigation.kind = "swiftui"` ✅
- T2.7 — Planting `Span` / `tracer` in a public doc comment fails CI ✅

## Notes for reviewers

- `EdgeRumCore` types are promoted to `public` so the public umbrella can route through them — load-bearing invariant is that `EdgeRumCore` stays out of `Package.swift`'s `products:`. Locked in by `PackageProductsTests`.
- `EdgeRum.handleBackgroundEvents(identifier:completion:)` is a stub today (F5 wires the real `BackgroundUploader`); it hops to main and calls `completion()` so the AppDelegate contract host apps wire into is honoured.
- README's Button example uses the closure-instrumented pattern because SwiftUI's `Button` consumes touches before any `simultaneousGesture` runs; `.edgeRumTrackTap` is documented as appropriate for non-Button tap-able views.