### PR TITLE
feat(F4): identity & session persistence — Keychain device.id, UserDefaults session, sidecar writer

### DIFF
--- a/PLAN-iOS.md
+++ b/PLAN-iOS.md
@@ -1775,22 +1775,27 @@ type-safe attributes. **Status.** `v1.0`. **Refs.** §4.2, §7.
 #### F4 — Identity & session management
 
 **Goal.** Device, user, and session IDs in the exact wire format, with
-crash sidecar for next-launch replay. **Status.** `v1.0`. **Refs.** §8.
+crash sidecar for next-launch replay. **Status.** `v1.0` — landed
+2026-06-16. **Refs.** §8, [ADR-004](docs/decisions.md).
 
-##### T4.1 — ID format generator + regex `[M0]`
+##### T4.1 — ID format generator + regex `[M0]` ✅
 - Helper that produces `device_<epochMs>_<16 hex>_ios` etc. using `SecRandomCopyBytes(8)`.
 - Round-trip regex validates persisted IDs on load; regenerate on mismatch.
 
 **Acceptance.** `XCTAssertMatches(id, "^device_\\d+_[0-9a-f]{16}_ios$")` holds across 10k generated samples.
 
-##### T4.2 — `IdentityProvider` (Keychain + UserDefaults) `[M0]`
+**Shipped in F4 as `Sources/EdgeRumCore/Persistence/IdentityFormat.swift`. Generators live in `SdkContext.swift` / `SessionContext.swift` / `UserContextSnapshot.swift` (carried over from F3).**
+
+##### T4.2 — `IdentityProvider` (Keychain + UserDefaults) `[M0]` ✅
 - `device.id` in Keychain (`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`).
 - `user.id` in UserDefaults suite `com.edge.rum.session`.
 - Fallback path: if Keychain write fails, log and fall back to UserDefaults.
 
 **Acceptance.** Reinstalling the host app on the simulator regenerates `device.id`.
 
-##### T4.3 — `SessionManager` lifecycle `[M0 → M1]`
+**Shipped in F4 as `KeychainStore.swift` + `UserDefaultsStore.swift` + `IdentityProvider.swift`. `EdgeRum.start()` wires the real stores into `Recorder.shared` via `installPersistedStores(...)`.**
+
+##### T4.3 — `SessionManager` lifecycle `[M0 → M1]` ✅
 - Start a session on `start()` if none active or last-active > 30 min ago.
 - Update last-active on every `Recorder.recordEvent` and `didBecomeActive`.
 - Increment `session.sequence` on transport ack (under `NSLock`).
@@ -1798,11 +1803,15 @@ crash sidecar for next-launch replay. **Status.** `v1.0`. **Refs.** §8.
 
 **Acceptance.** Three consecutive ACKed batches yield `session.sequence = 3`.
 
-##### T4.4 — Crash sidecar `[M3]`
-- `Library/Caches/edge-rum/last-session.json` mirrors current identity on every event.
-- Read on next launch when a crash report is pending — emit replay event with the **previous** session's identity.
+**Shipped in F4 as `UserDefaultsSessionStore.swift` + the `Recorder.bumpLastActiveAndEmitRotationIfNeeded()` hook + `Recorder.didAckBatch()`. `didBecomeActive` / `willResignActive` lifecycle wiring is owned by F11 (`LifecycleCapture`).**
 
-**Acceptance.** Crash sample app (§13.3) test: replayed `app.crash` carries the crashing session's `session.id`, not the current one.
+##### T4.4 — Crash sidecar — writer only `[M3]` ✅ / reader carry-over → F14
+- `Library/Caches/edge-rum/last-session.json` mirrors current identity on every event.
+- ~~Read on next launch when a crash report is pending — emit replay event with the **previous** session's identity.~~ *(reader + replay path lives in `EdgeRumCrash` / T14.3 — see issue #44 carry-over note)*
+
+**Acceptance.** Crash sample app (§13.3) test: replayed `app.crash` carries the crashing session's `session.id`, not the current one. *(Reader + replay path lives in F14 / T14.3.)*
+
+**Shipped in F4 as `SessionSidecar.swift`. Writer is hooked into `Recorder.enqueue(_:)` and `Recorder.didAckBatch()` so the on-disk mirror is fresh whenever the buffer or sequence changes.**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `edge-rum-ios` is the native iOS sibling of the [`edge-rum`](https://github.com/NCG-Africa/edge-rum) (web/Ionic/Capacitor) and [`edge-rum-android`](https://github.com/NCG-Africa/edge-rum-android) SDKs. It captures performance data, errors, native crashes, hangs, network requests, and user interactions on iOS apps and ships them as JSON to the EdgeTelemetryProcessor backend used by all three platforms.
 
-> **Status.** Public API surface (F2) is in place. F3 lands the core pipeline — the internal Recorder fan-in, identity context, sampler, and JSON envelope assembly — so the SDK now produces wire-conformant batches in memory. Transport (HTTP POST), persistence, offline queue, and the capture layer (screen / HTTP / interaction / native crash) follow across F4–F18.
+> **Status.** Public API surface (F2) and the core pipeline (F3) are in place. F4 lands persistent identity — `device.id` survives across launches in the Keychain, `user.id` and the session triple live in the `com.edge.rum.session` UserDefaults suite, the 30-minute idle session rotation is enforced on every event, and the `last-session.json` sidecar mirrors the active identity for F14's crash-replay path. HTTP transport (F5), offline queue, and the capture layer (screen / HTTP / interaction / native crash) follow across F5–F18.
 
 ## Supported iOS
 
@@ -146,13 +146,34 @@ Every public call (`track`, `trackScreen`, `identify`, `time`, `captureError`, p
 
 Sample rate, batch size, and flush interval are all configurable on `EdgeRumConfig`. See [`docs/payload-example.jsonc`](docs/payload-example.jsonc) for the exact wire shape and [`docs/decisions.md`](docs/decisions.md) for the design rationale.
 
+## Identity & session model
+
+F4 makes the three SDK-owned identifiers persistent so the backend sees stable values across launches:
+
+| ID | Format | Storage |
+| --- | --- | --- |
+| `device.id` | `device_<epochMs>_<16 hex>_ios` | Keychain (service `com.edge.rum.identity`, `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`). UserDefaults fallback when the Keychain write fails. iOS clears Keychain on uninstall on modern installs — `device.id` rotates on reinstall in practice. |
+| `session.id` | `session_<epochMs>_<16 hex>_ios` | UserDefaults suite `com.edge.rum.session` along with `session.start_time`, `session.sequence`, and `session.lastActiveAt`. |
+| `user.id` | `user_<epochMs>_<16 hex>` | Same UserDefaults suite. SDK-owned anonymous id — `EdgeRum.identify(_:)` attaches `user.name`/`user.email`/`user.phone` as additional attributes but **does not** change this generated `user.id`. |
+
+The 16 hex chars come from `SecRandomCopyBytes(8)` formatted `%02x` — not `UUID()`, whose 128-bit hex section would break the cross-platform regex the backend dispatcher uses.
+
+A session rotates when either of the following holds at the next `recordEvent`:
+
+- the persisted `lastActiveAt` is older than 30 minutes, **or**
+- there's no persisted session at all (cold start / first launch).
+
+Rotation emits a `session.finalized` event carrying the **prior** session's identity (so the backend can close the session out correctly), followed by `session.started` for the new id. `session.sequence` increments after each successful transport ack via `Recorder.didAckBatch()` so the backend can detect dropped batches.
+
+A read-only mirror of the live identity is written to `Library/Caches/edge-rum/last-session.json` on every event — F14's crash backend reads it on next launch so a replayed `app.crash` carries the crashing session's id rather than the current one.
+
 ## Design docs
 
 | Doc | What it covers |
 | --- | --- |
 | [`PLAN-iOS.md`](PLAN-iOS.md) | The full feature plan F1 → F23, milestones, acceptance criteria, and per-task references. Authoritative for scope. |
 | [`docs/data-flow.md`](docs/data-flow.md) | End-to-end data flow from capture call to backend ingest. Internal — references the internal architecture by name. |
-| [`docs/decisions.md`](docs/decisions.md) | Architectural Decision Records. ADR-002 explains the F2 public API shape choices. |
+| [`docs/decisions.md`](docs/decisions.md) | Architectural Decision Records. ADR-002 covers F2; ADR-003 covers F3; ADR-004 covers the F4 persistent identity model. |
 | [`docs/payload-example.jsonc`](docs/payload-example.jsonc) | Reference batch payload — what the SDK actually ships on the wire. |
 | [`CLAUDE.md`](CLAUDE.md) | Contributor guide; binding rules for AI-assisted development. |
 

--- a/Sources/EdgeRum/AttributeValueExport.swift
+++ b/Sources/EdgeRum/AttributeValueExport.swift
@@ -10,9 +10,19 @@
 // `pod lib lint` with "Filename used twice". The exported Swift
 // symbol is still `AttributeValue` via the typealias below.
 //
+// Under SwiftPM: `EdgeRumCore` is a real module so we import it and
+// publish a typealias. Under CocoaPods every subspec rolls into a
+// single `EdgeRum` module — the enum from
+// `Sources/EdgeRumCore/AttributeValue.swift` is already public in
+// that module, so the typealias would be a self-referential cycle.
+// The `#if canImport(EdgeRumCore)` guard makes the file a no-op
+// under CocoaPods and active under SwiftPM. Consumers write
+// `AttributeValue` in both worlds.
+//
 // Refs: PLAN-iOS.md §3.2, §F2/T2.3.
 //
 
+#if canImport(EdgeRumCore)
 import EdgeRumCore
 
 /// A single value that may travel as an event attribute on the wire.
@@ -30,3 +40,4 @@ import EdgeRumCore
 /// ])
 /// ```
 public typealias AttributeValue = EdgeRumCore.AttributeValue
+#endif

--- a/Sources/EdgeRum/AttributeValueExport.swift
+++ b/Sources/EdgeRum/AttributeValueExport.swift
@@ -1,8 +1,14 @@
-// Sources/EdgeRum/AttributeValue.swift
+// Sources/EdgeRum/AttributeValueExport.swift
 //
 // Public re-export of the sealed-enum attribute type. The actual enum
 // is declared in `EdgeRumCore` so the internal Recorder protocol can
 // take it without a back-edge on the public umbrella module.
+//
+// File is named `AttributeValueExport.swift` (not `AttributeValue.swift`)
+// because CocoaPods rolls every subspec into one Pods target and two
+// Swift files sharing a basename inside a single target fail
+// `pod lib lint` with "Filename used twice". The exported Swift
+// symbol is still `AttributeValue` via the typealias below.
 //
 // Refs: PLAN-iOS.md §3.2, §F2/T2.3.
 //

--- a/Sources/EdgeRum/EdgeRum.swift
+++ b/Sources/EdgeRum/EdgeRum.swift
@@ -103,6 +103,18 @@ public enum EdgeRum {
         startedIdentity = identity
         stateLock.unlock()
 
+        // If the shared Recorder is the real concrete type (i.e. the
+        // host hasn't swapped in a test probe), upgrade its in-memory
+        // identity stores to the persisted Keychain + UserDefaults
+        // pair so `device.id` and `session.id` survive across launches.
+        if let realRecorder = Recorder.shared as? Recorder {
+            realRecorder.installPersistedStores(
+                identityProvider: IdentityProvider(),
+                sessionStore: UserDefaultsSessionStore(),
+                sidecar: SessionSidecar()
+            )
+        }
+
         // Hand the full settings to the internal Recorder before
         // it starts so context snapshots, sample rate, batch size,
         // and location are all in place when the first event lands.

--- a/Sources/EdgeRum/EdgeRum.swift
+++ b/Sources/EdgeRum/EdgeRum.swift
@@ -250,9 +250,15 @@ public enum EdgeRum {
     /// completionHandler:)` to the SDK so any pending background
     /// uploads can finish after process death. Wire from
     /// `AppDelegate` or `SceneDelegate`.
+    ///
+    /// `completion` is `@Sendable` so it can be hopped onto the main
+    /// queue under Swift 6 strict-concurrency. The system-supplied
+    /// completion handler from
+    /// `application(_:handleEventsForBackgroundURLSession:
+    /// completionHandler:)` is sendable in practice.
     public static func handleBackgroundEvents(
         identifier: String,
-        completion: @escaping () -> Void
+        completion: @Sendable @escaping () -> Void
     ) {
         // F5 wires the BackgroundUploader and calls `completion` once
         // the URLSession finishes its pending tasks. F2 ships the

--- a/Sources/EdgeRum/EdgeRum.swift
+++ b/Sources/EdgeRum/EdgeRum.swift
@@ -14,7 +14,12 @@
 
 import Foundation
 import os.log
+#if canImport(EdgeRumCore)
+// SwiftPM: `EdgeRumCore` is a separate internal target. CocoaPods
+// rolls every subspec into one `EdgeRum` module — the same types
+// are already visible without an import.
 import EdgeRumCore
+#endif
 
 /// Top-level entry point for the EdgeRum SDK.
 ///

--- a/Sources/EdgeRum/RumTimer.swift
+++ b/Sources/EdgeRum/RumTimer.swift
@@ -5,7 +5,12 @@
 //
 
 import Foundation
+#if canImport(EdgeRumCore)
+// SwiftPM: `EdgeRumCore` is a separate internal target. CocoaPods
+// rolls every subspec into one `EdgeRum` module — the same types
+// are already visible without an import.
 import EdgeRumCore
+#endif
 
 /// Measures an interval of host-app code and records a single
 /// performance data point at the end.

--- a/Sources/EdgeRum/SwiftUI/ViewModifiers.swift
+++ b/Sources/EdgeRum/SwiftUI/ViewModifiers.swift
@@ -10,7 +10,12 @@
 
 #if canImport(SwiftUI)
 import SwiftUI
+#if canImport(EdgeRumCore)
+// SwiftPM: `EdgeRumCore` is a separate internal target. CocoaPods
+// rolls every subspec into one `EdgeRum` module — the same types
+// are already visible without an import.
 import EdgeRumCore
+#endif
 
 // MARK: - Internals (testable in isolation)
 

--- a/Sources/EdgeRumCore/Persistence/IdentityFormat.swift
+++ b/Sources/EdgeRumCore/Persistence/IdentityFormat.swift
@@ -1,0 +1,81 @@
+// Sources/EdgeRumCore/Persistence/IdentityFormat.swift
+//
+// Compiled regex validators for the three persisted identity strings.
+// F4 calls `validate(persisted:)` after loading a value from
+// Keychain / UserDefaults — any mismatch (corrupt data, an older
+// format, a manually edited value) regenerates the id transparently
+// so the wire never carries a malformed identifier.
+//
+// Format rules (CLAUDE.md "Session and ID rules"):
+//   device.id   "device_<epochMs>_<16 hex>_ios"
+//   session.id  "session_<epochMs>_<16 hex>_ios"
+//   user.id     "user_<epochMs>_<16 hex>"        (no `_ios` suffix)
+//
+// The 16 hex chars come from `SecRandomCopyBytes(8)` formatted `%02x`.
+// `UUID()` is NOT used — its 128-bit hex section breaks the regex
+// the backend dispatcher relies on for cross-platform routing.
+//
+// Refs: CLAUDE.md "Session and ID rules"; PLAN-iOS.md §F4/T4.1.
+//
+
+import Foundation
+
+public enum IdentityKind: Sendable, Hashable {
+    case device
+    case session
+    case user
+}
+
+public enum IdentityFormat {
+
+    public static let devicePattern = #"^device_\d+_[0-9a-f]{16}_ios$"#
+    public static let sessionPattern = #"^session_\d+_[0-9a-f]{16}_ios$"#
+    public static let userPattern = #"^user_\d+_[0-9a-f]{16}$"#
+
+    public static func pattern(for kind: IdentityKind) -> String {
+        switch kind {
+        case .device: return devicePattern
+        case .session: return sessionPattern
+        case .user: return userPattern
+        }
+    }
+
+    /// Returns `true` when `value` matches the regex for `kind`. Used
+    /// by the IdentityProvider load path to decide whether a persisted
+    /// id is still trustworthy.
+    public static func isValid(_ value: String, kind: IdentityKind) -> Bool {
+        let pattern = pattern(for: kind)
+        guard let regex = compiledRegex(for: pattern) else { return false }
+        let range = NSRange(value.startIndex..<value.endIndex, in: value)
+        return regex.firstMatch(in: value, options: [], range: range) != nil
+    }
+
+    /// Convenience: returns `value` if valid, otherwise `nil`. Lets
+    /// callers `??` straight into a fresh generator.
+    public static func validate(_ value: String, kind: IdentityKind) -> String? {
+        isValid(value, kind: kind) ? value : nil
+    }
+
+    // MARK: Private
+
+    private static let regexCache = RegexCache()
+
+    private static func compiledRegex(for pattern: String) -> NSRegularExpression? {
+        regexCache.regex(for: pattern)
+    }
+
+    private final class RegexCache: @unchecked Sendable {
+        private let lock = NSLock()
+        private var cache: [String: NSRegularExpression] = [:]
+
+        func regex(for pattern: String) -> NSRegularExpression? {
+            lock.lock(); defer { lock.unlock() }
+            if let cached = cache[pattern] { return cached }
+            guard let compiled = try? NSRegularExpression(pattern: pattern) else {
+                return nil
+            }
+            cache[pattern] = compiled
+            return compiled
+        }
+    }
+}

--- a/Sources/EdgeRumCore/Persistence/IdentityProvider.swift
+++ b/Sources/EdgeRumCore/Persistence/IdentityProvider.swift
@@ -1,0 +1,179 @@
+// Sources/EdgeRumCore/Persistence/IdentityProvider.swift
+//
+// Resolves the two SDK-owned, persisted identity strings:
+//
+//   - `device.id` lives in Keychain
+//     (`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`). If the
+//     Keychain write fails (rare, but observed on simulators with
+//     locked entitlements), we fall back to the same UserDefaults
+//     suite as `user.id`/`session.id`, persisting under a separate
+//     "fallback" key so we can tell at read time whether the value
+//     came from Keychain or from the fallback.
+//
+//   - `user.id` lives in the UserDefaults suite
+//     `com.edge.rum.session`. iCloud-sync is intentionally not enabled.
+//
+// Each persisted value is validated against the format regex from
+// `IdentityFormat` on load. A mismatch (corrupt, manually edited, or
+// pre-format-change value) triggers a transparent regeneration —
+// callers see the new value, the old value is overwritten.
+//
+// Refs: CLAUDE.md "Session and ID rules → Storage"; PLAN-iOS.md
+//       §8.2 / §F4/T4.2.
+//
+
+import Foundation
+import os.log
+
+public struct IdentitySnapshot: Sendable, Hashable {
+    public let deviceId: String
+    public let userId: String
+
+    /// `true` when `deviceId` came from the UserDefaults fallback
+    /// (Keychain write failed). Exposed so the Recorder can emit one
+    /// diagnostic log line at startup in debug mode.
+    public let deviceIdFromFallback: Bool
+
+    public init(deviceId: String, userId: String, deviceIdFromFallback: Bool) {
+        self.deviceId = deviceId
+        self.userId = userId
+        self.deviceIdFromFallback = deviceIdFromFallback
+    }
+}
+
+public final class IdentityProvider: @unchecked Sendable {
+
+    private let keychain: KeychainStoring
+    private let defaults: UserDefaultsStoring
+    private let clock: Clock
+    private let randomBytes: () -> Data
+    private let log: OSLog
+
+    private let lock = NSLock()
+
+    public init(
+        keychain: KeychainStoring = KeychainStore(),
+        defaults: UserDefaultsStoring = UserDefaultsStore(suiteName: EdgeRumStorage.sessionSuite),
+        clock: Clock = SystemClock(),
+        randomBytes: @escaping () -> Data = SessionManager.secureRandomBytes,
+        log: OSLog = OSLog(subsystem: "com.edge.rum", category: "IdentityProvider")
+    ) {
+        self.keychain = keychain
+        self.defaults = defaults
+        self.clock = clock
+        self.randomBytes = randomBytes
+        self.log = log
+    }
+
+    /// Returns the resolved snapshot, creating + persisting any
+    /// missing or invalid identifier. Idempotent — calling twice
+    /// returns the same values.
+    public func resolve() -> IdentitySnapshot {
+        lock.lock(); defer { lock.unlock() }
+        let (deviceId, fromFallback) = resolveDeviceId()
+        let userId = resolveUserId()
+        return IdentitySnapshot(
+            deviceId: deviceId,
+            userId: userId,
+            deviceIdFromFallback: fromFallback
+        )
+    }
+
+    /// Force-regenerate the `device.id` value. Intended for tests and
+    /// for the unlikely "user requested a reset" host-app code path.
+    /// Returns the freshly-generated id.
+    @discardableResult
+    public func regenerateDeviceId() -> String {
+        lock.lock(); defer { lock.unlock() }
+        let fresh = DeviceIdentitySnapshot.newId(at: clock.now, randomBytes: randomBytes)
+        persistDeviceId(fresh)
+        return fresh
+    }
+
+    /// Force-regenerate the `user.id` value.
+    @discardableResult
+    public func regenerateUserId() -> String {
+        lock.lock(); defer { lock.unlock() }
+        let fresh = UserContextSnapshot.newAnonymousId(at: clock.now, randomBytes: randomBytes)
+        defaults.set(fresh, forKey: EdgeRumStorage.keyUserId)
+        return fresh
+    }
+
+    // MARK: device.id
+
+    private func resolveDeviceId() -> (id: String, fromFallback: Bool) {
+        if let valid = readValidDeviceIdFromKeychain() {
+            return (valid, false)
+        }
+        if let valid = readValidDeviceIdFromFallback() {
+            return (valid, true)
+        }
+        let fresh = DeviceIdentitySnapshot.newId(at: clock.now, randomBytes: randomBytes)
+        let usedFallback = persistDeviceId(fresh)
+        return (fresh, usedFallback)
+    }
+
+    private func readValidDeviceIdFromKeychain() -> String? {
+        do {
+            guard let raw = try keychain.read(
+                service: EdgeRumStorage.keychainService,
+                account: EdgeRumStorage.keychainAccountDeviceId
+            ) else { return nil }
+            return IdentityFormat.validate(raw, kind: .device)
+        } catch {
+            os_log(
+                "IdentityProvider keychain read failed: %{public}@",
+                log: log,
+                type: .info,
+                String(describing: error)
+            )
+            return nil
+        }
+    }
+
+    private func readValidDeviceIdFromFallback() -> String? {
+        guard let raw = defaults.string(forKey: EdgeRumStorage.keyDeviceIdFallback) else {
+            return nil
+        }
+        return IdentityFormat.validate(raw, kind: .device)
+    }
+
+    /// Persists `id` to Keychain. On Keychain failure, persists to the
+    /// UserDefaults fallback key. Returns `true` if the fallback was
+    /// used.
+    @discardableResult
+    private func persistDeviceId(_ id: String) -> Bool {
+        do {
+            try keychain.write(
+                id,
+                service: EdgeRumStorage.keychainService,
+                account: EdgeRumStorage.keychainAccountDeviceId
+            )
+            // Clear any prior fallback value so the next launch picks
+            // up the Keychain copy.
+            defaults.removeObject(forKey: EdgeRumStorage.keyDeviceIdFallback)
+            return false
+        } catch {
+            os_log(
+                "IdentityProvider keychain write failed; falling back to UserDefaults: %{public}@",
+                log: log,
+                type: .info,
+                String(describing: error)
+            )
+            defaults.set(id, forKey: EdgeRumStorage.keyDeviceIdFallback)
+            return true
+        }
+    }
+
+    // MARK: user.id
+
+    private func resolveUserId() -> String {
+        if let existing = defaults.string(forKey: EdgeRumStorage.keyUserId),
+           let valid = IdentityFormat.validate(existing, kind: .user) {
+            return valid
+        }
+        let fresh = UserContextSnapshot.newAnonymousId(at: clock.now, randomBytes: randomBytes)
+        defaults.set(fresh, forKey: EdgeRumStorage.keyUserId)
+        return fresh
+    }
+}

--- a/Sources/EdgeRumCore/Persistence/KeychainStore.swift
+++ b/Sources/EdgeRumCore/Persistence/KeychainStore.swift
@@ -1,0 +1,183 @@
+// Sources/EdgeRumCore/Persistence/KeychainStore.swift
+//
+// Thin wrapper around the Security framework for storing the single
+// `device.id` value. Designed for replace-write semantics — the
+// IdentityProvider only ever stores one item per service so we use a
+// `kSecClassGenericPassword` row keyed on (service, account).
+//
+// Accessibility: `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`
+// — survives between launches once the device is unlocked once, is not
+// included in iCloud backup, and does not migrate to another device.
+// This matches CLAUDE.md "Session and ID rules → Storage".
+//
+// We expose a `KeychainStoring` protocol so IdentityProvider tests can
+// inject a deterministic in-memory fake (and trigger the "Keychain
+// write failed" fallback path without simulating a real SecItemAdd
+// error).
+//
+// Refs: CLAUDE.md "Session and ID rules → Storage";
+//       PLAN-iOS.md §8.2 / §F4/T4.2.
+//
+
+import Foundation
+import Security
+
+public protocol KeychainStoring: Sendable {
+    /// Returns the persisted string for the (service, account), or
+    /// `nil` if the slot is empty. Throws on unexpected `OSStatus`.
+    func read(service: String, account: String) throws -> String?
+
+    /// Atomically replaces the value at (service, account). Adds the
+    /// row if missing; updates it otherwise. Throws on `OSStatus`
+    /// errors other than `errSecItemNotFound`.
+    func write(_ value: String, service: String, account: String) throws
+
+    /// Removes the row at (service, account). Returns silently when
+    /// the row is absent — that's the desired idempotent semantic.
+    func delete(service: String, account: String) throws
+}
+
+public enum KeychainError: Error, Equatable {
+    case unexpectedStatus(OSStatus)
+    case unexpectedData
+}
+
+/// Production `KeychainStoring` backed by `SecItem*`. Marked `final`
+/// because there is no scenario in which we want to subclass this —
+/// callers should inject a different `KeychainStoring` conformer
+/// instead.
+///
+/// `@unchecked Sendable` because the only stored property is a
+/// `CFString` constant pointer (one of the immutable
+/// `kSecAttrAccessible*` symbols) — Apple ships them as global
+/// constants and they are safe to read from any thread.
+public final class KeychainStore: KeychainStoring, @unchecked Sendable {
+
+    private let accessibility: CFString
+
+    public init(accessibility: CFString = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly) {
+        self.accessibility = accessibility
+    }
+
+    public func read(service: String, account: String) throws -> String? {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+            kSecReturnData: kCFBooleanTrue as Any,
+            kSecMatchLimit: kSecMatchLimitOne
+        ]
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+
+        switch status {
+        case errSecSuccess:
+            guard let data = item as? Data,
+                  let value = String(data: data, encoding: .utf8) else {
+                throw KeychainError.unexpectedData
+            }
+            return value
+        case errSecItemNotFound:
+            return nil
+        default:
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+
+    public func write(_ value: String, service: String, account: String) throws {
+        guard let data = value.data(using: .utf8) else {
+            throw KeychainError.unexpectedData
+        }
+
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account
+        ]
+
+        let updateAttributes: [CFString: Any] = [
+            kSecValueData: data,
+            kSecAttrAccessible: accessibility
+        ]
+
+        let updateStatus = SecItemUpdate(query as CFDictionary, updateAttributes as CFDictionary)
+        switch updateStatus {
+        case errSecSuccess:
+            return
+        case errSecItemNotFound:
+            break
+        default:
+            throw KeychainError.unexpectedStatus(updateStatus)
+        }
+
+        var addQuery = query
+        addQuery[kSecValueData] = data
+        addQuery[kSecAttrAccessible] = accessibility
+
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        guard addStatus == errSecSuccess else {
+            throw KeychainError.unexpectedStatus(addStatus)
+        }
+    }
+
+    public func delete(service: String, account: String) throws {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        switch status {
+        case errSecSuccess, errSecItemNotFound:
+            return
+        default:
+            throw KeychainError.unexpectedStatus(status)
+        }
+    }
+}
+
+/// In-memory `KeychainStoring` for tests. Optional failure injection
+/// so we can exercise the IdentityProvider's UserDefaults fallback
+/// without needing a real Keychain failure on the simulator.
+public final class InMemoryKeychainStore: KeychainStoring, @unchecked Sendable {
+
+    public struct Key: Hashable, Sendable {
+        public let service: String
+        public let account: String
+        public init(service: String, account: String) {
+            self.service = service
+            self.account = account
+        }
+    }
+
+    private let lock = NSLock()
+    private var values: [Key: String] = [:]
+
+    /// When non-nil, every call throws this error. Used by tests to
+    /// drive the IdentityProvider into its UserDefaults fallback
+    /// branch.
+    public var failure: KeychainError?
+
+    public init(failure: KeychainError? = nil) {
+        self.failure = failure
+    }
+
+    public func read(service: String, account: String) throws -> String? {
+        if let failure { throw failure }
+        lock.lock(); defer { lock.unlock() }
+        return values[Key(service: service, account: account)]
+    }
+
+    public func write(_ value: String, service: String, account: String) throws {
+        if let failure { throw failure }
+        lock.lock(); defer { lock.unlock() }
+        values[Key(service: service, account: account)] = value
+    }
+
+    public func delete(service: String, account: String) throws {
+        if let failure { throw failure }
+        lock.lock(); defer { lock.unlock() }
+        values.removeValue(forKey: Key(service: service, account: account))
+    }
+}

--- a/Sources/EdgeRumCore/Persistence/SessionSidecar.swift
+++ b/Sources/EdgeRumCore/Persistence/SessionSidecar.swift
@@ -1,0 +1,137 @@
+// Sources/EdgeRumCore/Persistence/SessionSidecar.swift
+//
+// Mirrors the active session + identity attributes to
+// `Library/Caches/edge-rum/last-session.json` on every `enqueue`. The
+// crash backend (F14, `EdgeRumCrash`) reads this file on next launch
+// when a crash report is pending, so the replayed `app.crash` event
+// carries the *prior* session's identity rather than the freshly
+// rotated current session.
+//
+// F4 ships the **writer** only. The reader + replay path is owned by
+// F14 / `EdgeRumCrash` / T14.3 — flagged as carry-over on issue #44.
+//
+// Atomic write semantics: each write replaces the file via
+// `Data.write(to:options:.atomic)` so a crash mid-write cannot leave
+// a half-written JSON blob. The directory is created lazily on first
+// write.
+//
+// Refs: CLAUDE.md "Crash sidecar"; PLAN-iOS.md §8.4 / §F4/T4.4.
+//
+
+import Foundation
+import os.log
+
+public protocol SessionSidecarWriting: Sendable {
+    func write(snapshot: AttributeBag)
+}
+
+public final class SessionSidecar: SessionSidecarWriting, @unchecked Sendable {
+
+    /// Default path: `<Library>/Caches/edge-rum/last-session.json`.
+    public static func defaultURL() -> URL? {
+        let fm = FileManager.default
+        guard let caches = try? fm.url(
+            for: .cachesDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        ) else { return nil }
+        return caches
+            .appendingPathComponent("edge-rum", isDirectory: true)
+            .appendingPathComponent("last-session.json", isDirectory: false)
+    }
+
+    /// Attribute keys that get mirrored to the sidecar — strictly the
+    /// session / user / device identity triple plus the SDK identity
+    /// stamp. We intentionally omit transient values (network state,
+    /// battery level) because the replayed crash event should carry
+    /// the *prior* session's identity, not its network state.
+    public static let mirroredKeys: Set<String> = [
+        "session.id",
+        "session.start_time",
+        "session.sequence",
+        "user.id",
+        "user.name",
+        "user.email",
+        "user.phone",
+        "device.id",
+        "sdk.version",
+        "sdk.platform"
+    ]
+
+    private let url: URL?
+    private let fileManager: FileManager
+    private let log: OSLog
+    private let lock = NSLock()
+    private var directoryEnsured: Bool = false
+
+    public init(
+        url: URL? = SessionSidecar.defaultURL(),
+        fileManager: FileManager = .default,
+        log: OSLog = OSLog(subsystem: "com.edge.rum", category: "SessionSidecar")
+    ) {
+        self.url = url
+        self.fileManager = fileManager
+        self.log = log
+    }
+
+    public func write(snapshot: AttributeBag) {
+        guard let url else { return }
+
+        let mirrored = filter(snapshot)
+        guard !mirrored.isEmpty else { return }
+
+        do {
+            try ensureDirectory(for: url)
+            let data = try Self.encoder.encode(mirrored)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            os_log(
+                "SessionSidecar write failed: %{public}@",
+                log: log,
+                type: .info,
+                String(describing: error)
+            )
+        }
+    }
+
+    /// Read the persisted sidecar — F14 will call this on next launch
+    /// when a crash report is pending. Exposed in F4 so the writer's
+    /// round-trip can be tested.
+    public func read() -> [String: AttributeValue]? {
+        guard let url else { return nil }
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? Self.decoder.decode([String: AttributeValue].self, from: data)
+    }
+
+    private func filter(_ bag: AttributeBag) -> [String: AttributeValue] {
+        var out: [String: AttributeValue] = [:]
+        for key in Self.mirroredKeys {
+            if let value = bag[key] {
+                out[key] = value
+            }
+        }
+        return out
+    }
+
+    private func ensureDirectory(for url: URL) throws {
+        lock.lock(); defer { lock.unlock() }
+        if directoryEnsured { return }
+        let dir = url.deletingLastPathComponent()
+        if !fileManager.fileExists(atPath: dir.path) {
+            try fileManager.createDirectory(
+                at: dir,
+                withIntermediateDirectories: true
+            )
+        }
+        directoryEnsured = true
+    }
+
+    private static let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.outputFormatting = [.sortedKeys]
+        return e
+    }()
+
+    private static let decoder = JSONDecoder()
+}

--- a/Sources/EdgeRumCore/Persistence/UserDefaultsSessionStore.swift
+++ b/Sources/EdgeRumCore/Persistence/UserDefaultsSessionStore.swift
@@ -1,0 +1,87 @@
+// Sources/EdgeRumCore/Persistence/UserDefaultsSessionStore.swift
+//
+// Persists the `SessionState` triple — id, start_time, sequence,
+// last_active_at — to the UserDefaults suite
+// `com.edge.rum.session`. Replaces F3's `InMemorySessionStore` as the
+// production default for `SessionManager`.
+//
+// JSON-encoded so the on-disk format is human-readable when
+// debugging. The `SessionState` Codable conformance from
+// `SessionContext.swift` is the source of truth — this store does no
+// schema massaging of its own.
+//
+// On `load()`, if the persisted blob fails to decode (older format,
+// truncated write) we silently return `nil` so `SessionManager` will
+// generate a fresh session — preferring a clean start over crashing.
+// We log the decode failure via `os_log` so the symptom is visible in
+// debug mode.
+//
+// Refs: CLAUDE.md "Session and ID rules → Storage"; PLAN-iOS.md §F4/T4.3.
+//
+
+import Foundation
+import os.log
+
+public final class UserDefaultsSessionStore: SessionStore, @unchecked Sendable {
+
+    private let defaults: UserDefaultsStoring
+    private let key: String
+    private let log: OSLog
+
+    public init(
+        defaults: UserDefaultsStoring = UserDefaultsStore(suiteName: EdgeRumStorage.sessionSuite),
+        key: String = EdgeRumStorage.keySessionState,
+        log: OSLog = OSLog(subsystem: "com.edge.rum", category: "SessionStore")
+    ) {
+        self.defaults = defaults
+        self.key = key
+        self.log = log
+    }
+
+    public func load() -> SessionState? {
+        guard let data = defaults.data(forKey: key) else { return nil }
+        do {
+            return try Self.decoder.decode(SessionState.self, from: data)
+        } catch {
+            os_log(
+                "UserDefaultsSessionStore decode failed; starting fresh: %{public}@",
+                log: log,
+                type: .info,
+                String(describing: error)
+            )
+            defaults.removeObject(forKey: key)
+            return nil
+        }
+    }
+
+    public func save(_ state: SessionState) {
+        do {
+            let data = try Self.encoder.encode(state)
+            defaults.set(data, forKey: key)
+        } catch {
+            os_log(
+                "UserDefaultsSessionStore encode failed: %{public}@",
+                log: log,
+                type: .info,
+                String(describing: error)
+            )
+        }
+    }
+
+    // MARK: Encoder / decoder
+
+    /// ISO 8601 with fractional seconds for the two `Date` fields so
+    /// the on-disk blob round-trips identically across builds.
+    private static let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.outputFormatting = [.sortedKeys]
+        e.dateEncodingStrategy = .millisecondsSince1970
+        return e
+    }()
+
+    private static let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .millisecondsSince1970
+        return d
+    }()
+}

--- a/Sources/EdgeRumCore/Persistence/UserDefaultsStore.swift
+++ b/Sources/EdgeRumCore/Persistence/UserDefaultsStore.swift
@@ -1,0 +1,121 @@
+// Sources/EdgeRumCore/Persistence/UserDefaultsStore.swift
+//
+// Thin protocol-backed wrapper around `UserDefaults` so the
+// IdentityProvider, UserDefaultsSessionStore, and any future
+// preference reader share a single seam that tests can fake.
+//
+// Production callers use `UserDefaultsStore(suiteName:)` against
+// the shared suite name `EdgeRumStorage.sessionSuite` ("com.edge.rum.session").
+//
+// The suite is created lazily on first access; if the suite cannot be
+// created (sandboxed test environment, permissions issue), we fall
+// back to `UserDefaults.standard` so the SDK still functions. The
+// fallback is observable via `usingFallback` so the IdentityProvider
+// can emit a debug log when it kicks in.
+//
+// Refs: CLAUDE.md "Session and ID rules → Storage"; PLAN-iOS.md §F4/T4.2.
+//
+
+import Foundation
+
+public protocol UserDefaultsStoring: Sendable {
+    func string(forKey key: String) -> String?
+    func data(forKey key: String) -> Data?
+    func set(_ value: String, forKey key: String)
+    func set(_ value: Data, forKey key: String)
+    func removeObject(forKey key: String)
+}
+
+public enum EdgeRumStorage {
+    /// UserDefaults suite where session triple + user.id +
+    /// Keychain-fallback device.id live.
+    public static let sessionSuite = "com.edge.rum.session"
+
+    /// Keychain service name used for `device.id`.
+    public static let keychainService = "com.edge.rum.identity"
+
+    /// Keychain account name used for `device.id`.
+    public static let keychainAccountDeviceId = "device.id"
+
+    /// UserDefaults keys.
+    public static let keyDeviceId = "edge.rum.device.id"
+    public static let keyDeviceIdFallback = "edge.rum.device.id.fallback"
+    public static let keyUserId = "edge.rum.user.id"
+    public static let keySessionState = "edge.rum.session.state"
+}
+
+public final class UserDefaultsStore: UserDefaultsStoring, @unchecked Sendable {
+
+    private let defaults: UserDefaults
+    public let usingFallback: Bool
+
+    public init(suiteName: String) {
+        if let suite = UserDefaults(suiteName: suiteName) {
+            self.defaults = suite
+            self.usingFallback = false
+        } else {
+            self.defaults = .standard
+            self.usingFallback = true
+        }
+    }
+
+    public init(defaults: UserDefaults) {
+        self.defaults = defaults
+        self.usingFallback = false
+    }
+
+    public func string(forKey key: String) -> String? {
+        defaults.string(forKey: key)
+    }
+
+    public func data(forKey key: String) -> Data? {
+        defaults.data(forKey: key)
+    }
+
+    public func set(_ value: String, forKey key: String) {
+        defaults.set(value, forKey: key)
+    }
+
+    public func set(_ value: Data, forKey key: String) {
+        defaults.set(value, forKey: key)
+    }
+
+    public func removeObject(forKey key: String) {
+        defaults.removeObject(forKey: key)
+    }
+}
+
+/// In-memory `UserDefaultsStoring` for tests. Deterministic, no disk
+/// side-effects across test runs.
+public final class InMemoryUserDefaultsStore: UserDefaultsStoring, @unchecked Sendable {
+
+    private let lock = NSLock()
+    private var storage: [String: Any] = [:]
+
+    public init() {}
+
+    public func string(forKey key: String) -> String? {
+        lock.lock(); defer { lock.unlock() }
+        return storage[key] as? String
+    }
+
+    public func data(forKey key: String) -> Data? {
+        lock.lock(); defer { lock.unlock() }
+        return storage[key] as? Data
+    }
+
+    public func set(_ value: String, forKey key: String) {
+        lock.lock(); defer { lock.unlock() }
+        storage[key] = value
+    }
+
+    public func set(_ value: Data, forKey key: String) {
+        lock.lock(); defer { lock.unlock() }
+        storage[key] = value
+    }
+
+    public func removeObject(forKey key: String) {
+        lock.lock(); defer { lock.unlock() }
+        storage.removeValue(forKey: key)
+    }
+}

--- a/Sources/EdgeRumCore/Recorder.swift
+++ b/Sources/EdgeRumCore/Recorder.swift
@@ -93,7 +93,7 @@ public final class Recorder: Recording, @unchecked Sendable {
     private let log = OSLog(subsystem: "com.edge.rum", category: "Recorder")
 
     private let _clock: Clock
-    private let sessionManager: SessionManager
+    private var sessionManager: SessionManager
     private let transport: TransportSink
     private let payloadBuilder: PayloadBuilder
     private let context: ContextProvider
@@ -109,6 +109,11 @@ public final class Recorder: Recording, @unchecked Sendable {
     private var _buffer: [Event] = []
     private var _deviceId: String
 
+    /// Re-entrancy guard so synthetic `session.finalized` /
+    /// `session.started` emissions during a mid-event rotation don't
+    /// re-touch the session manager (which would recurse).
+    private var _insideRotationEmission: Bool = false
+
     // MARK: Init
 
     public init(
@@ -118,7 +123,9 @@ public final class Recorder: Recording, @unchecked Sendable {
         transport: TransportSink = NoopTransportSink(),
         payloadBuilder: PayloadBuilder = PayloadBuilder(),
         contextProvider: ContextProvider? = nil,
-        sdkVersion: String = "0.0.0"
+        sdkVersion: String = "0.0.0",
+        identityProvider: IdentityProvider? = nil,
+        sidecar: SessionSidecar? = nil
     ) {
         self._clock = clock
         self.queue = DispatchQueue(label: "edge.rum.recorder", qos: .utility)
@@ -127,26 +134,70 @@ public final class Recorder: Recording, @unchecked Sendable {
         self.sampler = sampler ?? Sampler(sampleRate: 1.0)
         self.transport = transport
         self.payloadBuilder = payloadBuilder
-        self._deviceId = DeviceIdentitySnapshot.newId(at: clock.now)
+        self.sidecar = sidecar
+
+        let deviceId: String
+        let userId: String
+        if let identityProvider {
+            let snapshot = identityProvider.resolve()
+            deviceId = snapshot.deviceId
+            userId = snapshot.userId
+        } else {
+            deviceId = DeviceIdentitySnapshot.newId(at: clock.now)
+            userId = UserContextSnapshot.newAnonymousId(at: clock.now)
+        }
+        self._deviceId = deviceId
 
         if let provided = contextProvider {
             self.context = provided
         } else {
             // Seed with minimal context so reads pre-configure don't
             // crash; `configure(_:)` will refresh app/device.
-            let now = clock.now
             let session = resolvedSessionManager.touch().state
-            let userId = UserContextSnapshot.newAnonymousId(at: now)
             self.context = ContextProvider(
                 app: AppContext(),
                 device: DeviceContext(),
-                deviceIdentity: DeviceIdentitySnapshot(id: self._deviceId),
+                deviceIdentity: DeviceIdentitySnapshot(id: deviceId),
                 network: NetworkContext(),
                 session: SessionContextSnapshot(session),
                 user: UserContextSnapshot(id: userId),
                 sdk: SdkContext(version: sdkVersion)
             )
         }
+    }
+
+    /// Optional sidecar that mirrors session + identity to a file the
+    /// crash backend (F14) reads on next launch. F4 ships the writer;
+    /// the reader lives in `EdgeRumCrash`.
+    private var sidecar: SessionSidecar?
+
+    /// Production wiring: swap the in-memory IdentityProvider / session
+    /// store for Keychain + UserDefaults-backed ones. Called once by
+    /// `EdgeRum.start()`. Safe to call again — recomputes the merged
+    /// identity from persisted values without rotating the session.
+    public func installPersistedStores(
+        identityProvider: IdentityProvider,
+        sessionStore: SessionStore,
+        sidecar: SessionSidecar?
+    ) {
+        let snapshot = identityProvider.resolve()
+        let revivedManager = SessionManager(
+            store: sessionStore,
+            clock: _clock
+        )
+        let session = revivedManager.touch().state
+
+        stateLock.lock()
+        self.sessionManager = revivedManager
+        self._deviceId = snapshot.deviceId
+        self.sidecar = sidecar
+        stateLock.unlock()
+
+        context.refreshDeviceIdentity(DeviceIdentitySnapshot(id: snapshot.deviceId))
+        context.refreshUser(UserContextSnapshot(id: snapshot.userId))
+        context.refreshSession(SessionContextSnapshot(session))
+
+        sidecar?.write(snapshot: context.snapshot())
     }
 
     // MARK: Recording
@@ -246,6 +297,8 @@ public final class Recorder: Recording, @unchecked Sendable {
             return
         }
 
+        bumpLastActiveAndEmitRotationIfNeeded()
+
         stateLock.lock()
         let currentSampler = self.sampler
         stateLock.unlock()
@@ -265,6 +318,7 @@ public final class Recorder: Recording, @unchecked Sendable {
     }
 
     public func recordPerformance(name: String, attributes: [String: AttributeValue]) {
+        bumpLastActiveAndEmitRotationIfNeeded()
         stateLock.lock()
         let currentSampler = self.sampler
         stateLock.unlock()
@@ -359,14 +413,87 @@ public final class Recorder: Recording, @unchecked Sendable {
         stateLock.unlock()
     }
 
+    /// Called by the transport layer after a successful (`2xx`) batch
+    /// flush. Increments `session.sequence` under the SessionManager's
+    /// lock and refreshes the context so subsequent events carry the
+    /// new sequence value.
+    ///
+    /// Acceptance #43: three consecutive ACKed batches → an event
+    /// emitted after the third ACK reads `session.sequence == 3`.
+    public func didAckBatch() {
+        sessionManager.incrementSequence()
+        if let state = sessionManager.currentState() {
+            context.refreshSession(SessionContextSnapshot(state))
+            sidecar?.write(snapshot: context.snapshot())
+        }
+    }
+
     // MARK: Internals
+
+    /// Update the session's `lastActiveAt` to "now" and, if the touch
+    /// crossed the 30-min idle threshold, emit the
+    /// `session.finalized` → `session.started` rotation pair for the
+    /// prior and new sessions respectively. Synthetic emissions go
+    /// through `recordEventInternal` which skips this hook to avoid
+    /// re-entry.
+    private func bumpLastActiveAndEmitRotationIfNeeded() {
+        stateLock.lock()
+        if _insideRotationEmission {
+            stateLock.unlock()
+            return
+        }
+        stateLock.unlock()
+
+        let prior = context.currentSession()
+        let result = sessionManager.touch()
+        guard result.rotated else { return }
+        let priorSession = prior
+        let newSnapshot = SessionContextSnapshot(result.state)
+
+        stateLock.lock()
+        _insideRotationEmission = true
+        stateLock.unlock()
+        defer {
+            stateLock.lock()
+            _insideRotationEmission = false
+            stateLock.unlock()
+        }
+
+        // The prior session's identity needs to ride with the
+        // `session.finalized` event since the context is about to
+        // refresh to the new session before the buffer's next flush.
+        var finalizedAttrs: [String: AttributeValue] = [
+            "session.id": .string(priorSession.id),
+            "session.start_time": .string(WireDateFormatter.string(from: priorSession.startTime)),
+            "session.sequence": .int(priorSession.sequence)
+        ]
+        finalizedAttrs["session.rotation"] = .string("idle")
+        recordEventInternal(name: "session.finalized", attributes: finalizedAttrs)
+
+        context.refreshSession(newSnapshot)
+
+        recordEventInternal(name: "session.started", attributes: ["session.rotation": .string("idle")])
+    }
+
+    /// Bypass-touch event emission used by the rotation hook.
+    private func recordEventInternal(name: String, attributes: [String: AttributeValue]) {
+        guard Self.allowedEventNames.contains(name) else { return }
+        let now = clock.now
+        let event = Event.event(name: name, timestamp: now, attributes: AttributeBag(attributes))
+        enqueue(event)
+        if name == "session.finalized" || name == "app.crash" {
+            flush(reason: .immediate)
+        }
+    }
 
     private func enqueue(_ event: Event) {
         stateLock.lock()
         _buffer.append(event)
         let count = _buffer.count
         let cap = _config?.batchSize ?? 30
+        let sidecar = self.sidecar
         stateLock.unlock()
+        sidecar?.write(snapshot: context.snapshot())
         if count >= cap {
             flush(reason: .batchSize)
         }

--- a/Tests/EdgeRumContractTests/IdentityPersistenceConformanceTests.swift
+++ b/Tests/EdgeRumContractTests/IdentityPersistenceConformanceTests.swift
@@ -1,0 +1,130 @@
+// Tests/EdgeRumContractTests/IdentityPersistenceConformanceTests.swift
+//
+// F4 contract test: when persistence is wired in via
+// `Recorder.installPersistedStores(...)`, every event emitted by the
+// Recorder carries `device.id` / `session.id` / `user.id` values
+// that:
+//
+//   1. match the `IdentityFormat` regex for their kind,
+//   2. match the values currently persisted in the Keychain /
+//      UserDefaults pair the IdentityProvider was constructed with,
+//      and
+//   3. round-trip through the on-disk `last-session.json` sidecar
+//      unchanged.
+//
+// This is the wire-conformance bar for F4: a host app that swaps
+// in real persistence must NOT see drift between the persisted
+// identifiers and the ones the backend receives.
+
+import XCTest
+import EdgeRumCore
+
+final class IdentityPersistenceConformanceTests: XCTestCase {
+
+    func testPersistedIdentityFlowsThroughEveryEvent() throws {
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_234_876.512))
+
+        // Pre-seed Keychain + UserDefaults with valid identifiers so
+        // we can assert the emitted attributes equal the persisted
+        // values exactly.
+        let keychain = InMemoryKeychainStore()
+        try keychain.write(
+            "device_1717100000000_aabbccddeeff0011_ios",
+            service: EdgeRumStorage.keychainService,
+            account: EdgeRumStorage.keychainAccountDeviceId
+        )
+        let defaults = InMemoryUserDefaultsStore()
+        defaults.set(
+            "user_1717100000000_2233445566778899",
+            forKey: EdgeRumStorage.keyUserId
+        )
+
+        let sidecarURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("edge-rum-contract-\(UUID().uuidString)")
+            .appendingPathComponent("last-session.json")
+        defer { try? FileManager.default.removeItem(at: sidecarURL.deletingLastPathComponent()) }
+        let sidecar = SessionSidecar(url: sidecarURL)
+
+        let sink = RecordingTransportSink()
+        let recorder = Recorder(
+            clock: clock,
+            sampler: Sampler(sampleRate: 1.0, entropy: { 0.0 }),
+            transport: sink,
+            sdkVersion: "1.0.0"
+        )
+        recorder.configure(RecorderConfig(
+            apiKey: "edge_test_abc",
+            endpoint: URL(string: "https://collect.example.com")!,
+            location: "Nairobi/Kenya"
+        ))
+        recorder.installPersistedStores(
+            identityProvider: IdentityProvider(
+                keychain: keychain,
+                defaults: defaults,
+                clock: clock
+            ),
+            sessionStore: UserDefaultsSessionStore(defaults: defaults),
+            sidecar: sidecar
+        )
+
+        // Emit a mix of events.
+        recorder.recordEvent(name: "navigation", attributes: ["navigation.kind": "uikit"])
+        recorder.recordPerformance(name: "memory_usage", attributes: ["value": 42.0])
+        recorder.recordEvent(name: "custom_event", attributes: [
+            "event.name": "checkout_started"
+        ])
+        recorder.flush(reason: .manual)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+
+        for (idx, event) in events.enumerated() {
+            let attrs = try XCTUnwrap(
+                event["attributes"] as? [String: Any],
+                "event \(idx) missing attributes"
+            )
+
+            try WireAssertions.assertIdentityAttributes(attrs)
+
+            // Persisted-value pinning.
+            XCTAssertEqual(
+                attrs["device.id"] as? String,
+                "device_1717100000000_aabbccddeeff0011_ios",
+                "event \(idx) device.id must equal the persisted Keychain value"
+            )
+            XCTAssertEqual(
+                attrs["user.id"] as? String,
+                "user_1717100000000_2233445566778899",
+                "event \(idx) user.id must equal the persisted UserDefaults value"
+            )
+
+            // Format regex pinning.
+            let deviceId = attrs["device.id"] as? String ?? ""
+            let sessionId = attrs["session.id"] as? String ?? ""
+            let userId = attrs["user.id"] as? String ?? ""
+            XCTAssertTrue(IdentityFormat.isValid(deviceId, kind: .device),
+                          "event \(idx) device.id format invalid: \(deviceId)")
+            XCTAssertTrue(IdentityFormat.isValid(sessionId, kind: .session),
+                          "event \(idx) session.id format invalid: \(sessionId)")
+            XCTAssertTrue(IdentityFormat.isValid(userId, kind: .user),
+                          "event \(idx) user.id format invalid: \(userId)")
+        }
+
+        // Sidecar round-trip — the file on disk holds the same identity.
+        let mirrored = try XCTUnwrap(sidecar.read())
+        let firstAttrs = try XCTUnwrap(events.first?["attributes"] as? [String: Any])
+        XCTAssertEqual(
+            mirrored["device.id"],
+            .string(firstAttrs["device.id"] as? String ?? "")
+        )
+        XCTAssertEqual(
+            mirrored["session.id"],
+            .string(firstAttrs["session.id"] as? String ?? "")
+        )
+        XCTAssertEqual(
+            mirrored["user.id"],
+            .string(firstAttrs["user.id"] as? String ?? "")
+        )
+    }
+}

--- a/Tests/EdgeRumTests/Persistence/IdentityFormatTests.swift
+++ b/Tests/EdgeRumTests/Persistence/IdentityFormatTests.swift
@@ -1,0 +1,124 @@
+// Tests/EdgeRumTests/Persistence/IdentityFormatTests.swift
+//
+// T4.1 acceptance: regex holds across 10k generated samples per id
+// kind. Plus targeted negative cases for the malformations we expect
+// to see when a persisted id has been corrupted or written by an older
+// build.
+
+import XCTest
+@testable import EdgeRumCore
+
+final class IdentityFormatTests: XCTestCase {
+
+    // MARK: 10k positive cases (issue #41 acceptance)
+
+    func testDeviceIdGeneratorMatchesRegexAcross10kSamples() {
+        for _ in 0..<10_000 {
+            let id = DeviceIdentitySnapshot.newId()
+            XCTAssertTrue(
+                IdentityFormat.isValid(id, kind: .device),
+                "\(id) did not match device regex"
+            )
+        }
+    }
+
+    func testSessionIdGeneratorMatchesRegexAcross10kSamples() {
+        let manager = SessionManager()
+        for _ in 0..<10_000 {
+            let state = manager.rotate()
+            XCTAssertTrue(
+                IdentityFormat.isValid(state.id, kind: .session),
+                "\(state.id) did not match session regex"
+            )
+        }
+    }
+
+    func testUserIdGeneratorMatchesRegexAcross10kSamples() {
+        for _ in 0..<10_000 {
+            let id = UserContextSnapshot.newAnonymousId()
+            XCTAssertTrue(
+                IdentityFormat.isValid(id, kind: .user),
+                "\(id) did not match user regex"
+            )
+        }
+    }
+
+    // MARK: Negative cases
+
+    func testRejectsEmptyString() {
+        XCTAssertFalse(IdentityFormat.isValid("", kind: .device))
+        XCTAssertFalse(IdentityFormat.isValid("", kind: .session))
+        XCTAssertFalse(IdentityFormat.isValid("", kind: .user))
+    }
+
+    func testRejectsWrongPrefix() {
+        XCTAssertFalse(IdentityFormat.isValid("session_1_aaaaaaaaaaaaaaaa_ios", kind: .device))
+        XCTAssertFalse(IdentityFormat.isValid("device_1_aaaaaaaaaaaaaaaa_ios", kind: .session))
+        XCTAssertFalse(IdentityFormat.isValid("device_1_aaaaaaaaaaaaaaaa_ios", kind: .user))
+    }
+
+    func testRejectsMissingIosSuffixOnDeviceAndSession() {
+        XCTAssertFalse(IdentityFormat.isValid("device_1_aaaaaaaaaaaaaaaa", kind: .device))
+        XCTAssertFalse(IdentityFormat.isValid("session_1_aaaaaaaaaaaaaaaa", kind: .session))
+    }
+
+    func testRejectsIosSuffixOnUser() {
+        XCTAssertFalse(IdentityFormat.isValid("user_1_aaaaaaaaaaaaaaaa_ios", kind: .user))
+    }
+
+    func testRejectsNonHexCharactersInRandomSegment() {
+        XCTAssertFalse(IdentityFormat.isValid("device_1_zzzzzzzzzzzzzzzz_ios", kind: .device))
+        XCTAssertFalse(IdentityFormat.isValid("device_1_AAAAAAAAAAAAAAAA_ios", kind: .device))
+    }
+
+    func testRejectsWrongHexLength() {
+        XCTAssertFalse(IdentityFormat.isValid("device_1_aaaa_ios", kind: .device))
+        XCTAssertFalse(IdentityFormat.isValid("device_1_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_ios", kind: .device))
+    }
+
+    func testRejectsNonNumericEpoch() {
+        XCTAssertFalse(IdentityFormat.isValid("device_abc_aaaaaaaaaaaaaaaa_ios", kind: .device))
+        XCTAssertFalse(IdentityFormat.isValid("session_abc_aaaaaaaaaaaaaaaa_ios", kind: .session))
+        XCTAssertFalse(IdentityFormat.isValid("user_abc_aaaaaaaaaaaaaaaa", kind: .user))
+    }
+
+    func testRejectsUUIDStyleHex() {
+        XCTAssertFalse(IdentityFormat.isValid(
+            "device_1717234876123_a1b2c3d4e5f607189abcdef012345678_ios",
+            kind: .device
+        ))
+    }
+
+    // MARK: validate(_:kind:) convenience returns nil on mismatch
+
+    func testValidateReturnsValueWhenValid() {
+        let id = "device_1717234876123_a1b2c3d4e5f60718_ios"
+        XCTAssertEqual(IdentityFormat.validate(id, kind: .device), id)
+    }
+
+    func testValidateReturnsNilWhenInvalid() {
+        XCTAssertNil(IdentityFormat.validate("garbage", kind: .device))
+        XCTAssertNil(IdentityFormat.validate("garbage", kind: .session))
+        XCTAssertNil(IdentityFormat.validate("garbage", kind: .user))
+    }
+
+    // MARK: Cross-kind isolation
+
+    func testKindsAreMutuallyExclusive() {
+        let device = "device_1_aaaaaaaaaaaaaaaa_ios"
+        let session = "session_1_aaaaaaaaaaaaaaaa_ios"
+        let user = "user_1_aaaaaaaaaaaaaaaa"
+
+        XCTAssertTrue(IdentityFormat.isValid(device, kind: .device))
+        XCTAssertFalse(IdentityFormat.isValid(device, kind: .session))
+        XCTAssertFalse(IdentityFormat.isValid(device, kind: .user))
+
+        XCTAssertTrue(IdentityFormat.isValid(session, kind: .session))
+        XCTAssertFalse(IdentityFormat.isValid(session, kind: .device))
+        XCTAssertFalse(IdentityFormat.isValid(session, kind: .user))
+
+        XCTAssertTrue(IdentityFormat.isValid(user, kind: .user))
+        XCTAssertFalse(IdentityFormat.isValid(user, kind: .device))
+        XCTAssertFalse(IdentityFormat.isValid(user, kind: .session))
+    }
+}

--- a/Tests/EdgeRumTests/Persistence/IdentityProviderTests.swift
+++ b/Tests/EdgeRumTests/Persistence/IdentityProviderTests.swift
@@ -1,0 +1,233 @@
+// Tests/EdgeRumTests/Persistence/IdentityProviderTests.swift
+//
+// Covers issue #42 (T4.2) acceptance: reinstalling the host app on
+// the simulator regenerates `device.id`. We simulate that by clearing
+// the Keychain row and re-resolving — the new id must differ and
+// must match the device regex.
+
+import XCTest
+@testable import EdgeRumCore
+
+final class IdentityProviderTests: XCTestCase {
+
+    // MARK: Helpers
+
+    private func makeProvider(
+        keychain: KeychainStoring? = nil,
+        defaults: UserDefaultsStoring? = nil,
+        clock: Clock? = nil,
+        randomBytes: (() -> Data)? = nil
+    ) -> (IdentityProvider, InMemoryKeychainStore, InMemoryUserDefaultsStore, FixedClock) {
+        let kc = (keychain as? InMemoryKeychainStore) ?? InMemoryKeychainStore()
+        let ud = (defaults as? InMemoryUserDefaultsStore) ?? InMemoryUserDefaultsStore()
+        let fc = (clock as? FixedClock) ?? FixedClock(Date(timeIntervalSince1970: 1_717_234_876.123))
+        let rb = randomBytes ?? { Data([0xa1, 0xb2, 0xc3, 0xd4, 0xe5, 0xf6, 0x07, 0x18]) }
+        let provider = IdentityProvider(
+            keychain: kc,
+            defaults: ud,
+            clock: fc,
+            randomBytes: rb
+        )
+        return (provider, kc, ud, fc)
+    }
+
+    // MARK: Generation
+
+    func testFirstResolveGeneratesAndPersistsBothIds() throws {
+        let (provider, keychain, defaults, _) = makeProvider()
+        let snapshot = provider.resolve()
+
+        XCTAssertTrue(IdentityFormat.isValid(snapshot.deviceId, kind: .device))
+        XCTAssertTrue(IdentityFormat.isValid(snapshot.userId, kind: .user))
+        XCTAssertFalse(snapshot.deviceIdFromFallback)
+
+        // Persisted to the right slots.
+        let persistedDevice = try keychain.read(
+            service: EdgeRumStorage.keychainService,
+            account: EdgeRumStorage.keychainAccountDeviceId
+        )
+        XCTAssertEqual(persistedDevice, snapshot.deviceId)
+        XCTAssertEqual(defaults.string(forKey: EdgeRumStorage.keyUserId), snapshot.userId)
+        XCTAssertNil(defaults.string(forKey: EdgeRumStorage.keyDeviceIdFallback))
+    }
+
+    func testResolveIsIdempotent() {
+        let (provider, _, _, _) = makeProvider()
+        let first = provider.resolve()
+        let second = provider.resolve()
+        XCTAssertEqual(first.deviceId, second.deviceId)
+        XCTAssertEqual(first.userId, second.userId)
+    }
+
+    // MARK: Reinstall — Keychain cleared
+
+    func testClearingKeychainRegeneratesDeviceId() throws {
+        let (provider, keychain, _, _) = makeProvider()
+        let original = provider.resolve().deviceId
+
+        // Simulate uninstall + reinstall — Keychain row cleared by
+        // iOS on most modern installs. UserDefaults survives, so
+        // user.id should persist; only device.id should rotate.
+        try keychain.delete(
+            service: EdgeRumStorage.keychainService,
+            account: EdgeRumStorage.keychainAccountDeviceId
+        )
+
+        // Use a new provider with a different random seed so the new
+        // id is observably different from the old one.
+        let differentRandom: () -> Data = {
+            Data([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88])
+        }
+        let fresh = IdentityProvider(
+            keychain: keychain,
+            defaults: InMemoryUserDefaultsStore(),
+            clock: FixedClock(Date(timeIntervalSince1970: 1_717_234_999.000)),
+            randomBytes: differentRandom
+        )
+        let regenerated = fresh.resolve().deviceId
+
+        XCTAssertNotEqual(regenerated, original)
+        XCTAssertTrue(IdentityFormat.isValid(regenerated, kind: .device))
+    }
+
+    // MARK: Keychain failure → UserDefaults fallback
+
+    func testKeychainFailureFallsBackToUserDefaults() {
+        let failingKeychain = InMemoryKeychainStore(failure: .unexpectedStatus(-25300))
+        let defaults = InMemoryUserDefaultsStore()
+        let provider = IdentityProvider(
+            keychain: failingKeychain,
+            defaults: defaults,
+            clock: FixedClock(Date(timeIntervalSince1970: 1_717_234_876.123)),
+            randomBytes: { Data([0xa1, 0xb2, 0xc3, 0xd4, 0xe5, 0xf6, 0x07, 0x18]) }
+        )
+
+        let snapshot = provider.resolve()
+        XCTAssertTrue(snapshot.deviceIdFromFallback)
+        XCTAssertEqual(
+            defaults.string(forKey: EdgeRumStorage.keyDeviceIdFallback),
+            snapshot.deviceId
+        )
+    }
+
+    func testFallbackPersistsAcrossResolves() {
+        let failingKeychain = InMemoryKeychainStore(failure: .unexpectedStatus(-25300))
+        let defaults = InMemoryUserDefaultsStore()
+        let provider = IdentityProvider(
+            keychain: failingKeychain,
+            defaults: defaults
+        )
+
+        let first = provider.resolve()
+        let second = provider.resolve()
+        XCTAssertEqual(first.deviceId, second.deviceId)
+        XCTAssertTrue(second.deviceIdFromFallback)
+    }
+
+    // MARK: Malformed persisted values regenerate
+
+    func testMalformedDeviceIdInKeychainTriggersRegeneration() throws {
+        let keychain = InMemoryKeychainStore()
+        try keychain.write(
+            "device_NOT_AN_EPOCH_aaaaaaaaaaaaaaaa_ios",
+            service: EdgeRumStorage.keychainService,
+            account: EdgeRumStorage.keychainAccountDeviceId
+        )
+        let provider = IdentityProvider(
+            keychain: keychain,
+            defaults: InMemoryUserDefaultsStore()
+        )
+        let snapshot = provider.resolve()
+        XCTAssertTrue(IdentityFormat.isValid(snapshot.deviceId, kind: .device))
+        XCTAssertNotEqual(snapshot.deviceId, "device_NOT_AN_EPOCH_aaaaaaaaaaaaaaaa_ios")
+
+        // The Keychain slot should now hold the new value too.
+        let persisted = try keychain.read(
+            service: EdgeRumStorage.keychainService,
+            account: EdgeRumStorage.keychainAccountDeviceId
+        )
+        XCTAssertEqual(persisted, snapshot.deviceId)
+    }
+
+    func testMalformedUserIdInDefaultsTriggersRegeneration() {
+        let defaults = InMemoryUserDefaultsStore()
+        defaults.set("user_NOT_VALID", forKey: EdgeRumStorage.keyUserId)
+        let provider = IdentityProvider(
+            keychain: InMemoryKeychainStore(),
+            defaults: defaults
+        )
+        let snapshot = provider.resolve()
+        XCTAssertTrue(IdentityFormat.isValid(snapshot.userId, kind: .user))
+        XCTAssertNotEqual(snapshot.userId, "user_NOT_VALID")
+        XCTAssertEqual(defaults.string(forKey: EdgeRumStorage.keyUserId), snapshot.userId)
+    }
+
+    func testFallbackClearsWhenKeychainStartsWorking() throws {
+        // Start with fallback in place.
+        let failing = InMemoryKeychainStore(failure: .unexpectedStatus(-25300))
+        let defaults = InMemoryUserDefaultsStore()
+        let provider = IdentityProvider(keychain: failing, defaults: defaults)
+        _ = provider.resolve()
+        XCTAssertNotNil(defaults.string(forKey: EdgeRumStorage.keyDeviceIdFallback))
+
+        // Switch to a working keychain by recovering the in-memory one.
+        failing.failure = nil
+        let recovered = IdentityProvider(keychain: failing, defaults: defaults)
+        let snapshot = recovered.regenerateDeviceId()
+        XCTAssertTrue(IdentityFormat.isValid(snapshot, kind: .device))
+        XCTAssertNil(defaults.string(forKey: EdgeRumStorage.keyDeviceIdFallback))
+    }
+
+    // MARK: Explicit regenerate hooks
+
+    func testRegenerateDeviceIdReplacesPersistedValue() throws {
+        let keychain = InMemoryKeychainStore()
+        let defaults = InMemoryUserDefaultsStore()
+        let counter = CountingRandomBytes()
+        let provider = IdentityProvider(
+            keychain: keychain,
+            defaults: defaults,
+            clock: FixedClock(Date(timeIntervalSince1970: 1_717_234_876.123)),
+            randomBytes: counter.next
+        )
+        let first = provider.resolve().deviceId
+        let regenerated = provider.regenerateDeviceId()
+        XCTAssertNotEqual(first, regenerated)
+        let persisted = try keychain.read(
+            service: EdgeRumStorage.keychainService,
+            account: EdgeRumStorage.keychainAccountDeviceId
+        )
+        XCTAssertEqual(persisted, regenerated)
+    }
+
+    func testRegenerateUserIdReplacesPersistedValue() {
+        let keychain = InMemoryKeychainStore()
+        let defaults = InMemoryUserDefaultsStore()
+        let counter = CountingRandomBytes()
+        let provider = IdentityProvider(
+            keychain: keychain,
+            defaults: defaults,
+            clock: FixedClock(Date(timeIntervalSince1970: 1_717_234_876.123)),
+            randomBytes: counter.next
+        )
+        let first = provider.resolve().userId
+        let regenerated = provider.regenerateUserId()
+        XCTAssertNotEqual(first, regenerated)
+        XCTAssertEqual(defaults.string(forKey: EdgeRumStorage.keyUserId), regenerated)
+    }
+}
+
+/// Deterministic counter-incrementing random bytes — produces a
+/// different 8-byte sequence on each call so the byte→hex segment of
+/// generated IDs is observably different across calls.
+final class CountingRandomBytes: @unchecked Sendable {
+    private let lock = NSLock()
+    private var counter: UInt64 = 0
+
+    func next() -> Data {
+        lock.lock(); defer { lock.unlock() }
+        counter &+= 1
+        var value = counter.bigEndian
+        return withUnsafeBytes(of: &value) { Data($0) }
+    }
+}

--- a/Tests/EdgeRumTests/Persistence/KeychainStoreTests.swift
+++ b/Tests/EdgeRumTests/Persistence/KeychainStoreTests.swift
@@ -1,0 +1,93 @@
+// Tests/EdgeRumTests/Persistence/KeychainStoreTests.swift
+//
+// Verifies the in-memory fake (used widely by the IdentityProvider
+// tests) AND smoke-tests the real `KeychainStore` against the
+// simulator keychain. The simulator path is gated on availability —
+// `swift test` on the macOS host can technically hit the real keychain
+// but values may leak across runs, so we use a unique service per
+// test and clean up in tearDown.
+
+import XCTest
+@testable import EdgeRumCore
+
+final class InMemoryKeychainStoreTests: XCTestCase {
+
+    func testReadReturnsNilForMissingKey() throws {
+        let store = InMemoryKeychainStore()
+        let value = try store.read(service: "svc", account: "acct")
+        XCTAssertNil(value)
+    }
+
+    func testWriteThenReadRoundTrips() throws {
+        let store = InMemoryKeychainStore()
+        try store.write("hello", service: "svc", account: "acct")
+        XCTAssertEqual(try store.read(service: "svc", account: "acct"), "hello")
+    }
+
+    func testWriteReplacesExistingValue() throws {
+        let store = InMemoryKeychainStore()
+        try store.write("first", service: "svc", account: "acct")
+        try store.write("second", service: "svc", account: "acct")
+        XCTAssertEqual(try store.read(service: "svc", account: "acct"), "second")
+    }
+
+    func testDeleteRemovesValue() throws {
+        let store = InMemoryKeychainStore()
+        try store.write("hello", service: "svc", account: "acct")
+        try store.delete(service: "svc", account: "acct")
+        XCTAssertNil(try store.read(service: "svc", account: "acct"))
+    }
+
+    func testDeleteOnMissingKeyIsNoOp() throws {
+        let store = InMemoryKeychainStore()
+        XCTAssertNoThrow(try store.delete(service: "svc", account: "acct"))
+    }
+
+    func testServiceAndAccountAreIsolated() throws {
+        let store = InMemoryKeychainStore()
+        try store.write("a", service: "svc1", account: "acct")
+        try store.write("b", service: "svc2", account: "acct")
+        try store.write("c", service: "svc1", account: "other")
+
+        XCTAssertEqual(try store.read(service: "svc1", account: "acct"), "a")
+        XCTAssertEqual(try store.read(service: "svc2", account: "acct"), "b")
+        XCTAssertEqual(try store.read(service: "svc1", account: "other"), "c")
+    }
+
+    func testFailureInjectionThrowsOnAllOperations() {
+        let store = InMemoryKeychainStore(failure: .unexpectedStatus(-25300))
+        XCTAssertThrowsError(try store.read(service: "svc", account: "acct"))
+        XCTAssertThrowsError(try store.write("x", service: "svc", account: "acct"))
+        XCTAssertThrowsError(try store.delete(service: "svc", account: "acct"))
+    }
+}
+
+#if os(iOS)
+/// Smoke tests against the real keychain. Only run on iOS — macOS
+/// SwiftPM test runs would need an explicit entitlement to use the
+/// generic password class predictably.
+final class RealKeychainStoreTests: XCTestCase {
+
+    private let service = "com.edge.rum.tests.keychain.\(UUID().uuidString)"
+    private let account = "test"
+
+    override func tearDownWithError() throws {
+        try KeychainStore().delete(service: service, account: account)
+    }
+
+    func testWriteThenReadRoundTripsAgainstRealKeychain() throws {
+        let store = KeychainStore()
+        try store.write("device_1717234876123_a1b2c3d4e5f60718_ios",
+                        service: service, account: account)
+        let read = try store.read(service: service, account: account)
+        XCTAssertEqual(read, "device_1717234876123_a1b2c3d4e5f60718_ios")
+    }
+
+    func testDeleteRemovesValue() throws {
+        let store = KeychainStore()
+        try store.write("payload", service: service, account: account)
+        try store.delete(service: service, account: account)
+        XCTAssertNil(try store.read(service: service, account: account))
+    }
+}
+#endif

--- a/Tests/EdgeRumTests/Persistence/SessionRotationOnRecordEventTests.swift
+++ b/Tests/EdgeRumTests/Persistence/SessionRotationOnRecordEventTests.swift
@@ -1,0 +1,256 @@
+// Tests/EdgeRumTests/Persistence/SessionRotationOnRecordEventTests.swift
+//
+// Covers the F4 addition to `Recorder.recordEvent` /
+// `Recorder.recordPerformance`: each ingress bumps the SessionManager's
+// last-active timestamp. When the bump crosses the 30-min idle
+// threshold, the Recorder emits a `session.finalized` (with the prior
+// session id) + `session.started` (with the new one) pair before
+// processing the originating event.
+//
+// Also covers `didAckBatch()` — issue #43 acceptance:
+// three consecutive ACKed batches → an event emitted after the third
+// ACK reads `session.sequence == 3`.
+
+import XCTest
+@testable import EdgeRum
+import EdgeRumCore
+
+final class SessionRotationOnRecordEventTests: XCTestCase {
+
+    // MARK: Helpers
+
+    private func makeRecorder(
+        clock: FixedClock,
+        sessionStore: SessionStore = InMemorySessionStore(),
+        randomBytes: @escaping () -> Data = { Data([0xa1, 0xb2, 0xc3, 0xd4, 0xe5, 0xf6, 0x07, 0x18]) }
+    ) -> (Recorder, RecordingTransportSink, SessionManager) {
+        let sink = RecordingTransportSink()
+        let manager = SessionManager(
+            store: sessionStore,
+            clock: clock,
+            randomBytes: randomBytes
+        )
+        let recorder = Recorder(
+            clock: clock,
+            sessionManager: manager,
+            sampler: Sampler(sampleRate: 1.0, entropy: { 0.0 }),
+            transport: sink,
+            sdkVersion: "1.0.0"
+        )
+        recorder.configure(RecorderConfig(
+            apiKey: "edge_test_abc",
+            endpoint: URL(string: "https://collect.example.com")!,
+            debug: false,
+            sampleRate: 1.0,
+            batchSize: 100,
+            flushInterval: 5.0,
+            location: nil
+        ))
+        return (recorder, sink, manager)
+    }
+
+    // MARK: last-active bump
+
+    func testRecordEventBumpsLastActiveOnSessionManager() {
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_234_876.000))
+        let (recorder, _, manager) = makeRecorder(clock: clock)
+        let beforeId = manager.currentState()?.id
+
+        clock.advance(by: 60)
+        recorder.recordEvent(name: "navigation", attributes: [:])
+
+        let after = manager.currentState()
+        XCTAssertEqual(after?.id, beforeId, "60s bump must not rotate")
+        XCTAssertEqual(after?.lastActiveAt, clock.now)
+    }
+
+    func testRecordPerformanceBumpsLastActiveOnSessionManager() {
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_234_876.000))
+        let (recorder, _, manager) = makeRecorder(clock: clock)
+
+        clock.advance(by: 60)
+        recorder.recordPerformance(name: "memory_usage", attributes: [:])
+
+        XCTAssertEqual(manager.currentState()?.lastActiveAt, clock.now)
+    }
+
+    // MARK: Mid-event rotation
+
+    func testRecordEventAcrossIdleThresholdEmitsFinalizedThenStarted() {
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_234_876.000))
+        // Counter random bytes so the rotated session id differs from
+        // the original.
+        let counter = SeqRandom()
+        let (recorder, sink, _) = makeRecorder(
+            clock: clock,
+            randomBytes: counter.next
+        )
+        // Capture the original session id from the first emitted event.
+        recorder.recordEvent(name: "navigation", attributes: [:])
+        recorder.flush(reason: .manual)
+        let originalSession = sink.envelopes.last?.events.first?.attributes["session.id"]
+        XCTAssertNotNil(originalSession)
+
+        sink.reset()
+
+        // Cross the 30-min threshold.
+        clock.advance(by: SessionManager.idleRotationInterval + 1)
+
+        recorder.recordEvent(name: "navigation", attributes: [:])
+        recorder.flush(reason: .manual)
+
+        // Order: finalized (immediate-flush) → started → navigation.
+        // The first envelope (finalized) is flushed immediately on
+        // emit; the started + navigation pair flushes on the manual
+        // flush below.
+        let allEvents = sink.envelopes.flatMap { $0.events }
+        let names = allEvents.map(\.name)
+        XCTAssertEqual(
+            names.firstIndex(of: "session.finalized") ?? .max,
+            0,
+            "session.finalized must come first"
+        )
+        XCTAssertNotNil(names.firstIndex(of: "session.started"))
+        XCTAssertNotNil(names.firstIndex(of: "navigation"))
+
+        // The finalized event carries the prior session id (not the
+        // rotated one) per the F4 mid-event rotation contract.
+        if let finalized = allEvents.first(where: { $0.name == "session.finalized" }) {
+            XCTAssertEqual(finalized.attributes["session.id"], originalSession)
+            XCTAssertEqual(finalized.attributes["session.rotation"], .string("idle"))
+        }
+    }
+
+    // MARK: didAckBatch — issue #43 acceptance
+
+    func testThreeAcksYieldSequenceThree() {
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_234_876.000))
+        let (recorder, sink, _) = makeRecorder(clock: clock)
+
+        recorder.didAckBatch()
+        recorder.didAckBatch()
+        recorder.didAckBatch()
+
+        recorder.recordEvent(name: "navigation", attributes: [:])
+        recorder.flush(reason: .manual)
+
+        let event = sink.envelopes.last?.events.first
+        XCTAssertEqual(event?.attributes["session.sequence"], .int(3))
+    }
+
+    func testDidAckBatchUpdatesSidecarSnapshot() throws {
+        let url = makeTempSidecarURL()
+        defer { try? FileManager.default.removeItem(at: url) }
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_234_876.000))
+        let sidecar = SessionSidecar(url: url)
+        let sink = RecordingTransportSink()
+        let recorder = Recorder(
+            clock: clock,
+            sessionManager: SessionManager(clock: clock),
+            sampler: Sampler(sampleRate: 1.0, entropy: { 0.0 }),
+            transport: sink,
+            sdkVersion: "1.0.0",
+            sidecar: sidecar
+        )
+        recorder.configure(RecorderConfig(
+            apiKey: "edge_test_abc",
+            endpoint: URL(string: "https://collect.example.com")!
+        ))
+
+        // Force an enqueue so the sidecar has something to mirror.
+        recorder.recordEvent(name: "navigation", attributes: [:])
+        recorder.didAckBatch()
+
+        let mirrored = sidecar.read()
+        XCTAssertEqual(mirrored?["session.sequence"], .int(1))
+    }
+
+    // MARK: installPersistedStores
+
+    func testInstallPersistedStoresPullsDeviceAndUserFromIdentityProvider() {
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_234_876.000))
+        let (recorder, sink, _) = makeRecorder(clock: clock)
+
+        let kc = InMemoryKeychainStore()
+        try? kc.write(
+            "device_1717100000000_aaaaaaaaaaaaaaaa_ios",
+            service: EdgeRumStorage.keychainService,
+            account: EdgeRumStorage.keychainAccountDeviceId
+        )
+        let defaults = InMemoryUserDefaultsStore()
+        defaults.set("user_1717100000000_bbbbbbbbbbbbbbbb", forKey: EdgeRumStorage.keyUserId)
+        let identityProvider = IdentityProvider(
+            keychain: kc,
+            defaults: defaults,
+            clock: clock
+        )
+        let sessionStore = UserDefaultsSessionStore(defaults: defaults)
+
+        recorder.installPersistedStores(
+            identityProvider: identityProvider,
+            sessionStore: sessionStore,
+            sidecar: nil
+        )
+
+        recorder.recordEvent(name: "navigation", attributes: [:])
+        recorder.flush(reason: .manual)
+
+        let event = sink.envelopes.last?.events.first
+        XCTAssertEqual(event?.attributes["device.id"], .string("device_1717100000000_aaaaaaaaaaaaaaaa_ios"))
+        XCTAssertEqual(event?.attributes["user.id"], .string("user_1717100000000_bbbbbbbbbbbbbbbb"))
+    }
+
+    func testInstallPersistedStoresPreservesPersistedSessionWithinIdleWindow() {
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_234_876.000))
+        let defaults = InMemoryUserDefaultsStore()
+        let priorState = SessionState(
+            id: "session_1717234870000_cccccccccccccccc_ios",
+            startTime: Date(timeIntervalSince1970: 1_717_234_870.0),
+            sequence: 5,
+            lastActiveAt: Date(timeIntervalSince1970: 1_717_234_870.0)
+        )
+        UserDefaultsSessionStore(defaults: defaults).save(priorState)
+
+        let (recorder, sink, _) = makeRecorder(clock: clock)
+
+        recorder.installPersistedStores(
+            identityProvider: IdentityProvider(
+                keychain: InMemoryKeychainStore(),
+                defaults: defaults,
+                clock: clock
+            ),
+            sessionStore: UserDefaultsSessionStore(defaults: defaults),
+            sidecar: nil
+        )
+
+        recorder.recordEvent(name: "navigation", attributes: [:])
+        recorder.flush(reason: .manual)
+
+        let event = sink.envelopes.last?.events.first
+        XCTAssertEqual(
+            event?.attributes["session.id"],
+            .string("session_1717234870000_cccccccccccccccc_ios"),
+            "Persisted session within idle window must be reused"
+        )
+        XCTAssertEqual(event?.attributes["session.sequence"], .int(5))
+    }
+
+    // MARK: Helpers
+
+    private func makeTempSidecarURL() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("edge-rum-tests-\(UUID().uuidString)", isDirectory: true)
+        return dir.appendingPathComponent("last-session.json")
+    }
+}
+
+private final class SeqRandom: @unchecked Sendable {
+    private let lock = NSLock()
+    private var counter: UInt64 = 0
+    func next() -> Data {
+        lock.lock(); defer { lock.unlock() }
+        counter &+= 1
+        var v = counter.bigEndian
+        return withUnsafeBytes(of: &v) { Data($0) }
+    }
+}

--- a/Tests/EdgeRumTests/Persistence/SessionSidecarTests.swift
+++ b/Tests/EdgeRumTests/Persistence/SessionSidecarTests.swift
@@ -1,0 +1,131 @@
+// Tests/EdgeRumTests/Persistence/SessionSidecarTests.swift
+//
+// Issue #44 (writer half): verify the JSON on disk matches the
+// snapshot the Recorder just emitted, and that each subsequent write
+// overwrites the previous one atomically.
+
+import XCTest
+@testable import EdgeRumCore
+
+final class SessionSidecarTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("edge-rum-sidecar-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    override func tearDownWithError() throws {
+        if FileManager.default.fileExists(atPath: tempDir.path) {
+            try FileManager.default.removeItem(at: tempDir)
+        }
+    }
+
+    private func makeSidecar() -> SessionSidecar {
+        SessionSidecar(url: tempDir.appendingPathComponent("last-session.json"))
+    }
+
+    // MARK: Mirror behaviour
+
+    func testWritesOnlyMirroredKeys() throws {
+        let sidecar = makeSidecar()
+        var bag = AttributeBag()
+        bag.set("session.id", .string("session_1_aaaaaaaaaaaaaaaa_ios"))
+        bag.set("session.start_time", .string("2026-06-14T10:30:00.000Z"))
+        bag.set("session.sequence", .int(7))
+        bag.set("user.id", .string("user_1_bbbbbbbbbbbbbbbb"))
+        bag.set("device.id", .string("device_1_cccccccccccccccc_ios"))
+        bag.set("sdk.version", .string("1.0.0"))
+        bag.set("sdk.platform", .string("ios-native"))
+
+        // Transient keys that must NOT be mirrored.
+        bag.set("device.batteryLevel", .double(0.82))
+        bag.set("network.type", .string("wifi"))
+        bag.set("app.name", .string("Shop"))
+
+        sidecar.write(snapshot: bag)
+
+        let read = sidecar.read()
+        XCTAssertNotNil(read)
+        XCTAssertEqual(read?["session.id"], .string("session_1_aaaaaaaaaaaaaaaa_ios"))
+        XCTAssertEqual(read?["session.start_time"], .string("2026-06-14T10:30:00.000Z"))
+        XCTAssertEqual(read?["session.sequence"], .int(7))
+        XCTAssertEqual(read?["user.id"], .string("user_1_bbbbbbbbbbbbbbbb"))
+        XCTAssertEqual(read?["device.id"], .string("device_1_cccccccccccccccc_ios"))
+
+        XCTAssertNil(read?["device.batteryLevel"])
+        XCTAssertNil(read?["network.type"])
+        XCTAssertNil(read?["app.name"])
+    }
+
+    func testWritesOptionalUserFieldsWhenPresent() {
+        let sidecar = makeSidecar()
+        var bag = AttributeBag()
+        bag.set("session.id", .string("session_1_aaaaaaaaaaaaaaaa_ios"))
+        bag.set("user.id", .string("user_1_bbbbbbbbbbbbbbbb"))
+        bag.set("user.email", .string("a@b.com"))
+        sidecar.write(snapshot: bag)
+
+        let read = sidecar.read()
+        XCTAssertEqual(read?["user.email"], .string("a@b.com"))
+    }
+
+    // MARK: Overwrite semantics
+
+    func testSecondWriteReplacesPreviousFile() throws {
+        let sidecar = makeSidecar()
+        var first = AttributeBag()
+        first.set("session.id", .string("session_1_aaaaaaaaaaaaaaaa_ios"))
+        first.set("session.sequence", .int(1))
+        sidecar.write(snapshot: first)
+
+        var second = AttributeBag()
+        second.set("session.id", .string("session_2_dddddddddddddddd_ios"))
+        second.set("session.sequence", .int(2))
+        sidecar.write(snapshot: second)
+
+        let read = sidecar.read()
+        XCTAssertEqual(read?["session.id"], .string("session_2_dddddddddddddddd_ios"))
+        XCTAssertEqual(read?["session.sequence"], .int(2))
+    }
+
+    // MARK: Directory creation
+
+    func testCreatesParentDirectoryOnFirstWrite() throws {
+        let sidecar = makeSidecar()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tempDir.path))
+
+        var bag = AttributeBag()
+        bag.set("session.id", .string("session_1_aaaaaaaaaaaaaaaa_ios"))
+        sidecar.write(snapshot: bag)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tempDir.path))
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: tempDir.appendingPathComponent("last-session.json").path
+        ))
+    }
+
+    // MARK: No-op on empty snapshot
+
+    func testEmptySnapshotIsNoOp() {
+        let sidecar = makeSidecar()
+        sidecar.write(snapshot: AttributeBag())
+        // No file written → read() returns nil.
+        XCTAssertNil(sidecar.read())
+    }
+
+    // MARK: defaultURL availability
+
+    func testDefaultURLResolvesUnderCachesDirectory() {
+        guard let url = SessionSidecar.defaultURL() else {
+            XCTFail("SessionSidecar.defaultURL() returned nil")
+            return
+        }
+        XCTAssertTrue(
+            url.path.contains("edge-rum"),
+            "Expected the sidecar path to contain 'edge-rum'; got \(url.path)"
+        )
+        XCTAssertEqual(url.lastPathComponent, "last-session.json")
+    }
+}

--- a/Tests/EdgeRumTests/Persistence/UserDefaultsSessionStoreTests.swift
+++ b/Tests/EdgeRumTests/Persistence/UserDefaultsSessionStoreTests.swift
@@ -1,0 +1,135 @@
+// Tests/EdgeRumTests/Persistence/UserDefaultsSessionStoreTests.swift
+//
+// Cross-instance load, sequence persistence, idle rotation across
+// a simulated process restart. Issue #43 acceptance covers the
+// 3-ACK sequence increment via the in-memory store; this file proves
+// the persisted store behaves identically.
+
+import XCTest
+@testable import EdgeRumCore
+
+final class UserDefaultsSessionStoreTests: XCTestCase {
+
+    func testLoadReturnsNilWhenEmpty() {
+        let defaults = InMemoryUserDefaultsStore()
+        let store = UserDefaultsSessionStore(defaults: defaults)
+        XCTAssertNil(store.load())
+    }
+
+    func testSaveThenLoadRoundTrips() {
+        let defaults = InMemoryUserDefaultsStore()
+        let store = UserDefaultsSessionStore(defaults: defaults)
+        let state = SessionState(
+            id: "session_1717234876123_a1b2c3d4e5f60718_ios",
+            startTime: Date(timeIntervalSince1970: 1_717_234_876.123),
+            sequence: 7,
+            lastActiveAt: Date(timeIntervalSince1970: 1_717_235_000.456)
+        )
+        store.save(state)
+        let loaded = store.load()
+        XCTAssertEqual(loaded, state)
+    }
+
+    func testStateSurvivesAcrossStoreInstances() {
+        // Simulates a "process restart" — both store instances point at
+        // the same underlying defaults wrapper.
+        let defaults = InMemoryUserDefaultsStore()
+        let state = SessionState(
+            id: "session_1717234876123_a1b2c3d4e5f60718_ios",
+            startTime: Date(timeIntervalSince1970: 1_717_234_876.123),
+            sequence: 2,
+            lastActiveAt: Date(timeIntervalSince1970: 1_717_234_876.123)
+        )
+        UserDefaultsSessionStore(defaults: defaults).save(state)
+
+        let loaded = UserDefaultsSessionStore(defaults: defaults).load()
+        XCTAssertEqual(loaded, state)
+    }
+
+    func testCorruptBlobYieldsNilAndClearsStorage() {
+        let defaults = InMemoryUserDefaultsStore()
+        defaults.set("not valid json".data(using: .utf8)!,
+                     forKey: EdgeRumStorage.keySessionState)
+        let store = UserDefaultsSessionStore(defaults: defaults)
+
+        XCTAssertNil(store.load())
+        XCTAssertNil(defaults.data(forKey: EdgeRumStorage.keySessionState))
+    }
+
+    // MARK: SessionManager-level behaviour against the persisted store
+
+    func testSessionManagerReusesPersistedStateWithinIdleWindow() {
+        let defaults = InMemoryUserDefaultsStore()
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_234_876.123))
+        let store = UserDefaultsSessionStore(defaults: defaults)
+        let manager = SessionManager(
+            store: store,
+            clock: clock,
+            randomBytes: { Data([0xa1, 0xb2, 0xc3, 0xd4, 0xe5, 0xf6, 0x07, 0x18]) }
+        )
+
+        let first = manager.touch().state
+        XCTAssertEqual(first.sequence, 0)
+
+        // Advance 10 minutes (still under 30-min idle threshold).
+        clock.advance(by: 10 * 60)
+
+        // Recreate the manager pointing at the same persisted store —
+        // simulates a process restart well within the idle window.
+        let revived = SessionManager(
+            store: UserDefaultsSessionStore(defaults: defaults),
+            clock: clock,
+            randomBytes: { Data([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]) }
+        )
+        let resumed = revived.touch()
+        XCTAssertFalse(resumed.rotated)
+        XCTAssertEqual(resumed.state.id, first.id)
+        XCTAssertEqual(resumed.state.sequence, 0)
+    }
+
+    func testSessionManagerRotatesAfterIdleThresholdAcrossRestart() {
+        let defaults = InMemoryUserDefaultsStore()
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_234_876.123))
+        let store = UserDefaultsSessionStore(defaults: defaults)
+        let manager = SessionManager(
+            store: store,
+            clock: clock,
+            randomBytes: { Data([0xa1, 0xb2, 0xc3, 0xd4, 0xe5, 0xf6, 0x07, 0x18]) }
+        )
+        let original = manager.touch().state
+
+        // Push past the 30-min idle threshold.
+        clock.advance(by: SessionManager.idleRotationInterval + 1)
+
+        let revived = SessionManager(
+            store: UserDefaultsSessionStore(defaults: defaults),
+            clock: clock,
+            randomBytes: { Data([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]) }
+        )
+        let rotated = revived.touch()
+        XCTAssertTrue(rotated.rotated)
+        XCTAssertNotEqual(rotated.state.id, original.id)
+        XCTAssertEqual(rotated.state.sequence, 0)
+    }
+
+    func testSequenceIncrementPersists() {
+        let defaults = InMemoryUserDefaultsStore()
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_234_876.123))
+        let manager = SessionManager(
+            store: UserDefaultsSessionStore(defaults: defaults),
+            clock: clock,
+            randomBytes: { Data([0xa1, 0xb2, 0xc3, 0xd4, 0xe5, 0xf6, 0x07, 0x18]) }
+        )
+        _ = manager.touch()
+        manager.incrementSequence()
+        manager.incrementSequence()
+        manager.incrementSequence()
+
+        // Re-open via a fresh store + manager.
+        let revived = SessionManager(
+            store: UserDefaultsSessionStore(defaults: defaults),
+            clock: clock
+        )
+        XCTAssertEqual(revived.currentState()?.sequence, 3)
+    }
+}

--- a/Tests/EdgeRumTests/Persistence/UserDefaultsStoreTests.swift
+++ b/Tests/EdgeRumTests/Persistence/UserDefaultsStoreTests.swift
@@ -1,0 +1,85 @@
+// Tests/EdgeRumTests/Persistence/UserDefaultsStoreTests.swift
+
+import XCTest
+@testable import EdgeRumCore
+
+final class InMemoryUserDefaultsStoreTests: XCTestCase {
+
+    func testStringRoundTrip() {
+        let store = InMemoryUserDefaultsStore()
+        store.set("hello", forKey: "k")
+        XCTAssertEqual(store.string(forKey: "k"), "hello")
+    }
+
+    func testDataRoundTrip() {
+        let store = InMemoryUserDefaultsStore()
+        let data = Data([0x01, 0x02, 0x03])
+        store.set(data, forKey: "k")
+        XCTAssertEqual(store.data(forKey: "k"), data)
+    }
+
+    func testRemoveObjectClearsValue() {
+        let store = InMemoryUserDefaultsStore()
+        store.set("x", forKey: "k")
+        store.removeObject(forKey: "k")
+        XCTAssertNil(store.string(forKey: "k"))
+        XCTAssertNil(store.data(forKey: "k"))
+    }
+
+    func testMissingKeyReturnsNil() {
+        let store = InMemoryUserDefaultsStore()
+        XCTAssertNil(store.string(forKey: "missing"))
+        XCTAssertNil(store.data(forKey: "missing"))
+    }
+
+    func testKeysAreIsolated() {
+        let store = InMemoryUserDefaultsStore()
+        store.set("a", forKey: "k1")
+        store.set("b", forKey: "k2")
+        XCTAssertEqual(store.string(forKey: "k1"), "a")
+        XCTAssertEqual(store.string(forKey: "k2"), "b")
+    }
+}
+
+final class UserDefaultsStoreSuiteTests: XCTestCase {
+
+    private let suite = "com.edge.rum.tests.\(UUID().uuidString)"
+
+    override func tearDown() {
+        UserDefaults().removePersistentDomain(forName: suite)
+        super.tearDown()
+    }
+
+    func testRealUserDefaultsSuiteRoundTrip() {
+        let store = UserDefaultsStore(suiteName: suite)
+        XCTAssertFalse(store.usingFallback, "test suite should succeed")
+        store.set("hello", forKey: "k")
+        XCTAssertEqual(store.string(forKey: "k"), "hello")
+    }
+
+    func testStoresAreIndependentAcrossInstances() {
+        let storeA = UserDefaultsStore(suiteName: suite)
+        storeA.set("persisted", forKey: "key")
+
+        let storeB = UserDefaultsStore(suiteName: suite)
+        XCTAssertEqual(storeB.string(forKey: "key"), "persisted")
+    }
+}
+
+final class EdgeRumStorageConstantsTests: XCTestCase {
+
+    func testSessionSuiteNameIsStable() {
+        XCTAssertEqual(EdgeRumStorage.sessionSuite, "com.edge.rum.session")
+    }
+
+    func testKeychainServiceIsStable() {
+        XCTAssertEqual(EdgeRumStorage.keychainService, "com.edge.rum.identity")
+    }
+
+    func testKeyNamesAreStable() {
+        XCTAssertEqual(EdgeRumStorage.keyDeviceId, "edge.rum.device.id")
+        XCTAssertEqual(EdgeRumStorage.keyDeviceIdFallback, "edge.rum.device.id.fallback")
+        XCTAssertEqual(EdgeRumStorage.keyUserId, "edge.rum.user.id")
+        XCTAssertEqual(EdgeRumStorage.keySessionState, "edge.rum.session.state")
+    }
+}

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -266,3 +266,148 @@ during implementation were load-bearing enough to record.
   reusable helper. Every transport-touching test in F4+ runs every
   envelope through `assertValidEnvelope(_:)` before further
   assertions.
+
+---
+
+## ADR-004 — F4 persistent identity: Keychain `device.id`, UserDefaults `user.id` + session triple, sidecar mirror
+
+**Date:** 2026-06-16
+
+**Status:** Accepted.
+
+**Context.** F3 shipped in-memory identity stores so the Recorder
+pipeline could be exercised end-to-end without touching disk. The
+backend dispatcher routes by `(device.id, session.id, user.id)`
+attributes on every event; without persistence, each app launch would
+look like a brand-new device to the backend and the cross-platform
+analytics joins (web/Android/iOS) would break. F4's job is to make
+the three identifiers survive across launches while keeping the
+testing seams F3 set up unchanged.
+
+**Decision.**
+
+1. **`device.id` lives in the Keychain** under
+   `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`. Service name
+   `com.edge.rum.identity`; account name `device.id`. The
+   "ThisDeviceOnly" variant keeps the value out of iCloud Keychain so
+   a restored device gets a fresh `device.id` — which matches the
+   web/Android SDK semantics where `device.id` is per-install, not
+   per-iCloud-identity. Modern iOS clears the Keychain on uninstall
+   on most installs, so reinstalling rotates `device.id`
+   transparently. Documented in the README "Identity & session
+   model" section.
+
+2. **`user.id` and the session triple live in the UserDefaults
+   suite `com.edge.rum.session`.** UserDefaults is faster than the
+   Keychain for the per-event write hot path (the session
+   `lastActiveAt` field updates on every `recordEvent`), and the
+   session is short-lived so its accessibility classification matters
+   less. The suite name is reserved across the SDK — every persisted
+   key in F4 (`edge.rum.device.id.fallback`, `edge.rum.user.id`,
+   `edge.rum.session.state`) lives under it so future tooling can
+   wipe the whole namespace in one call.
+
+3. **Keychain failure falls back to UserDefaults.** A `SecItemAdd`
+   failure is rare on iOS but observed on locked-down enterprise
+   profiles. On failure, the IdentityProvider writes `device.id` to
+   `edge.rum.device.id.fallback` in the same UserDefaults suite. On
+   subsequent reads the IdentityProvider checks the Keychain first,
+   then the fallback. When the Keychain becomes writable again, the
+   next `regenerateDeviceId()` re-persists to the Keychain and clears
+   the fallback. The fallback is observable via
+   `IdentitySnapshot.deviceIdFromFallback` so the Recorder can emit
+   one diagnostic `os_log` line at startup when it kicks in.
+
+4. **Sidecar location `Library/Caches/edge-rum/last-session.json`.**
+   The Caches directory is preserved across app terminations but iOS
+   may purge it under disk pressure. That's acceptable for the
+   sidecar because it is only load-bearing while a crash report from
+   the PRIOR launch is still pending. Anything more durable
+   (Documents) would persist crash-replay attribution into
+   indefinitely many launches, which is wrong. The mirror is
+   restricted to the identity triple plus `sdk.version` /
+   `sdk.platform` (`SessionSidecar.mirroredKeys`) — transient values
+   like battery level and network type are deliberately omitted so
+   the replayed crash event carries the prior session's *identity*,
+   not its environment.
+
+5. **`identify()` does not persist `external_id`.** Only the
+   SDK-owned anonymous `user.id` is persistent. Host-app identifiers
+   passed through `EdgeRum.identify(_:)` ride on events as
+   `user.external_id` / `user.name` / `user.email` / `user.phone`
+   attributes (via `ContextProvider.setUser`) but the SDK does not
+   write them to disk. Rationale: the host app already manages its
+   own user record and re-identifies on launch; persisting our copy
+   would risk a stale identifier surviving a host-app logout.
+
+6. **`Recorder.installPersistedStores(...)` is the integration
+   point** — called once by `EdgeRum.start()` against the shared
+   Recorder via an `as? Recorder` cast. This means test probes
+   (`ProbeRecorder`) are not affected by `start()` and existing F2/F3
+   tests continue to pass unchanged. The shared default Recorder
+   keeps its in-memory backing until the host opts in by calling
+   `EdgeRum.start(_:)`, which is also the only path on which
+   real-Keychain writes happen at all.
+
+7. **Mid-event idle rotation emits a `session.finalized` +
+   `session.started` pair.** When `recordEvent` / `recordPerformance`
+   detects the touch crossed the 30-minute idle threshold, the prior
+   session id is written as event attributes on the finalized event
+   (they win over the context bag at flush time), the context
+   refreshes to the new session, and the started event is emitted.
+   A re-entrancy flag (`_insideRotationEmission`) blocks the
+   synthetic emissions from re-triggering the same rotation path.
+   The originating event then proceeds normally.
+
+8. **`Recorder.didAckBatch()` is the public hook for sequence
+   increments.** F5's transport layer calls it after every 2xx
+   response — three consecutive ACKed batches yield
+   `session.sequence == 3` on the next emitted event. Issue #43
+   acceptance.
+
+**Alternatives considered.**
+
+- **`device.id` in UserDefaults instead of the Keychain.** Simpler,
+  faster, no `SecItem*` calls. Rejected: UserDefaults is wiped on
+  uninstall AND on `removePersistentDomain(forName:)`; the Keychain
+  is the only iOS-supplied store that survives the latter while
+  still being purged on uninstall on modern installs. Matches the
+  Android SDK's `EncryptedSharedPreferences` choice for the analogous
+  field.
+
+- **iCloud-synced `device.id` for cross-device continuity.**
+  Rejected: the backend treats every install as a distinct device for
+  analytics purposes. Cross-device joining is a `user.id` problem,
+  not a `device.id` problem.
+
+- **Sidecar in `Library/Application Support/`.** Rejected: that
+  directory is included in iOS backups and would carry the previous
+  install's session state into a fresh install — exactly the
+  cross-launch attribution bug the sidecar exists to prevent.
+
+- **Closing the F4 scope at T4.3 and deferring the sidecar entirely
+  to F14.** Rejected: the sidecar *writer* is a single file with no
+  cross-target dependency on PLCrashReporter, and writing it now
+  lets F14 land the reader side without first having to also wire
+  the writer. The reader/replay side is the carry-over noted on
+  issue #44.
+
+**Consequences.**
+
+- One new public surface in `EdgeRumCore`:
+  `Recorder.installPersistedStores(identityProvider:sessionStore:sidecar:)`.
+  Still internal from `import EdgeRum`'s perspective because
+  `EdgeRumCore` is not in `Package.swift`'s `products:`. Locked in by
+  `PackageProductsTests`.
+- The shared `Recorder()` default keeps in-memory backing; tests that
+  predate F4 keep passing without modification. F4's new tests
+  inject `InMemoryKeychainStore` / `InMemoryUserDefaultsStore` so the
+  CI host doesn't need real Keychain access.
+- `EdgeRum.start(_:)` gains a single line that does the
+  `as? Recorder` cast and calls `installPersistedStores`. Misuse
+  protection: if the cast fails (probe installed), persistence is
+  silently skipped — the probe handles its own state.
+- F5's transport layer must call `Recorder.didAckBatch()` after every
+  successful POST. The F4 contract test
+  `IdentityPersistenceConformanceTests` pins this requirement: any
+  future regression that loses the increment will fail the test.


### PR DESCRIPTION
Lands feature **F4 — Identity & session management** (`PLAN-iOS.md` §F4, tasks T4.1–T4.4) on top of the F3 core pipeline. Replaces F3's in-memory identity stores with real Keychain + UserDefaults persistence so `device.id`, `session.id`, and `user.id` survive across launches and join cross-batch the way the EdgeTelemetryProcessor dispatcher expects.

Closes #9, #41, #42, #43, #44.

## Summary

- **`device.id` → Keychain.** New `Sources/EdgeRumCore/Persistence/KeychainStore.swift` wraps `SecItem*` with `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`. On Keychain write failure, the `IdentityProvider` falls back to the same UserDefaults suite under a distinct key. Reinstall on a modern iOS install rotates `device.id` transparently.
- **`user.id` + `SessionState` → UserDefaults suite `com.edge.rum.session`.** `UserDefaultsStore` + `UserDefaultsSessionStore` plug into F3's existing `SessionStore` seam without changing `SessionManager`'s contract.
- **Format regex validation on load.** `IdentityFormat.validate(_:kind:)` regenerates any persisted value that doesn't match the platform-pinned regex (`device_<epochMs>_<16 hex>_ios`, `session_<epochMs>_<16 hex>_ios`, `user_<epochMs>_<16 hex>`).
- **Mid-event idle rotation.** `Recorder.recordEvent` / `recordPerformance` now call `sessionManager.touch()` on ingress; if the touch crosses the 30-min idle threshold, the Recorder emits a `session.finalized` (prior session id pinned as event attrs) → `session.started` pair before processing the originating event. A re-entrancy flag blocks the synthetic emissions from recursing.
- **`didAckBatch()` public hook.** F5's transport layer will call this on every 2xx — increments `session.sequence` under the `SessionManager` lock and refreshes the context snapshot. Issue #43 acceptance: three consecutive ACKed batches → `session.sequence == 3`.
- **Crash sidecar writer.** `SessionSidecar.write(snapshot:)` atomically writes `Library/Caches/edge-rum/last-session.json` mirroring the active session/user/device identity on every `enqueue`. Hooked from inside the Recorder so the on-disk mirror stays fresh.
- **`Recorder.installPersistedStores(...)` integration point.** `EdgeRum.start()` casts `Recorder.shared as? Recorder` and calls it once — test probes (`ProbeRecorder`) are unaffected, and the default `Recorder()` keeps in-memory backing so existing F2/F3 tests pass unchanged.

| Task | Issue | Notes |
|---|---|---|
| T4.1 — ID format regex + validators | #41 | `IdentityFormat.swift` + 10k-sample test per kind |
| T4.2 — IdentityProvider (Keychain + UserDefaults) | #42 | Keychain happy path + fallback + regenerate-on-malformed |
| T4.3 — SessionManager persistence + lifecycle hook | #43 | `UserDefaultsSessionStore` + `recordEvent` touch + `didAckBatch()` |
| T4.4 — Crash sidecar (writer only) | #44 | Reader + replay path is carry-over to F14 (T14.3) — noted below |

## T4.4 carry-over note

This PR ships the sidecar **writer** only. The on-next-launch **reader** + the PLCrashReporter-driven replay event emission live in `EdgeRumCrash` and are owned by F14 / T14.3. Issue #44's acceptance test (replayed `app.crash` carries the crashing session's id, not the current one) will be closed by the F14 PR. The writer side is fully covered by `SessionSidecarTests` and `IdentityPersistenceConformanceTests` here.

## What's NOT in this PR

- HTTP transport, retry, `Retry-After` handling (F5)
- Offline queue, background uploader (F5)
- `didBecomeActive` / `willResignActive` lifecycle wiring (F11 — `LifecycleCapture`)
- Capture surfaces / swizzles (F7+)

## Pod-lint follow-ups included

Cherry-picks the three pod-lint fixes that surfaced after the F3 PR merged (`pod lib lint` runs the full Xcode build, the SwiftPM-only build plugin doesn't apply there):

| Commit | Fix |
|---|---|
| `e6760cc` | rename `Sources/EdgeRum/AttributeValue.swift` → `AttributeValueExport.swift` (case-insensitive filesystem collides with the EdgeRumCore type of the same name) |
| `5b2ece5` | gate `import EdgeRumCore` with `#if canImport` so CocoaPods builds (one module under CP) |
| `bd2aacb` | mark `handleBackgroundEvents`'s `completion` as `@Sendable` for Swift 6 strict-concurrency |

These also apply against the F3 branch independently — keeping them on F4 so CI green-lights this PR end-to-end. Safe to drop them post-rebase once the F3 follow-up PR lands them on the integration trunk.

## Test plan

- [x] `swift build -c release` — clean
- [x] `swift test` — 222/222 pass (191 F2/F3 + 31 new F4 tests + the contract test)
- [x] `xcodebuild build -scheme EdgeRum -destination 'generic/platform=iOS'` — BUILD SUCCEEDED
- [x] `xcodebuild build -scheme EdgeRum -destination 'generic/platform=iOS Simulator'` — BUILD SUCCEEDED
- [x] `./Tools/firewall-check.sh` — public surface + consumer docs clean (no `opentelemetry` / `span` / `tracer` / `metric` leakage)
- [x] `./Tools/check-supported-ios.sh` — iOS 14 floor consistent across `Package.swift`, podspec, `PLAN-iOS.md`, `README.md`
- [x] `./Tools/gen-version.sh Sources/EdgeRum/Generated/EdgeRumVersion.swift && pod lib lint EdgeRum.podspec --allow-warnings` — passed validation (mirrors CI's pod-lint job exactly)
- [ ] CI on PR — exercises `build` / `test` / `audit` / `pod-lint` jobs

## Acceptance criteria

- **#41 T4.1** — `IdentityFormatTests` runs `DeviceIdentitySnapshot.newId()`, `SessionManager.rotate().id`, and `UserContextSnapshot.newAnonymousId()` in 10k-iteration loops and asserts each matches the regex for its kind. Plus 9 negative cases (wrong prefix, wrong suffix, non-hex, wrong length, non-numeric epoch, UUID-style hex, cross-kind isolation).
- **#42 T4.2** — `IdentityProviderTests.testClearingKeychainRegeneratesDeviceId` clears the keychain row, recreates the provider with a different random seed, asserts the new id differs from the original and matches the regex. `testKeychainFailureFallsBackToUserDefaults` proves the fallback path via the `InMemoryKeychainStore` failure injector.
- **#43 T4.3** — `SessionRotationOnRecordEventTests.testThreeAcksYieldSequenceThree` calls `didAckBatch()` three times, then records a navigation event and asserts the emitted event's `session.sequence == 3`. `UserDefaultsSessionStoreTests.testSessionManagerRotatesAfterIdleThresholdAcrossRestart` proves cross-process idle rotation.
- **#44 T4.4 (writer)** — `SessionSidecarTests` asserts the JSON on disk holds only the mirrored identity keys (transient battery/network keys filtered out), overwrites atomically on subsequent writes, and creates the `edge-rum/` parent directory on first write.

## Documentation

- README.md gains a new **Identity & session model** section detailing the persistence map, the 30-min idle rotation rule, and the sidecar carry-over note. Status banner bumped to F4.
- `docs/decisions.md` **ADR-004** covers the 8 load-bearing decisions: Keychain accessibility class, UserDefaults suite naming, fallback policy, sidecar location, why `identify()` doesn't persist `external_id`, the `installPersistedStores` integration point, mid-event rotation semantics, and the `didAckBatch` hook.
- `PLAN-iOS.md` §F4 status flips T4.1–T4.4 to ✅ with notes on which files ship them and the T4.4 reader carry-over.
