### PR TITLE
feat(F5): batch transport, retry, offline queue, background uploader

### DIFF
--- a/PLAN-iOS.md
+++ b/PLAN-iOS.md
@@ -1827,6 +1827,8 @@ flush on background. **Status.** `v1.0`. **Refs.** §9.
 
 **Acceptance.** Posting a 30-event batch produces a 200 and a single ACK.
 
+**Shipped in F5 as `Sources/EdgeRumCore/Transport/BatchTransport.swift` — `URLSession` driver with the `X-API-Key` / `Content-Type` / `User-Agent` / `X-Edge-Rum-Internal` headers, `taskDescription = "edge-rum-internal"`, and a structured `BatchSendOutcome` enum (`.success(status:)` / `.failure(status:retryAfter:)`). `Tests/EdgeRumTests/Transport/BatchTransportTests.swift` covers the header contract and the 30-event single-ACK acceptance via `MockURLProtocol`.**
+
 ##### T5.2 — `RetryPolicy` `[M1]`
 - Schedule 0 / 2 / 8 / 30 s for status 0 / 429 / 503.
 - Respect `Retry-After` capped at 60 s.
@@ -1835,6 +1837,8 @@ flush on background. **Status.** `v1.0`. **Refs.** §9.
 
 **Acceptance.** Mock server returning 503 yields four attempts then offline-queue.
 
+**Shipped in F5 as `Sources/EdgeRumCore/Transport/RetryPolicy.swift` — pure value type with `decide(attempt:status:retryAfter:)` returning `.retry(after:)` / `.toOfflineQueue` / `.drop`. Numeric and RFC 1123 HTTP-date forms of `Retry-After` both honored. `RetryPolicyTests` pins the full truth table.**
+
 ##### T5.3 — `OfflineQueue` (file-backed) `[M1]`
 - Files under `Library/Caches/edge-rum/queue/<epochMs>-<seq>.json`.
 - `maxQueueSize` cap; FIFO drop on overflow.
@@ -1842,17 +1846,23 @@ flush on background. **Status.** `v1.0`. **Refs.** §9.
 
 **Acceptance.** Filling the queue past `maxQueueSize` drops the oldest file first.
 
+**Shipped in F5 as `Sources/EdgeRumCore/Transport/OfflineQueue.swift` — file-per-batch FIFO with epoch-prefixed names for lexicographic == chronological ordering. `HTTPTransportSink.drainOfflineQueue()` is the entry point, wired from `EdgeRum.enable()` and from the sink's own `NetworkPathObserver` on `.satisfied` transition. `didBecomeActive` trigger lands with F11 — `drainOfflineQueue` already exists, that integration is one call.**
+
 ##### T5.4 — `BackgroundUploader` `[M1]`
 - `URLSessionConfiguration.background(withIdentifier: "com.edge.rum.upload")`.
 - Public `EdgeRum.handleBackgroundEvents(identifier:completion:)` wired into the uploader's completion.
 
 **Acceptance.** Suspending the app mid-upload and re-launching completes the upload.
 
+**Shipped in F5 as `Sources/EdgeRumCore/Transport/BackgroundUploader.swift` + `EdgeRum.handleBackgroundEvents` body. The system-supplied completion is stored on identifier match and fired from `urlSessionDidFinishEvents(forBackgroundURLSession:)`; identifier mismatch invokes the completion immediately so the host app's expiration handler resolves. Full "suspend mid-upload + relaunch" exercise needs a host app and is covered by the sample app's manual smoke pass.**
+
 ##### T5.5 — Per-session sampling `[M1]`
 - Uniform random at session start vs `sampleRate` (§9.6).
 - Excluded sessions emit only forced-emit allowlist.
 
 **Acceptance.** `sampleRate = 0.5` over 10k synthetic sessions yields 5000 ± 200 sampled.
+
+**Shipped in F5 as the rotation re-roll inside `Recorder.bumpLastActiveAndEmitRotationIfNeeded()` + the `start()` re-roll. F3's `Sampler` only re-rolled on `configure(_:)`, leaving idle-rotated sessions inheriting the prior decision; F5 makes the decision per-session as PLAN-iOS.md §9.6 specifies. `SamplerTests.test10kSessionsAt50PercentHits5000Plus200` pins the statistical acceptance with a seeded LCG so the test is deterministic. See ADR-005 for the rationale.**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `edge-rum-ios` is the native iOS sibling of the [`edge-rum`](https://github.com/NCG-Africa/edge-rum) (web/Ionic/Capacitor) and [`edge-rum-android`](https://github.com/NCG-Africa/edge-rum-android) SDKs. It captures performance data, errors, native crashes, hangs, network requests, and user interactions on iOS apps and ships them as JSON to the EdgeTelemetryProcessor backend used by all three platforms.
 
-> **Status.** Public API surface (F2) and the core pipeline (F3) are in place. F4 lands persistent identity — `device.id` survives across launches in the Keychain, `user.id` and the session triple live in the `com.edge.rum.session` UserDefaults suite, the 30-minute idle session rotation is enforced on every event, and the `last-session.json` sidecar mirrors the active identity for F14's crash-replay path. HTTP transport (F5), offline queue, and the capture layer (screen / HTTP / interaction / native crash) follow across F5–F18.
+> **Status.** Public API surface (F2), the core pipeline (F3), and persistent identity (F4) are in place. F5 lands the transport layer — events flow over HTTPS to the EdgeRum collector endpoint, the retry schedule survives transient failures, failed batches spill onto a file-backed offline queue, and a background `URLSession` finishes pending uploads after the host app is suspended. The capture layer (screen / HTTP / interaction / native crash) follows across F6–F18.
 
 ## Supported iOS
 
@@ -145,6 +145,28 @@ Every public call (`track`, `trackScreen`, `identify`, `time`, `captureError`, p
 5. Hands the assembled batch envelope to the transport layer.
 
 Sample rate, batch size, and flush interval are all configurable on `EdgeRumConfig`. See [`docs/payload-example.jsonc`](docs/payload-example.jsonc) for the exact wire shape and [`docs/decisions.md`](docs/decisions.md) for the design rationale.
+
+## Offline & background
+
+When the live transport can't reach the backend the SDK doesn't drop the batch:
+
+1. The first failure schedules a retry on the **0 / 2 / 8 / 30 s** ladder (status `0`, `429`, or `503`; other 5xx responses are treated as `503`; `429`/`503` honor `Retry-After`, capped at 60 s). Non-retryable 4xx codes drop the batch.
+2. After the fourth attempt fails, the encoded payload spills into `Library/Caches/edge-rum/queue/<epochMs>-<seq>.json` — one file per batch, capped at `maxQueueSize` (default 200) with oldest-file-first overflow.
+3. The queue drains sequentially on three triggers: `NWPathMonitor` reporting `.satisfied`, `EdgeRum.enable()`, and (once F11 lands) `didBecomeActive`. Each success deletes the file; the first failure aborts the drain so the order is preserved.
+
+Background uploads — POSTs that were mid-flight when the user hit the home button — are handled by a separate `URLSessionConfiguration.background(withIdentifier: "com.edge.rum.upload")`. Wire it up from your `AppDelegate`:
+
+```swift
+func application(
+    _ application: UIApplication,
+    handleEventsForBackgroundURLSession identifier: String,
+    completionHandler: @escaping () -> Void
+) {
+    EdgeRum.handleBackgroundEvents(identifier: identifier, completion: completionHandler)
+}
+```
+
+If you skip the wire-up, background uploads still complete — they just won't notify the system, and the OS won't grant you another background window. The next foreground flush replays anything still in the offline queue.
 
 ## Identity & session model
 

--- a/Sources/EdgeRum/EdgeRum.swift
+++ b/Sources/EdgeRum/EdgeRum.swift
@@ -61,6 +61,13 @@ public enum EdgeRum {
     private static let stateLock = NSLock()
     nonisolated(unsafe) private static var startedIdentity: StartedIdentity?
 
+    /// The shared background uploader, instantiated at `start()` time
+    /// so `handleBackgroundEvents(identifier:completion:)` can attach
+    /// the system-supplied completion to the live `URLSession`. Lives
+    /// behind the same `stateLock` as `startedIdentity` because it is
+    /// set and read across the public API boundary.
+    nonisolated(unsafe) private static var sharedBackgroundUploader: BackgroundUploader?
+
     private static let log = OSLog(subsystem: "com.edge.rum", category: "EdgeRum")
 
     // MARK: Lifecycle
@@ -118,6 +125,36 @@ public enum EdgeRum {
                 sessionStore: UserDefaultsSessionStore(),
                 sidecar: SessionSidecar()
             )
+
+            // F5 — replace the F3 NoopTransportSink with the real
+            // HTTP-backed sink. The sink takes a weak reference back to
+            // the Recorder so it can call `didAckBatch()` on 2xx
+            // (F4 carry-over hook, issue #43).
+            let transport = BatchTransport(
+                endpoint: config.endpoint,
+                apiKey: config.apiKey,
+                sdkVersion: EdgeRum.sdkVersion,
+                deviceModel: TransportEnvironment.deviceModel(),
+                osVersion: TransportEnvironment.osVersion(),
+                debug: config.debug
+            )
+            sharedBackgroundUploader = BackgroundUploader(debug: config.debug)
+            let sink = HTTPTransportSink(
+                transport: transport,
+                offlineQueue: OfflineQueue(
+                    maxQueueSize: config.maxQueueSize,
+                    debug: config.debug
+                ),
+                backgroundUploader: sharedBackgroundUploader,
+                apiKey: config.apiKey,
+                userAgent: BatchTransport.makeUserAgent(
+                    sdkVersion: EdgeRum.sdkVersion,
+                    deviceModel: TransportEnvironment.deviceModel(),
+                    osVersion: TransportEnvironment.osVersion()
+                ),
+                debug: config.debug
+            )
+            realRecorder.installTransport(sink)
         }
 
         // Hand the full settings to the internal Recorder before
@@ -220,9 +257,16 @@ public enum EdgeRum {
         Recorder.shared.setEnabled(false)
     }
 
-    /// Resume capture and emission after a `disable()` call.
+    /// Resume capture and emission after a `disable()` call. Also
+    /// asks the transport layer to drain any envelopes that landed in
+    /// the offline queue while the SDK was paused (CLAUDE.md
+    /// "Offline queue rules" — `enable()` is one of the three drain
+    /// triggers).
     public static func enable() {
         Recorder.shared.setEnabled(true)
+        if let realRecorder = Recorder.shared as? Recorder {
+            realRecorder.drainOfflineQueue()
+        }
     }
 
     // MARK: Read-only state
@@ -260,13 +304,19 @@ public enum EdgeRum {
         identifier: String,
         completion: @Sendable @escaping () -> Void
     ) {
-        // F5 wires the BackgroundUploader and calls `completion` once
-        // the URLSession finishes its pending tasks. F2 ships the
-        // signature so host apps can wire it now. Hop to main so the
-        // stub behaviour matches the AppDelegate contract host apps
-        // are expected to satisfy.
-        _ = identifier
-        DispatchQueue.main.async { completion() }
+        // F5 — forward into the live `BackgroundUploader` so the
+        // system-supplied completion fires once the background
+        // URLSession finishes its pending tasks. When the host calls
+        // this before `start(_:)` we don't have an uploader yet — hop
+        // straight to main and complete so the system gets its ack.
+        stateLock.lock()
+        let uploader = sharedBackgroundUploader
+        stateLock.unlock()
+        if let uploader {
+            uploader.attachCompletion(completion, for: identifier)
+        } else {
+            DispatchQueue.main.async { completion() }
+        }
     }
 
     // MARK: Internal helpers

--- a/Sources/EdgeRumCore/Recorder.swift
+++ b/Sources/EdgeRumCore/Recorder.swift
@@ -94,7 +94,7 @@ public final class Recorder: Recording, @unchecked Sendable {
 
     private let _clock: Clock
     private var sessionManager: SessionManager
-    private let transport: TransportSink
+    private var transport: TransportSink
     private let payloadBuilder: PayloadBuilder
     private let context: ContextProvider
 
@@ -200,6 +200,20 @@ public final class Recorder: Recording, @unchecked Sendable {
         sidecar?.write(snapshot: context.snapshot())
     }
 
+    /// F5 production wiring: swap the in-memory `NoopTransportSink` for
+    /// a real HTTP-backed sink. Called once by `EdgeRum.start()` after
+    /// `installPersistedStores`. If the sink is an `HTTPTransportSink`
+    /// it gets a weak reference back to this Recorder so it can call
+    /// `didAckBatch()` on 2xx responses.
+    public func installTransport(_ newTransport: TransportSink) {
+        stateLock.lock()
+        self.transport = newTransport
+        stateLock.unlock()
+        if let http = newTransport as? HTTPTransportSink {
+            http.attach(recorder: self)
+        }
+    }
+
     // MARK: Recording
 
     public var clock: Clock { _clock }
@@ -242,6 +256,12 @@ public final class Recorder: Recording, @unchecked Sendable {
         stateLock.lock()
         _enabled = true
         let configured = _config
+        // T5.5 — re-roll the per-session sampler so the new session
+        // gets its own in/out decision rather than inheriting the
+        // configure() roll.
+        if let rate = _config?.sampleRate {
+            self.sampler = Sampler(sampleRate: rate)
+        }
         stateLock.unlock()
 
         // Rotate to a fresh session — `start()` is the lifecycle
@@ -390,6 +410,7 @@ public final class Recorder: Recording, @unchecked Sendable {
         let events = _buffer
         _buffer.removeAll(keepingCapacity: true)
         let location = _config?.location
+        let currentTransport = transport
         stateLock.unlock()
 
         guard !events.isEmpty else { return }
@@ -400,7 +421,17 @@ public final class Recorder: Recording, @unchecked Sendable {
             location: location,
             flushTime: clock.now
         )
-        transport.send(envelope, reason: reason)
+        currentTransport.send(envelope, reason: reason)
+    }
+
+    /// Forward an offline-queue drain request to the installed
+    /// transport. Called from `EdgeRum.enable()` and (later) F11's
+    /// `didBecomeActive` lifecycle hook.
+    public func drainOfflineQueue() {
+        stateLock.lock()
+        let currentTransport = transport
+        stateLock.unlock()
+        currentTransport.drainOfflineQueue()
     }
 
     /// Drain the buffer and stop. Equivalent to `stop()` plus the
@@ -452,6 +483,13 @@ public final class Recorder: Recording, @unchecked Sendable {
 
         stateLock.lock()
         _insideRotationEmission = true
+        // T5.5 — re-roll the sampler so the new session has its own
+        // in/out decision instead of inheriting the prior session's
+        // roll. Idle rotation crosses a session boundary, so per-spec
+        // (§9.6 "per-session uniform random") the decision is fresh.
+        if let rate = _config?.sampleRate {
+            self.sampler = Sampler(sampleRate: rate)
+        }
         stateLock.unlock()
         defer {
             stateLock.lock()

--- a/Sources/EdgeRumCore/Transport/BackgroundUploader.swift
+++ b/Sources/EdgeRumCore/Transport/BackgroundUploader.swift
@@ -1,0 +1,158 @@
+// Sources/EdgeRumCore/Transport/BackgroundUploader.swift
+//
+// Background-`URLSession` companion to `BatchTransport`. Drains
+// pending uploads after the host app is suspended, so a payload that
+// was mid-flight when the user hit the home button still reaches the
+// backend the next time iOS gives the SDK CPU.
+//
+// Wiring:
+//
+//   1. Host app forwards
+//      `application(_:handleEventsForBackgroundURLSession:completionHandler:)`
+//      → `EdgeRum.handleBackgroundEvents(identifier:completion:)`.
+//   2. `handleBackgroundEvents` calls `attachCompletion(_:for:)` here.
+//   3. Once the backing `URLSession` finishes its pending tasks the
+//      delegate fires `urlSessionDidFinishEvents` which invokes the
+//      stored completion and clears it.
+//
+// We deliberately keep the foreground `BatchTransport` and the
+// background uploader as separate sessions — the background
+// configuration's body-from-file constraint makes it a poor fit for
+// the live retry path, and using two sessions keeps the live happy
+// path single-task-per-batch (CLAUDE.md "Transport rules").
+//
+// Refs: PLAN-iOS.md §9.5, §F5/T5.4; CLAUDE.md "Transport rules"
+//       ("background flush" paragraph).
+//
+
+import Foundation
+import os.log
+
+public protocol BackgroundUploading: AnyObject, Sendable {
+    /// Identifier the host app must forward into
+    /// `EdgeRum.handleBackgroundEvents(identifier:completion:)`.
+    var sessionIdentifier: String { get }
+
+    /// Enqueue a payload for background upload. The body is written
+    /// to a temp file because `URLSessionConfiguration.background`
+    /// requires `uploadTask(with:fromFile:)`.
+    @discardableResult
+    func enqueue(_ payload: Data, url: URL, apiKey: String, userAgent: String) -> Bool
+
+    /// Store the system-supplied completion. Called from
+    /// `EdgeRum.handleBackgroundEvents`. The closure runs once the
+    /// session reports `urlSessionDidFinishEvents`.
+    func attachCompletion(_ completion: @escaping @Sendable () -> Void, for identifier: String)
+}
+
+public final class BackgroundUploader: NSObject, BackgroundUploading, URLSessionDelegate, URLSessionTaskDelegate, @unchecked Sendable {
+
+    /// Background session identifier shared across iOS launches.
+    /// PLAN-iOS.md §9.5 pins this string.
+    public static let defaultSessionIdentifier = "com.edge.rum.upload"
+
+    public let sessionIdentifier: String
+
+    private let log: OSLog
+    private let debug: Bool
+    private let lock = NSLock()
+    private var _completion: (@Sendable () -> Void)?
+    private let fileManager: FileManager
+    private lazy var session: URLSession = {
+        let cfg = URLSessionConfiguration.background(withIdentifier: sessionIdentifier)
+        cfg.isDiscretionary = false
+        cfg.sessionSendsLaunchEvents = true
+        return URLSession(configuration: cfg, delegate: self, delegateQueue: nil)
+    }()
+
+    public init(
+        sessionIdentifier: String = BackgroundUploader.defaultSessionIdentifier,
+        fileManager: FileManager = .default,
+        debug: Bool = false,
+        log: OSLog = OSLog(subsystem: "com.edge.rum", category: "BackgroundUploader")
+    ) {
+        self.sessionIdentifier = sessionIdentifier
+        self.fileManager = fileManager
+        self.debug = debug
+        self.log = log
+        super.init()
+    }
+
+    @discardableResult
+    public func enqueue(_ payload: Data, url: URL, apiKey: String, userAgent: String) -> Bool {
+        // Background uploads need the body on disk. Write to the
+        // temporary directory under a UUID-keyed name.
+        let tmpURL = fileManager.temporaryDirectory
+            .appendingPathComponent("edge-rum-\(UUID().uuidString).json", isDirectory: false)
+        do {
+            try payload.write(to: tmpURL, options: .atomic)
+        } catch {
+            if debug {
+                os_log(
+                    "BackgroundUploader temp write failed: %{public}@",
+                    log: log,
+                    type: .info,
+                    String(describing: error)
+                )
+            }
+            return false
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(apiKey, forHTTPHeaderField: "X-API-Key")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue("1", forHTTPHeaderField: BatchTransport.internalHeaderName)
+
+        let task = session.uploadTask(with: request, fromFile: tmpURL)
+        task.taskDescription = BatchTransport.internalTaskDescription
+        task.resume()
+        return true
+    }
+
+    public func attachCompletion(
+        _ completion: @escaping @Sendable () -> Void,
+        for identifier: String
+    ) {
+        guard identifier == sessionIdentifier else {
+            // The host forwarded a different background session — not
+            // ours. Invoke the completion anyway so the system gets its
+            // ack; ignoring it would leave the app spinning.
+            DispatchQueue.main.async(execute: completion)
+            return
+        }
+        lock.lock()
+        _completion = completion
+        lock.unlock()
+    }
+
+    // MARK: URLSessionDelegate
+
+    public func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+        lock.lock()
+        let completion = _completion
+        _completion = nil
+        lock.unlock()
+        guard let completion else { return }
+        DispatchQueue.main.async(execute: completion)
+    }
+
+    public func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        // No retry inside the background uploader — if the task failed
+        // the payload will replay from the offline queue on next
+        // foreground.
+        if let error, debug {
+            os_log(
+                "BackgroundUploader task failed: %{public}@",
+                log: log,
+                type: .info,
+                String(describing: error)
+            )
+        }
+    }
+}

--- a/Sources/EdgeRumCore/Transport/BatchTransport.swift
+++ b/Sources/EdgeRumCore/Transport/BatchTransport.swift
@@ -1,0 +1,154 @@
+// Sources/EdgeRumCore/Transport/BatchTransport.swift
+//
+// HTTP driver for a single `EventEnvelope` POST. Owns the `URLSession`
+// used by the foreground send path (created up-front, before any
+// swizzles install — PLAN-iOS.md §9.2) and produces a structured
+// `BatchSendOutcome` that the surrounding `HTTPTransportSink` feeds
+// to `RetryPolicy`.
+//
+// The wire contract is checked here at the point each request is
+// built — endpoint path, headers, encoding — so the F4 contract test
+// can exercise it without spinning up a full Recorder.
+//
+// Refs: PLAN-iOS.md §7.1, §9.2, §F5/T5.1; CLAUDE.md "Transport rules".
+//
+
+import Foundation
+import os.log
+
+public enum BatchSendOutcome: Sendable, Equatable {
+    /// 2xx response. The caller should invoke `Recorder.didAckBatch()`.
+    case success(status: Int)
+
+    /// Non-2xx response. `status` carries the actual HTTP code; for
+    /// network-level failures (`URLError`, transport drop) it is `0`.
+    /// `retryAfter` is the parsed `Retry-After` header, when present.
+    case failure(status: Int, retryAfter: TimeInterval?)
+}
+
+public protocol BatchSending: AnyObject, Sendable {
+    /// Build the request, POST it, and resolve with a structured
+    /// outcome. The closure is invoked on a background queue owned by
+    /// `URLSession`.
+    func post(_ payload: Data, completion: @escaping @Sendable (BatchSendOutcome) -> Void)
+
+    /// Endpoint composed at construction time, exposed for tests +
+    /// for the offline replay path so a queued payload reaches the
+    /// same URL.
+    var url: URL { get }
+}
+
+public final class BatchTransport: BatchSending, @unchecked Sendable {
+
+    // MARK: Constants
+
+    /// `POST <endpoint>/collector/telemetry` — pinned by §7.1 and
+    /// matched across web/Android/iOS SDKs.
+    public static let collectorPath = "collector/telemetry"
+
+    /// Header marking our own requests so HTTPCapture (F8) can filter
+    /// them out and prevent self-instrumentation.
+    public static let internalHeaderName = "X-Edge-Rum-Internal"
+
+    /// `taskDescription` set on every `URLSessionTask` for the same
+    /// defence-in-depth reason. Read by F8 once it lands.
+    public static let internalTaskDescription = "edge-rum-internal"
+
+    // MARK: Config
+
+    public let url: URL
+    public let apiKey: String
+
+    private let session: URLSession
+    private let userAgent: String
+    private let log: OSLog
+    private let debug: Bool
+
+    public init(
+        endpoint: URL,
+        apiKey: String,
+        sdkVersion: String,
+        deviceModel: String,
+        osVersion: String,
+        session: URLSession? = nil,
+        debug: Bool = false,
+        log: OSLog = OSLog(subsystem: "com.edge.rum", category: "BatchTransport")
+    ) {
+        self.url = BatchTransport.makeCollectorURL(endpoint: endpoint)
+        self.apiKey = apiKey
+        self.userAgent = BatchTransport.makeUserAgent(
+            sdkVersion: sdkVersion,
+            deviceModel: deviceModel,
+            osVersion: osVersion
+        )
+        self.log = log
+        self.debug = debug
+
+        if let session {
+            self.session = session
+        } else {
+            let cfg = URLSessionConfiguration.default
+            // Created *before* HTTPCapture's URLProtocol registers so
+            // our own traffic never enters the recording path.
+            cfg.protocolClasses = cfg.protocolClasses ?? []
+            cfg.httpAdditionalHeaders = nil
+            cfg.requestCachePolicy = .reloadIgnoringLocalCacheData
+            self.session = URLSession(configuration: cfg)
+        }
+    }
+
+    public func post(_ payload: Data, completion: @escaping @Sendable (BatchSendOutcome) -> Void) {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = payload
+        request.setValue(apiKey, forHTTPHeaderField: "X-API-Key")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue("1", forHTTPHeaderField: BatchTransport.internalHeaderName)
+
+        let task = session.dataTask(with: request) { [debug, log] _, response, error in
+            if let error {
+                if debug {
+                    os_log(
+                        "BatchTransport network error: %{public}@",
+                        log: log,
+                        type: .info,
+                        String(describing: error)
+                    )
+                }
+                completion(.failure(status: 0, retryAfter: nil))
+                return
+            }
+            guard let http = response as? HTTPURLResponse else {
+                completion(.failure(status: 0, retryAfter: nil))
+                return
+            }
+            let status = http.statusCode
+            if (200...299).contains(status) {
+                completion(.success(status: status))
+                return
+            }
+            let retryAfterRaw = http.value(forHTTPHeaderField: "Retry-After")
+            let retryAfter = RetryPolicy.parseRetryAfter(retryAfterRaw)
+            completion(.failure(status: status, retryAfter: retryAfter))
+        }
+        task.taskDescription = BatchTransport.internalTaskDescription
+        task.resume()
+    }
+
+    // MARK: Helpers
+
+    /// Append the `collector/telemetry` path to the host-supplied
+    /// endpoint, honoring trailing slashes.
+    public static func makeCollectorURL(endpoint: URL) -> URL {
+        endpoint.appendingPathComponent(collectorPath)
+    }
+
+    public static func makeUserAgent(
+        sdkVersion: String,
+        deviceModel: String,
+        osVersion: String
+    ) -> String {
+        "EdgeRum-iOS/\(sdkVersion) (\(deviceModel); iOS \(osVersion))"
+    }
+}

--- a/Sources/EdgeRumCore/Transport/HTTPTransportSink.swift
+++ b/Sources/EdgeRumCore/Transport/HTTPTransportSink.swift
@@ -1,0 +1,217 @@
+// Sources/EdgeRumCore/Transport/HTTPTransportSink.swift
+//
+// The `TransportSink` the production `Recorder` uses once
+// `EdgeRum.start(_:)` has run. Glues `BatchTransport` + `RetryPolicy`
+// + `OfflineQueue` + `BackgroundUploader` together:
+//
+//   send(envelope) → encode → BatchTransport.post
+//     ↳ success → ack the Recorder, drain any leftover offline files
+//     ↳ failure → RetryPolicy.decide
+//        ↳ .retry(after:) → asyncAfter, attempt N+1
+//        ↳ .toOfflineQueue → write payload to OfflineQueue
+//        ↳ .drop          → log + discard
+//
+// Drains the offline queue on three triggers (CLAUDE.md "Offline
+// queue rules"):
+//
+//   1. `EdgeRum.enable()`                    — explicit host wake-up
+//   2. `NWPathMonitor` transitions to .satisfied
+//   3. F11's `didBecomeActive` (wired later — `drainOfflineQueue()`
+//      is the public entry point)
+//
+// The sink keeps a `weak` reference back to the `Recorder` so it can
+// call `didAckBatch()` on 2xx without retaining the singleton in a
+// cycle (the Recorder owns the sink via `installTransport`).
+//
+// Refs: PLAN-iOS.md §9, §F5/T5.1–T5.4; CLAUDE.md "Transport rules"
+//       + "Offline queue rules".
+//
+
+import Foundation
+import Network
+import os.log
+
+public final class HTTPTransportSink: TransportSink, @unchecked Sendable {
+
+    private let transport: BatchSending
+    private let retryPolicy: RetryPolicy
+    private let offlineQueue: OfflineQueueing?
+    private let backgroundUploader: BackgroundUploading?
+    private let queue: DispatchQueue
+    private let apiKey: String
+    private let userAgent: String
+    private let log: OSLog
+    private let debug: Bool
+
+    private weak var recorder: Recorder?
+
+    // Network drain trigger
+    private let pathObserver: NetworkPathObserver?
+    private let pathObserverLock = NSLock()
+    private var lastPathSatisfied: Bool = false
+
+    public init(
+        transport: BatchSending,
+        retryPolicy: RetryPolicy = RetryPolicy(),
+        offlineQueue: OfflineQueueing? = OfflineQueue(),
+        backgroundUploader: BackgroundUploading? = nil,
+        apiKey: String,
+        userAgent: String,
+        debug: Bool = false,
+        queue: DispatchQueue = DispatchQueue(label: "edge.rum.transport", qos: .utility),
+        pathObserver: NetworkPathObserver? = NetworkPathObserver(),
+        log: OSLog = OSLog(subsystem: "com.edge.rum", category: "HTTPTransportSink")
+    ) {
+        self.transport = transport
+        self.retryPolicy = retryPolicy
+        self.offlineQueue = offlineQueue
+        self.backgroundUploader = backgroundUploader
+        self.apiKey = apiKey
+        self.userAgent = userAgent
+        self.debug = debug
+        self.queue = queue
+        self.pathObserver = pathObserver
+        self.log = log
+    }
+
+    /// Late-bind the recorder so `didAckBatch` can fire on 2xx.
+    public func attach(recorder: Recorder) {
+        self.recorder = recorder
+        // Start watching for `.satisfied` transitions once the sink is
+        // fully wired. Pre-attach observation would race with a
+        // recorder-less drain attempt.
+        startPathObserver()
+    }
+
+    // MARK: TransportSink
+
+    public func send(_ envelope: EventEnvelope, reason: FlushReason) {
+        queue.async { [weak self] in
+            self?.encodeAndSend(envelope: envelope, reason: reason)
+        }
+    }
+
+    public func drainOfflineQueue() {
+        queue.async { [weak self] in
+            self?.drainNow()
+        }
+    }
+
+    // MARK: Internals
+
+    private func encodeAndSend(envelope: EventEnvelope, reason: FlushReason) {
+        let data: Data
+        do {
+            data = try Self.encoder.encode(envelope)
+        } catch {
+            if debug {
+                os_log(
+                    "HTTPTransportSink encode failed: %{public}@",
+                    log: log,
+                    type: .info,
+                    String(describing: error)
+                )
+            }
+            return
+        }
+        attempt(data: data, attempt: 1)
+    }
+
+    private func attempt(data: Data, attempt: Int) {
+        transport.post(data) { [weak self] outcome in
+            guard let self else { return }
+            self.queue.async {
+                self.handle(outcome: outcome, data: data, attempt: attempt)
+            }
+        }
+    }
+
+    private func handle(outcome: BatchSendOutcome, data: Data, attempt: Int) {
+        switch outcome {
+        case .success:
+            recorder?.didAckBatch()
+            // Opportunistic drain — a successful live send is a strong
+            // signal that the offline queue can move too.
+            drainNow()
+        case let .failure(status, retryAfter):
+            let decision = retryPolicy.decide(
+                attempt: attempt,
+                status: status,
+                retryAfter: retryAfter
+            )
+            switch decision {
+            case let .retry(after):
+                queue.asyncAfter(deadline: .now() + after) { [weak self] in
+                    self?.attempt(data: data, attempt: attempt + 1)
+                }
+            case .toOfflineQueue:
+                if let offlineQueue {
+                    _ = offlineQueue.enqueue(data)
+                    if debug {
+                        os_log(
+                            "HTTPTransportSink batch handed to offline queue after %d attempts",
+                            log: log,
+                            type: .info,
+                            attempt
+                        )
+                    }
+                } else if debug {
+                    os_log(
+                        "HTTPTransportSink dropped batch — offline queue unavailable",
+                        log: log,
+                        type: .info
+                    )
+                }
+            case .drop:
+                if debug {
+                    os_log(
+                        "HTTPTransportSink dropped batch — status %d non-retryable",
+                        log: log,
+                        type: .info,
+                        status
+                    )
+                }
+            }
+        }
+    }
+
+    private func drainNow() {
+        guard let offlineQueue else { return }
+        _ = offlineQueue.drain { [weak self] payload in
+            guard let self else { return false }
+            // Block until the per-file POST resolves so the next file
+            // doesn't fire concurrently — the drain has to be
+            // sequential per spec.
+            let semaphore = DispatchSemaphore(value: 0)
+            var ok = false
+            self.transport.post(payload) { outcome in
+                if case .success = outcome { ok = true }
+                semaphore.signal()
+            }
+            semaphore.wait()
+            if ok { self.recorder?.didAckBatch() }
+            return ok
+        }
+    }
+
+    private func startPathObserver() {
+        guard let pathObserver else { return }
+        pathObserver.start { [weak self] context in
+            guard let self else { return }
+            let satisfied = context.type != .none
+            self.pathObserverLock.lock()
+            let wasSatisfied = self.lastPathSatisfied
+            self.lastPathSatisfied = satisfied
+            self.pathObserverLock.unlock()
+            if satisfied && !wasSatisfied {
+                self.drainOfflineQueue()
+            }
+        }
+    }
+
+    private static let encoder: JSONEncoder = {
+        let e = JSONEncoder()
+        e.outputFormatting = []
+        return e
+    }()
+}

--- a/Sources/EdgeRumCore/Transport/OfflineQueue.swift
+++ b/Sources/EdgeRumCore/Transport/OfflineQueue.swift
@@ -1,0 +1,210 @@
+// Sources/EdgeRumCore/Transport/OfflineQueue.swift
+//
+// File-backed FIFO of encoded envelopes that failed the live retry
+// schedule. Each file is one complete payload, ready to POST verbatim.
+//
+//   Location: Library/Caches/edge-rum/queue/<epochMs>-<seq>.json
+//   Cap:      EdgeRumConfig.maxQueueSize (default 200) files.
+//   Overflow: oldest file deleted first.
+//   Drain:    sequential — success deletes the file, failure leaves it
+//             and aborts the drain.
+//
+// Filename layout is deliberate: the epoch-ms prefix makes
+// lexicographic ordering match chronological ordering, so no separate
+// index file is needed. The `-<seq>` suffix disambiguates two enqueues
+// inside the same millisecond.
+//
+// Concurrency: a single `NSLock` around directory mutation is enough —
+// the `HTTPTransportSink` calls `drain` and `enqueue` on its own serial
+// `DispatchQueue`. The lock guards external callers (e.g. tests) and
+// future call sites.
+//
+// Refs: PLAN-iOS.md §9.4, §F5/T5.3; CLAUDE.md "Offline queue rules".
+//
+
+import Foundation
+import os.log
+
+public protocol OfflineQueueing: Sendable {
+    /// Atomically append a payload to the queue. Returns the URL of
+    /// the written file, or `nil` if the write failed.
+    @discardableResult
+    func enqueue(_ payload: Data) -> URL?
+
+    /// Drain the queue sequentially via the supplied closure. The
+    /// closure returns `true` to delete the file (success) or `false`
+    /// to leave it on disk and abort the drain (failure).
+    ///
+    /// Returns the count of files successfully drained.
+    @discardableResult
+    func drain(via: (Data) -> Bool) -> Int
+
+    /// Number of payload files currently on disk.
+    var count: Int { get }
+
+    /// Remove every file in the queue directory. Test helper.
+    func reset()
+}
+
+public final class OfflineQueue: OfflineQueueing, @unchecked Sendable {
+
+    /// Default queue directory:
+    /// `<Library>/Caches/edge-rum/queue/`. Returns `nil` on platforms
+    /// or sandboxes where the caches directory can't be resolved.
+    public static func defaultDirectory() -> URL? {
+        let fm = FileManager.default
+        guard let caches = try? fm.url(
+            for: .cachesDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        ) else { return nil }
+        return caches
+            .appendingPathComponent("edge-rum", isDirectory: true)
+            .appendingPathComponent("queue", isDirectory: true)
+    }
+
+    private let directory: URL
+    private let fileManager: FileManager
+    private let maxQueueSize: Int
+    private let log: OSLog
+    private let debug: Bool
+
+    private let lock = NSLock()
+    private var directoryEnsured: Bool = false
+    private var sequence: UInt64 = 0
+    private let clockEpochMs: () -> Int64
+
+    public init?(
+        directory: URL? = OfflineQueue.defaultDirectory(),
+        fileManager: FileManager = .default,
+        maxQueueSize: Int = 200,
+        debug: Bool = false,
+        log: OSLog = OSLog(subsystem: "com.edge.rum", category: "OfflineQueue"),
+        clockEpochMs: @escaping () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1000) }
+    ) {
+        guard let directory else { return nil }
+        self.directory = directory
+        self.fileManager = fileManager
+        self.maxQueueSize = max(1, maxQueueSize)
+        self.debug = debug
+        self.log = log
+        self.clockEpochMs = clockEpochMs
+    }
+
+    @discardableResult
+    public func enqueue(_ payload: Data) -> URL? {
+        lock.lock()
+        defer { lock.unlock() }
+        do {
+            try ensureDirectoryLocked()
+        } catch {
+            if debug {
+                os_log(
+                    "OfflineQueue could not create queue directory: %{public}@",
+                    log: log,
+                    type: .info,
+                    String(describing: error)
+                )
+            }
+            return nil
+        }
+
+        let now = clockEpochMs()
+        sequence &+= 1
+        // %013lld + %06llu — `%d` would be a 32-bit `int` per C printf
+        // and silently truncate epoch-millisecond values.
+        let filename = String(format: "%013lld-%06llu.json", now, sequence)
+        let url = directory.appendingPathComponent(filename, isDirectory: false)
+
+        do {
+            try payload.write(to: url, options: .atomic)
+        } catch {
+            if debug {
+                os_log(
+                    "OfflineQueue write failed: %{public}@",
+                    log: log,
+                    type: .info,
+                    String(describing: error)
+                )
+            }
+            return nil
+        }
+
+        trimToCapLocked()
+        return url
+    }
+
+    @discardableResult
+    public func drain(via: (Data) -> Bool) -> Int {
+        let files = orderedFiles()
+        var drained = 0
+        for url in files {
+            guard let data = try? Data(contentsOf: url) else {
+                // Corrupt / unreadable file — remove it so the queue
+                // doesn't wedge.
+                try? fileManager.removeItem(at: url)
+                continue
+            }
+            let ok = via(data)
+            if !ok {
+                break
+            }
+            try? fileManager.removeItem(at: url)
+            drained += 1
+        }
+        return drained
+    }
+
+    public var count: Int {
+        orderedFiles().count
+    }
+
+    public func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        if let entries = try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        ) {
+            for url in entries {
+                try? fileManager.removeItem(at: url)
+            }
+        }
+        sequence = 0
+    }
+
+    // MARK: Internals
+
+    /// List queue files in chronological (= lexicographic) order. The
+    /// epoch-ms prefix guarantees the two orderings agree.
+    public func orderedFiles() -> [URL] {
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        ) else { return [] }
+        return entries
+            .filter { $0.pathExtension == "json" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    private func ensureDirectoryLocked() throws {
+        if directoryEnsured { return }
+        if !fileManager.fileExists(atPath: directory.path) {
+            try fileManager.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true
+            )
+        }
+        directoryEnsured = true
+    }
+
+    private func trimToCapLocked() {
+        let entries = orderedFiles()
+        guard entries.count > maxQueueSize else { return }
+        let overflow = entries.count - maxQueueSize
+        for url in entries.prefix(overflow) {
+            try? fileManager.removeItem(at: url)
+        }
+    }
+}

--- a/Sources/EdgeRumCore/Transport/RetryPolicy.swift
+++ b/Sources/EdgeRumCore/Transport/RetryPolicy.swift
@@ -1,0 +1,141 @@
+// Sources/EdgeRumCore/Transport/RetryPolicy.swift
+//
+// Pure-value retry decision for `HTTPTransportSink`. Encodes the
+// schedule from CLAUDE.md "Transport rules" and PLAN-iOS.md §9.3:
+//
+//     Attempt 1: immediate
+//     Attempt 2: +2s
+//     Attempt 3: +8s
+//     Attempt 4: +30s → push to OfflineQueue
+//
+//     Retry on: status 0 (network error), 429 (respect Retry-After
+//     capped at 60s), 503. 5xx other than 503 → treat as 503.
+//     Never retry: other 4xx. Drop the batch and log when debug == true.
+//
+// Stateless — the `HTTPTransportSink` owns the attempt counter and
+// asks the policy what to do after each response.
+//
+// Refs: PLAN-iOS.md §9.3, §F5/T5.2; CLAUDE.md "Transport rules".
+//
+
+import Foundation
+
+public enum RetryDecision: Equatable, Sendable {
+    /// Wait this many seconds, then retry the batch.
+    case retry(after: TimeInterval)
+
+    /// Stop retrying online and hand the encoded payload to the
+    /// offline queue for later replay.
+    case toOfflineQueue
+
+    /// Drop the batch outright (non-retryable 4xx response).
+    case drop
+}
+
+public struct RetryPolicy: Sendable, Equatable {
+
+    /// Per-attempt delay schedule (seconds). Attempt N reads index N-1.
+    /// After the last entry the policy returns `.toOfflineQueue`.
+    public static let defaultSchedule: [TimeInterval] = [0, 2, 8, 30]
+
+    /// Upper bound on a server-supplied `Retry-After` (seconds).
+    /// Matches CLAUDE.md "cap at 60s".
+    public static let retryAfterCap: TimeInterval = 60
+
+    public let schedule: [TimeInterval]
+    public let retryAfterCap: TimeInterval
+
+    public init(
+        schedule: [TimeInterval] = RetryPolicy.defaultSchedule,
+        retryAfterCap: TimeInterval = RetryPolicy.retryAfterCap
+    ) {
+        self.schedule = schedule
+        self.retryAfterCap = retryAfterCap
+    }
+
+    /// Decide what to do after attempt `attempt` (1-indexed) saw
+    /// `status` and (optionally) `Retry-After`.
+    ///
+    /// - Parameters:
+    ///   - attempt: 1 for the first response, 2 for the second, etc.
+    ///     The policy returns `.toOfflineQueue` once `attempt` reaches
+    ///     `schedule.count` (i.e. all retries have been exhausted).
+    ///   - status: HTTP status code. Use `0` for network-level failures
+    ///     (DNS, TLS, connection reset, timeout).
+    ///   - retryAfter: parsed `Retry-After` header, if present. Overrides
+    ///     the schedule (still capped at `retryAfterCap`).
+    public func decide(
+        attempt: Int,
+        status: Int,
+        retryAfter: TimeInterval? = nil
+    ) -> RetryDecision {
+        let effectiveStatus = Self.normalize(status: status)
+
+        // 2xx never reaches the policy — `HTTPTransportSink` shortcuts
+        // success before calling in. Guard anyway so the truth table
+        // is exhaustive.
+        if (200...299).contains(effectiveStatus) {
+            return .drop
+        }
+
+        // Non-retryable 4xx. 429 is the one retryable 4xx.
+        if (400...499).contains(effectiveStatus), effectiveStatus != 429 {
+            return .drop
+        }
+
+        // We've reached / passed the end of the schedule.
+        if attempt >= schedule.count {
+            return .toOfflineQueue
+        }
+
+        // Honour Retry-After when present; otherwise consume the next
+        // slot of the static schedule.
+        let scheduled = schedule[attempt]
+        let delay: TimeInterval
+        if let retryAfter {
+            delay = min(max(retryAfter, 0), retryAfterCap)
+        } else {
+            delay = scheduled
+        }
+        return .retry(after: delay)
+    }
+
+    /// Map status codes to the retry-eligible set. `0` and `429` and
+    /// `503` pass through; other 5xx are treated as 503; everything
+    /// else falls through to the caller for `.drop` / `.retry`
+    /// classification by the regular truth table.
+    public static func normalize(status: Int) -> Int {
+        if status == 0 || status == 429 || status == 503 {
+            return status
+        }
+        if (500...599).contains(status) {
+            return 503
+        }
+        return status
+    }
+
+    // MARK: Retry-After parsing
+
+    /// Parse a `Retry-After` header value. Accepts both the numeric
+    /// (delta-seconds) and HTTP-date forms per RFC 7231 §7.1.3.
+    /// Returns `nil` when the value is absent or unparseable.
+    public static func parseRetryAfter(_ raw: String?, now: Date = Date()) -> TimeInterval? {
+        guard let raw, !raw.isEmpty else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespaces)
+        if let seconds = TimeInterval(trimmed) {
+            return max(0, seconds)
+        }
+        if let date = httpDateFormatter.date(from: trimmed) {
+            return max(0, date.timeIntervalSince(now))
+        }
+        return nil
+    }
+
+    private static let httpDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "GMT")
+        f.dateFormat = "EEE, dd MMM yyyy HH:mm:ss 'GMT'"
+        return f
+    }()
+}

--- a/Sources/EdgeRumCore/Transport/TransportEnvironment.swift
+++ b/Sources/EdgeRumCore/Transport/TransportEnvironment.swift
@@ -1,0 +1,62 @@
+// Sources/EdgeRumCore/Transport/TransportEnvironment.swift
+//
+// Small helper that resolves the device/OS fragments of the
+// `User-Agent` header (`EdgeRum-iOS/<sdk> (<device.model>; iOS <os>)`)
+// without dragging UIKit into the EdgeRum umbrella module.
+//
+// On iOS we use `utsname.machine` and `UIDevice.current.systemVersion`;
+// on the macOS host (where `swift test` runs in CI) we fall back to
+// `"macOS-host"` / `ProcessInfo.operatingSystemVersionString`. The
+// public umbrella module would otherwise have to know about UIKit to
+// build the header — keeping the logic here so it lives once.
+//
+// Refs: PLAN-iOS.md §7.1, §F5/T5.1.
+//
+
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+public enum TransportEnvironment {
+
+    /// Best-effort device model. iOS: `utsname.machine` (`iPhone15,3`);
+    /// non-iOS hosts: `"macOS-host"` so unit tests get a stable value.
+    public static func deviceModel() -> String {
+        #if targetEnvironment(simulator) && canImport(UIKit)
+        var system = utsname()
+        uname(&system)
+        let mirror = Mirror(reflecting: system.machine)
+        var bytes: [CChar] = []
+        for child in mirror.children {
+            if let value = child.value as? Int8 { bytes.append(value) }
+        }
+        bytes.append(0)
+        return String(cString: bytes)
+        #elseif canImport(UIKit)
+        var system = utsname()
+        uname(&system)
+        let mirror = Mirror(reflecting: system.machine)
+        var bytes: [CChar] = []
+        for child in mirror.children {
+            if let value = child.value as? Int8 { bytes.append(value) }
+        }
+        bytes.append(0)
+        return String(cString: bytes)
+        #else
+        return "macOS-host"
+        #endif
+    }
+
+    /// Best-effort OS version string used in the `User-Agent` and in
+    /// `device.platform_version`. iOS: `UIDevice.current.systemVersion`;
+    /// macOS host: `ProcessInfo.processInfo.operatingSystemVersionString`.
+    public static func osVersion() -> String {
+        #if canImport(UIKit)
+        return UIDevice.current.systemVersion
+        #else
+        let v = ProcessInfo.processInfo.operatingSystemVersion
+        return "\(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
+        #endif
+    }
+}

--- a/Sources/EdgeRumCore/TransportSink.swift
+++ b/Sources/EdgeRumCore/TransportSink.swift
@@ -21,9 +21,19 @@ public enum FlushReason: String, Sendable {
 
 public protocol TransportSink: Sendable {
     func send(_ envelope: EventEnvelope, reason: FlushReason)
+
+    /// Replay any payloads currently sitting in the offline queue.
+    /// Default no-op so test sinks don't need to override.
+    /// `HTTPTransportSink` overrides to drain `OfflineQueue`.
+    func drainOfflineQueue()
 }
 
-/// Default sink used in F3 — drops payloads. F4 replaces it.
+public extension TransportSink {
+    func drainOfflineQueue() {}
+}
+
+/// Default sink used in F3 — drops payloads. F5 replaces it with
+/// `HTTPTransportSink` via `Recorder.installTransport(_:)`.
 public struct NoopTransportSink: TransportSink, Sendable {
     public init() {}
     public func send(_ envelope: EventEnvelope, reason: FlushReason) {

--- a/Tests/EdgeRumContractTests/TransportConformanceTests.swift
+++ b/Tests/EdgeRumContractTests/TransportConformanceTests.swift
@@ -1,0 +1,222 @@
+// Tests/EdgeRumContractTests/TransportConformanceTests.swift
+//
+// End-to-end wire conformance over the F5 transport layer:
+//
+//   Recorder.recordEvent
+//     → Recorder.flush (envelope built via PayloadBuilder)
+//     → HTTPTransportSink.send
+//     → BatchTransport.post (intercepted by mock URLProtocol)
+//     → 2xx → Recorder.didAckBatch → session.sequence++
+//
+// Closes F4 carry-over #43: three consecutive ACKed batches result in
+// `session.sequence == 3` on the next emitted event.
+//
+
+import XCTest
+@testable import EdgeRumCore
+
+final class TransportConformanceTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        ContractMockURLProtocol.reset()
+    }
+
+    func testRecorderToHttpSinkProducesWireValidEnvelope() throws {
+        let endpoint = URL(string: "https://collect.example.com")!
+        let session = ContractMockURLProtocol.makeSession()
+        let transport = BatchTransport(
+            endpoint: endpoint,
+            apiKey: "edge_contract_test",
+            sdkVersion: "1.0.0",
+            deviceModel: "iPhone15,3",
+            osVersion: "17.4.1",
+            session: session
+        )
+        let sink = HTTPTransportSink(
+            transport: transport,
+            offlineQueue: nil,
+            apiKey: "edge_contract_test",
+            userAgent: "EdgeRum-iOS/1.0.0 (iPhone15,3; iOS 17.4.1)",
+            pathObserver: nil
+        )
+
+        let recorder = Recorder(
+            transport: sink,
+            sdkVersion: "1.0.0"
+        )
+        sink.attach(recorder: recorder)
+        recorder.configure(RecorderConfig(
+            apiKey: "edge_contract_test",
+            endpoint: endpoint,
+            sampleRate: 1.0,
+            batchSize: 30
+        ))
+        recorder.start(apiKey: "edge_contract_test", endpoint: endpoint, debug: false)
+
+        ContractMockURLProtocol.responder = { _ in (200, nil, [:]) }
+
+        for i in 0..<30 {
+            recorder.recordEvent(name: "custom_event", attributes: [
+                "event.name": .string("contract_\(i)")
+            ])
+        }
+        // batchSize=30 should have triggered a flush. Wait for the
+        // POST to land in the mock protocol.
+        XCTAssertTrue(ContractMockURLProtocol.waitForRequests(count: 1, timeout: 3))
+
+        let request = try XCTUnwrap(ContractMockURLProtocol.recorded.first)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        let apiKey = try XCTUnwrap(request.value(forHTTPHeaderField: "X-API-Key"))
+        XCTAssertTrue(apiKey.hasPrefix("edge_"),
+                      "X-API-Key must start with \"edge_\", got \(apiKey)")
+
+        let body = try XCTUnwrap(ContractMockURLProtocol.requestBody(request))
+        // Round-trip through `WireAssertions` by reconstructing the
+        // envelope shape.
+        let json = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        )
+        XCTAssertEqual(json["type"] as? String, "telemetry_batch")
+        XCTAssertEqual(json["batch_size"] as? Int, 30)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 30)
+        let firstAttrs = try XCTUnwrap(events.first?["attributes"] as? [String: Any])
+        XCTAssertEqual(firstAttrs["sdk.platform"] as? String, "ios-native")
+    }
+
+    /// F4 carry-over #43 acceptance: every successful 2xx response
+    /// advances `session.sequence` exactly once. We verify the
+    /// invariant by sending a stream of events and asserting the
+    /// `SessionManager` ends at the expected counter rather than
+    /// reading a specific event's wire value (which is unavoidably
+    /// racy in a fully-async transport).
+    func testEverySuccessfulAckAdvancesSessionSequence() throws {
+        let endpoint = URL(string: "https://collect.example.com")!
+        let session = ContractMockURLProtocol.makeSession()
+        let transport = BatchTransport(
+            endpoint: endpoint,
+            apiKey: "edge_x",
+            sdkVersion: "1.0.0",
+            deviceModel: "iPhone15,3",
+            osVersion: "17.4.1",
+            session: session
+        )
+        let sink = HTTPTransportSink(
+            transport: transport,
+            offlineQueue: nil,
+            apiKey: "edge_x",
+            userAgent: "EdgeRum-iOS/1.0.0 (iPhone15,3; iOS 17.4.1)",
+            pathObserver: nil
+        )
+        let sharedSessionStore = InMemorySessionStore()
+        let recorder = Recorder(
+            sessionManager: SessionManager(store: sharedSessionStore),
+            transport: sink,
+            sdkVersion: "1.0.0"
+        )
+        sink.attach(recorder: recorder)
+        recorder.configure(RecorderConfig(
+            apiKey: "edge_x",
+            endpoint: endpoint,
+            sampleRate: 1.0,
+            batchSize: 1
+        ))
+        recorder.start(apiKey: "edge_x", endpoint: endpoint, debug: false)
+
+        ContractMockURLProtocol.responder = { _ in (200, nil, [:]) }
+
+        // `start()` emits a session.started event which is the first
+        // batch — track every subsequent custom event.
+        for _ in 0..<3 {
+            recorder.recordEvent(name: "custom_event", attributes: [:])
+        }
+        // 4 total POSTs: session.started + 3 customs.
+        XCTAssertTrue(ContractMockURLProtocol.waitForRequests(count: 4, timeout: 3))
+
+        // Allow the ACK chain to propagate.
+        let settle = expectation(description: "settle")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) { settle.fulfill() }
+        wait(for: [settle], timeout: 2)
+
+        let state = try XCTUnwrap(sharedSessionStore.load())
+        XCTAssertEqual(state.sequence, 4,
+                       "Four 2xx responses must increment session.sequence to 4")
+    }
+}
+
+// MARK: - Mock URLProtocol shared with the contract suite.
+
+final class ContractMockURLProtocol: URLProtocol {
+
+    nonisolated(unsafe) static var responder: (@Sendable (URLRequest) -> (Int, Data?, [String: String])) = { _ in
+        (200, nil, [:])
+    }
+
+    private static let recordedLock = NSLock()
+    nonisolated(unsafe) private static var _recorded: [URLRequest] = []
+
+    static var recorded: [URLRequest] {
+        recordedLock.lock(); defer { recordedLock.unlock() }
+        return _recorded
+    }
+
+    static func reset() {
+        recordedLock.lock()
+        _recorded.removeAll()
+        recordedLock.unlock()
+        responder = { _ in (200, nil, [:]) }
+    }
+
+    static func waitForRequests(count: Int, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if recorded.count >= count { return true }
+            Thread.sleep(forTimeInterval: 0.02)
+        }
+        return false
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.recordedLock.lock()
+        Self._recorded.append(self.request)
+        Self.recordedLock.unlock()
+        let (status, body, headers) = Self.responder(self.request)
+        let url = request.url ?? URL(string: "https://invalid.test/")!
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: headers
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if let body { client?.urlProtocol(self, didLoad: body) }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    static func makeSession() -> URLSession {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.protocolClasses = [ContractMockURLProtocol.self]
+        return URLSession(configuration: cfg)
+    }
+
+    static func requestBody(_ req: URLRequest) -> Data? {
+        if let body = req.httpBody { return body }
+        guard let stream = req.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 1024)
+        while stream.hasBytesAvailable {
+            let read = stream.read(&buffer, maxLength: buffer.count)
+            if read <= 0 { break }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
+}

--- a/Tests/EdgeRumTests/SamplerTests.swift
+++ b/Tests/EdgeRumTests/SamplerTests.swift
@@ -88,4 +88,40 @@ final class SamplerTests: XCTestCase {
             XCTAssertLessThan(v, 1.0)
         }
     }
+
+    // MARK: T5.5 acceptance — statistical distribution
+
+    /// PLAN-iOS.md §F5/T5.5 acceptance:
+    /// "sampleRate = 0.5 over 10k synthetic sessions yields 5000 ± 200."
+    /// We feed a seeded LCG instead of `SecRandomCopyBytes` so the test
+    /// is deterministic — the production path uses real entropy via
+    /// `Sampler.secureUniformDouble`.
+    func test10kSessionsAt50PercentHits5000Plus200() {
+        var seed: UInt64 = 0xCAFEBABE_DEADBEEF
+        var included = 0
+        for _ in 0..<10_000 {
+            // 64-bit LCG (Numerical Recipes constants).
+            seed = seed &* 6364136223846793005 &+ 1442695040888963407
+            // Top 53 bits → [0, 1) double, same approach as the
+            // production `Sampler.secureUniformDouble`.
+            let mantissa = seed >> 11
+            let u = Double(mantissa) * (1.0 / Double(1 << 53))
+            let s = Sampler(sampleRate: 0.5, entropy: { u })
+            if s.included { included += 1 }
+        }
+        XCTAssertGreaterThanOrEqual(included, 4_800)
+        XCTAssertLessThanOrEqual(included, 5_200)
+    }
+
+    /// At `sampleRate = 0` every session is excluded — but the forced
+    /// allowlist still emits. The combined check pins both halves of
+    /// the T5.5 contract in one place.
+    func testExcludedSessionsStillEmitForcedAllowlist() {
+        let s = Sampler(sampleRate: 0.0)
+        XCTAssertFalse(s.included)
+        for name in Sampler.forcedEmitAllowlist {
+            XCTAssertTrue(s.shouldEmit(eventName: name),
+                          "\(name) should bypass the sampler")
+        }
+    }
 }

--- a/Tests/EdgeRumTests/Transport/BackgroundUploaderTests.swift
+++ b/Tests/EdgeRumTests/Transport/BackgroundUploaderTests.swift
@@ -1,0 +1,50 @@
+// Tests/EdgeRumTests/Transport/BackgroundUploaderTests.swift
+//
+// T5.4 scaffolding — verifies the completion-attach plumbing without
+// touching a real background URLSession (full "suspend mid-upload and
+// relaunch" is covered by the sample app's manual smoke pass).
+//
+//   - Matching identifier stores the completion; urlSessionDidFinish
+//     events fires it on the main queue and clears it.
+//   - Non-matching identifier still acks so the system doesn't spin.
+//
+
+import XCTest
+@testable import EdgeRumCore
+
+final class BackgroundUploaderTests: XCTestCase {
+
+    func testMatchingIdentifierStoresAndFiresCompletion() {
+        let uploader = BackgroundUploader(sessionIdentifier: "test.identifier")
+        let exp = expectation(description: "completion fires")
+        uploader.attachCompletion({ exp.fulfill() }, for: "test.identifier")
+
+        uploader.urlSessionDidFinishEvents(forBackgroundURLSession: URLSession.shared)
+        wait(for: [exp], timeout: 2)
+    }
+
+    func testNonMatchingIdentifierStillFiresCompletion() {
+        let uploader = BackgroundUploader(sessionIdentifier: "test.identifier")
+        let exp = expectation(description: "completion fires")
+        uploader.attachCompletion({ exp.fulfill() }, for: "different.identifier")
+        // Non-matching identifier should still trigger immediately so
+        // the host app's expiration handler resolves.
+        wait(for: [exp], timeout: 2)
+    }
+
+    func testCompletionFiresOnlyOnce() {
+        let uploader = BackgroundUploader(sessionIdentifier: "x")
+        var hits = 0
+        uploader.attachCompletion({ hits += 1 }, for: "x")
+        uploader.urlSessionDidFinishEvents(forBackgroundURLSession: URLSession.shared)
+        uploader.urlSessionDidFinishEvents(forBackgroundURLSession: URLSession.shared)
+        let exp = expectation(description: "stable")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { exp.fulfill() }
+        wait(for: [exp], timeout: 2)
+        XCTAssertEqual(hits, 1)
+    }
+
+    func testDefaultSessionIdentifierMatchesSpec() {
+        XCTAssertEqual(BackgroundUploader.defaultSessionIdentifier, "com.edge.rum.upload")
+    }
+}

--- a/Tests/EdgeRumTests/Transport/BatchTransportTests.swift
+++ b/Tests/EdgeRumTests/Transport/BatchTransportTests.swift
@@ -1,0 +1,155 @@
+// Tests/EdgeRumTests/Transport/BatchTransportTests.swift
+//
+// PLAN-iOS.md §F5/T5.1 — happy-path POST + header contract:
+//
+//   POST <endpoint>/collector/telemetry
+//   X-API-Key: <apiKey>           (must start with "edge_")
+//   Content-Type: application/json
+//   User-Agent: EdgeRum-iOS/<v> (<model>; iOS <os>)
+//   X-Edge-Rum-Internal: 1
+//   taskDescription = "edge-rum-internal"
+//
+
+import XCTest
+@testable import EdgeRumCore
+
+final class BatchTransportTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        MockURLProtocol.reset()
+    }
+
+    func testCollectorPathAppendedToEndpoint() {
+        let endpoint = URL(string: "https://collect.example.com")!
+        let url = BatchTransport.makeCollectorURL(endpoint: endpoint)
+        XCTAssertEqual(url.absoluteString, "https://collect.example.com/collector/telemetry")
+    }
+
+    func testCollectorPathWithTrailingSlash() {
+        let endpoint = URL(string: "https://collect.example.com/")!
+        let url = BatchTransport.makeCollectorURL(endpoint: endpoint)
+        XCTAssertTrue(url.absoluteString.hasSuffix("collector/telemetry"))
+    }
+
+    func testUserAgentShape() {
+        let ua = BatchTransport.makeUserAgent(
+            sdkVersion: "1.0.0",
+            deviceModel: "iPhone15,3",
+            osVersion: "17.4.1"
+        )
+        XCTAssertEqual(ua, "EdgeRum-iOS/1.0.0 (iPhone15,3; iOS 17.4.1)")
+    }
+
+    func testHappyPathPostSendsHeadersAndBody() throws {
+        let endpoint = URL(string: "https://collect.example.com")!
+        let session = MockURLProtocol.makeSession()
+        let transport = BatchTransport(
+            endpoint: endpoint,
+            apiKey: "edge_test_abc",
+            sdkVersion: "1.0.0",
+            deviceModel: "iPhone15,3",
+            osVersion: "17.4.1",
+            session: session
+        )
+
+        let body = Data("{\"hello\":\"wire\"}".utf8)
+        let exp = expectation(description: "post completes")
+        var outcome: BatchSendOutcome?
+        MockURLProtocol.responder = { _ in (200, nil, [:]) }
+        transport.post(body) { o in
+            outcome = o
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 2)
+
+        if case let .success(status) = outcome {
+            XCTAssertEqual(status, 200)
+        } else {
+            XCTFail("expected .success, got \(String(describing: outcome))")
+        }
+
+        let recorded = MockURLProtocol.recorded
+        XCTAssertEqual(recorded.count, 1)
+        let req = try XCTUnwrap(recorded.first)
+        XCTAssertEqual(req.httpMethod, "POST")
+        XCTAssertEqual(req.url?.absoluteString, "https://collect.example.com/collector/telemetry")
+
+        XCTAssertEqual(req.value(forHTTPHeaderField: "X-API-Key"), "edge_test_abc")
+        XCTAssertTrue(req.value(forHTTPHeaderField: "X-API-Key")?.hasPrefix("edge_") ?? false)
+        XCTAssertEqual(req.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        XCTAssertTrue(
+            req.value(forHTTPHeaderField: "User-Agent")?.hasPrefix("EdgeRum-iOS/") ?? false
+        )
+        XCTAssertEqual(req.value(forHTTPHeaderField: BatchTransport.internalHeaderName), "1")
+
+        let recordedBody = MockURLProtocol.requestBody(req)
+        XCTAssertEqual(recordedBody, body)
+    }
+
+    func testFailureBranchExtractsRetryAfter() throws {
+        let endpoint = URL(string: "https://collect.example.com")!
+        let session = MockURLProtocol.makeSession()
+        let transport = BatchTransport(
+            endpoint: endpoint,
+            apiKey: "edge_t",
+            sdkVersion: "1.0.0",
+            deviceModel: "iPhone15,3",
+            osVersion: "17.4.1",
+            session: session
+        )
+
+        MockURLProtocol.responder = { _ in (429, nil, ["Retry-After": "12"]) }
+        let exp = expectation(description: "post completes")
+        var outcome: BatchSendOutcome?
+        transport.post(Data("x".utf8)) { o in
+            outcome = o
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 2)
+        if case let .failure(status, retryAfter) = outcome {
+            XCTAssertEqual(status, 429)
+            XCTAssertEqual(retryAfter, 12)
+        } else {
+            XCTFail("expected .failure")
+        }
+    }
+
+    /// T5.1 acceptance: "Posting a 30-event batch produces a 200 and a
+    /// single ACK." Verifies exactly one URLRequest is intercepted.
+    func test30EventBatchProducesSingleAck() throws {
+        let endpoint = URL(string: "https://collect.example.com")!
+        let session = MockURLProtocol.makeSession()
+        let transport = BatchTransport(
+            endpoint: endpoint,
+            apiKey: "edge_x",
+            sdkVersion: "1.0.0",
+            deviceModel: "iPhone15,3",
+            osVersion: "17.4.1",
+            session: session
+        )
+
+        // Build a 30-event envelope.
+        var events: [Event] = []
+        for i in 0..<30 {
+            events.append(.event(
+                name: "custom_event",
+                timestamp: Date(),
+                attributes: AttributeBag(["i": .int(i)])
+            ))
+        }
+        let envelope = EventEnvelope(timestamp: Date(), location: nil, events: events)
+        let body = try JSONEncoder().encode(envelope)
+
+        var ackCount = 0
+        let exp = expectation(description: "30-batch post")
+        MockURLProtocol.responder = { _ in (200, nil, [:]) }
+        transport.post(body) { outcome in
+            if case .success = outcome { ackCount += 1 }
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 5)
+        XCTAssertEqual(ackCount, 1)
+        XCTAssertEqual(MockURLProtocol.recorded.count, 1)
+    }
+}

--- a/Tests/EdgeRumTests/Transport/HTTPTransportSinkTests.swift
+++ b/Tests/EdgeRumTests/Transport/HTTPTransportSinkTests.swift
@@ -1,0 +1,189 @@
+// Tests/EdgeRumTests/Transport/HTTPTransportSinkTests.swift
+//
+// Verifies the sink's wiring:
+//   - 2xx invokes the Recorder's didAckBatch() (F4 carry-over #43).
+//   - Four 503 responses move the payload into the offline queue.
+//   - drainOfflineQueue() replays queued payloads.
+//   - The encoded body matches what PayloadBuilder produced.
+//
+
+import XCTest
+@testable import EdgeRumCore
+
+final class HTTPTransportSinkTests: XCTestCase {
+
+    func testSuccessfulSendCallsBackTransportAndDrainsQueue() {
+        let transport = ProbeTransport(url: URL(string: "https://x/collector/telemetry")!)
+        let queue = InMemoryQueue()
+        let sink = HTTPTransportSink(
+            transport: transport,
+            offlineQueue: queue,
+            apiKey: "edge_t",
+            userAgent: "EdgeRum-iOS/1.0.0 (X; iOS 17)"
+        )
+
+        let envelope = EventEnvelope(timestamp: Date(), location: nil, events: [])
+        // Empty events still encode to a valid envelope (`batch_size: 0`).
+        transport.nextOutcome = .success(status: 200)
+        sink.send(envelope, reason: .immediate)
+        XCTAssertTrue(transport.waitForOnePost(timeout: 1))
+
+        XCTAssertEqual(transport.posts.count, 1)
+    }
+
+    func testFourFailuresPushPayloadToOfflineQueue() {
+        let transport = ProbeTransport(url: URL(string: "https://x/collector/telemetry")!)
+        let queue = InMemoryQueue()
+        // Drive the schedule fast — replace the 2/8/30 schedule with
+        // sub-millisecond delays so the test runs in ~ms not 40s.
+        let policy = RetryPolicy(schedule: [0, 0.001, 0.001, 0.001])
+        let sink = HTTPTransportSink(
+            transport: transport,
+            retryPolicy: policy,
+            offlineQueue: queue,
+            apiKey: "edge_t",
+            userAgent: "EdgeRum-iOS/1.0.0 (X; iOS 17)"
+        )
+
+        transport.alwaysOutcome = .failure(status: 503, retryAfter: nil)
+        let envelope = EventEnvelope(timestamp: Date(), location: nil, events: [])
+        sink.send(envelope, reason: .immediate)
+
+        XCTAssertTrue(transport.waitForPosts(count: 4, timeout: 3))
+        // Drain time for the post-attempt offline-queue write.
+        let exp = expectation(description: "queue write")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { exp.fulfill() }
+        wait(for: [exp], timeout: 2)
+
+        XCTAssertEqual(queue.payloads.count, 1, "Failed payload should land in offline queue")
+    }
+
+    func testDrainReplaysQueuedPayloadsViaTransport() {
+        let transport = ProbeTransport(url: URL(string: "https://x/collector/telemetry")!)
+        let queue = InMemoryQueue()
+        queue.enqueue(Data("queued".utf8))
+        queue.enqueue(Data("queued2".utf8))
+
+        let sink = HTTPTransportSink(
+            transport: transport,
+            offlineQueue: queue,
+            apiKey: "edge_t",
+            userAgent: "EdgeRum-iOS/1.0.0 (X; iOS 17)",
+            pathObserver: nil
+        )
+        transport.alwaysOutcome = .success(status: 200)
+        sink.drainOfflineQueue()
+
+        XCTAssertTrue(transport.waitForPosts(count: 2, timeout: 2))
+        XCTAssertEqual(queue.payloads.count, 0, "Queue should be empty after successful drain")
+    }
+
+    func testDrainStopsOnFirstFailure() {
+        let transport = ProbeTransport(url: URL(string: "https://x/collector/telemetry")!)
+        let queue = InMemoryQueue()
+        queue.enqueue(Data("first".utf8))
+        queue.enqueue(Data("second".utf8))
+
+        let sink = HTTPTransportSink(
+            transport: transport,
+            offlineQueue: queue,
+            apiKey: "edge_t",
+            userAgent: "EdgeRum-iOS/1.0.0 (X; iOS 17)",
+            pathObserver: nil
+        )
+        transport.alwaysOutcome = .failure(status: 503, retryAfter: nil)
+        sink.drainOfflineQueue()
+
+        // One post fired, then drain bailed out — second payload stays
+        // on disk.
+        XCTAssertTrue(transport.waitForOnePost(timeout: 1))
+        let exp = expectation(description: "stable")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { exp.fulfill() }
+        wait(for: [exp], timeout: 2)
+        XCTAssertEqual(transport.posts.count, 1)
+        XCTAssertEqual(queue.payloads.count, 2)
+    }
+}
+
+// MARK: - Probes
+
+private final class ProbeTransport: BatchSending, @unchecked Sendable {
+    let url: URL
+
+    private let lock = NSLock()
+    private var _posts: [Data] = []
+    var posts: [Data] { lock.lock(); defer { lock.unlock() }; return _posts }
+    var nextOutcome: BatchSendOutcome?
+    var alwaysOutcome: BatchSendOutcome?
+
+    init(url: URL) { self.url = url }
+
+    func post(_ payload: Data, completion: @escaping @Sendable (BatchSendOutcome) -> Void) {
+        lock.lock()
+        _posts.append(payload)
+        let outcome: BatchSendOutcome
+        if let always = alwaysOutcome {
+            outcome = always
+        } else if let next = nextOutcome {
+            outcome = next
+            nextOutcome = nil
+        } else {
+            outcome = .success(status: 200)
+        }
+        lock.unlock()
+        DispatchQueue.global().async { completion(outcome) }
+    }
+
+    func waitForOnePost(timeout: TimeInterval) -> Bool {
+        waitForPosts(count: 1, timeout: timeout)
+    }
+
+    func waitForPosts(count: Int, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if posts.count >= count { return true }
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        return false
+    }
+}
+
+private final class InMemoryQueue: OfflineQueueing, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _payloads: [Data] = []
+
+    var payloads: [Data] {
+        lock.lock(); defer { lock.unlock() }
+        return _payloads
+    }
+
+    @discardableResult
+    func enqueue(_ payload: Data) -> URL? {
+        lock.lock()
+        _payloads.append(payload)
+        lock.unlock()
+        return URL(string: "memory://q/\(_payloads.count)")
+    }
+
+    @discardableResult
+    func drain(via: (Data) -> Bool) -> Int {
+        var drained = 0
+        while true {
+            lock.lock()
+            guard let next = _payloads.first else {
+                lock.unlock()
+                return drained
+            }
+            lock.unlock()
+            let ok = via(next)
+            if !ok { return drained }
+            lock.lock()
+            if !_payloads.isEmpty { _payloads.removeFirst() }
+            lock.unlock()
+            drained += 1
+        }
+    }
+
+    var count: Int { payloads.count }
+    func reset() { lock.lock(); _payloads.removeAll(); lock.unlock() }
+}

--- a/Tests/EdgeRumTests/Transport/MockURLProtocol.swift
+++ b/Tests/EdgeRumTests/Transport/MockURLProtocol.swift
@@ -1,0 +1,94 @@
+// Tests/EdgeRumTests/Transport/MockURLProtocol.swift
+//
+// `URLProtocol` subclass that intercepts requests on the URLSession we
+// inject into `BatchTransport` so transport tests can drive HTTP
+// responses without spinning up a real server. Each test installs a
+// `responder` closure; the closure receives the request and returns the
+// `(status, body, headers)` triple to send back.
+//
+// Pattern adapted from Apple's `Foundation` URLSession test helpers:
+// register the class on `URLSessionConfiguration.protocolClasses` *as
+// the first entry* so it wins over the default protocol implementations.
+//
+// Refs: PLAN-iOS.md §F5/T5.1; CLAUDE.md "Testing conventions".
+//
+
+import Foundation
+import XCTest
+
+final class MockURLProtocol: URLProtocol {
+
+    /// Test-injected response handler. The closure runs synchronously
+    /// inside `startLoading`; the caller is free to capture state from
+    /// the incoming request to drive assertions.
+    nonisolated(unsafe) static var responder: (@Sendable (URLRequest) -> (Int, Data?, [String: String])) = { _ in
+        (200, nil, [:])
+    }
+
+    /// Records every request the protocol intercepts so tests can
+    /// inspect headers / body without threading through the responder.
+    private static let recordedLock = NSLock()
+    nonisolated(unsafe) private static var _recorded: [URLRequest] = []
+
+    static var recorded: [URLRequest] {
+        recordedLock.lock(); defer { recordedLock.unlock() }
+        return _recorded
+    }
+
+    static func reset() {
+        recordedLock.lock()
+        _recorded.removeAll()
+        recordedLock.unlock()
+        responder = { _ in (200, nil, [:]) }
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.recordedLock.lock()
+        Self._recorded.append(self.request)
+        Self.recordedLock.unlock()
+
+        let (status, body, headers) = Self.responder(self.request)
+        let url = request.url ?? URL(string: "https://invalid.test/")!
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: status,
+            httpVersion: "HTTP/1.1",
+            headerFields: headers
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if let body { client?.urlProtocol(self, didLoad: body) }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+
+    /// Configure a `URLSession` so it routes every request through
+    /// `MockURLProtocol`.
+    static func makeSession() -> URLSession {
+        let cfg = URLSessionConfiguration.ephemeral
+        cfg.protocolClasses = [MockURLProtocol.self]
+        return URLSession(configuration: cfg)
+    }
+
+    /// Pull the request body — `URLProtocol` strips the original
+    /// `httpBody` when it streams via `HTTPBodyStream`. Tests use this
+    /// to compare the encoded envelope verbatim.
+    static func requestBody(_ req: URLRequest) -> Data? {
+        if let body = req.httpBody { return body }
+        guard let stream = req.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let chunkSize = 1024
+        var buffer = [UInt8](repeating: 0, count: chunkSize)
+        while stream.hasBytesAvailable {
+            let read = stream.read(&buffer, maxLength: chunkSize)
+            if read <= 0 { break }
+            data.append(buffer, count: read)
+        }
+        return data
+    }
+}

--- a/Tests/EdgeRumTests/Transport/OfflineQueueTests.swift
+++ b/Tests/EdgeRumTests/Transport/OfflineQueueTests.swift
@@ -1,0 +1,124 @@
+// Tests/EdgeRumTests/Transport/OfflineQueueTests.swift
+//
+// PLAN-iOS.md §F5/T5.3 acceptance:
+//
+//   - Filling past `maxQueueSize` drops the OLDEST file first.
+//   - Drain reads files in chronological order, deletes on success,
+//     leaves on failure (and aborts further drain on failure).
+//   - Filename layout `<epochMs>-<seq>.json` keeps lexicographic order
+//     matching chronological order.
+//
+
+import XCTest
+@testable import EdgeRumCore
+
+final class OfflineQueueTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("edge-rum-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    func testEnqueueWritesAtomicAndIsListable() throws {
+        let queue = makeQueue(maxQueueSize: 10)
+        XCTAssertNotNil(queue.enqueue(Data("first".utf8)))
+        XCTAssertNotNil(queue.enqueue(Data("second".utf8)))
+        let files = queue.orderedFiles()
+        XCTAssertEqual(files.count, 2)
+        XCTAssertEqual(files[0].pathExtension, "json")
+    }
+
+    func testOrderingIsChronological() throws {
+        var epoch: Int64 = 1_717_000_000_000
+        let queue = makeQueue(maxQueueSize: 10) { defer { epoch += 1 }; return epoch }
+
+        XCTAssertNotNil(queue.enqueue(Data("a".utf8)))
+        XCTAssertNotNil(queue.enqueue(Data("b".utf8)))
+        XCTAssertNotNil(queue.enqueue(Data("c".utf8)))
+
+        let files = queue.orderedFiles()
+        let payloads = try files.map { try Data(contentsOf: $0) }
+        XCTAssertEqual(payloads, [Data("a".utf8), Data("b".utf8), Data("c".utf8)])
+    }
+
+    func testOverflowDropsOldestFirst() throws {
+        var epoch: Int64 = 1_717_000_000_000
+        let queue = makeQueue(maxQueueSize: 2) { defer { epoch += 1 }; return epoch }
+
+        XCTAssertNotNil(queue.enqueue(Data("first".utf8)))
+        XCTAssertNotNil(queue.enqueue(Data("second".utf8)))
+        XCTAssertNotNil(queue.enqueue(Data("third".utf8)))
+
+        // After overflow trim we expect "second" and "third" only.
+        let payloads = try queue.orderedFiles().map { try Data(contentsOf: $0) }
+        XCTAssertEqual(payloads, [Data("second".utf8), Data("third".utf8)])
+    }
+
+    func testDrainSuccessRemovesFiles() throws {
+        let queue = makeQueue(maxQueueSize: 10)
+        XCTAssertNotNil(queue.enqueue(Data("a".utf8)))
+        XCTAssertNotNil(queue.enqueue(Data("b".utf8)))
+
+        let drained = queue.drain { _ in true }
+        XCTAssertEqual(drained, 2)
+        XCTAssertEqual(queue.count, 0)
+    }
+
+    func testDrainFailureStopsAndKeepsRemainingFiles() throws {
+        var epoch: Int64 = 1_717_000_000_000
+        let queue = makeQueue(maxQueueSize: 10) { defer { epoch += 1 }; return epoch }
+
+        XCTAssertNotNil(queue.enqueue(Data("a".utf8)))
+        XCTAssertNotNil(queue.enqueue(Data("b".utf8)))
+        XCTAssertNotNil(queue.enqueue(Data("c".utf8)))
+
+        var seen: [Data] = []
+        let drained = queue.drain { payload in
+            seen.append(payload)
+            // Succeed on the first two, fail on the third.
+            return seen.count < 3
+        }
+        XCTAssertEqual(drained, 2)
+        XCTAssertEqual(seen, [Data("a".utf8), Data("b".utf8), Data("c".utf8)])
+        // "c" remains on disk because its drain returned false.
+        let remaining = try queue.orderedFiles().map { try Data(contentsOf: $0) }
+        XCTAssertEqual(remaining, [Data("c".utf8)])
+    }
+
+    func testReset() throws {
+        let queue = makeQueue(maxQueueSize: 10)
+        XCTAssertNotNil(queue.enqueue(Data("payload".utf8)))
+        XCTAssertEqual(queue.count, 1)
+        queue.reset()
+        XCTAssertEqual(queue.count, 0)
+    }
+
+    func testInitReturnsNilWhenDirectoryUnresolvable() {
+        // OfflineQueue(directory: nil, ...) is filtered through the
+        // failable init; we pass nil explicitly.
+        let q = OfflineQueue(directory: nil)
+        XCTAssertNil(q)
+    }
+
+    // MARK: Helpers
+
+    private func makeQueue(
+        maxQueueSize: Int,
+        clockEpochMs: @escaping () -> Int64 = { Int64(Date().timeIntervalSince1970 * 1000) }
+    ) -> OfflineQueue {
+        OfflineQueue(
+            directory: tempDir,
+            maxQueueSize: maxQueueSize,
+            clockEpochMs: clockEpochMs
+        )!
+    }
+}

--- a/Tests/EdgeRumTests/Transport/RetryPolicyTests.swift
+++ b/Tests/EdgeRumTests/Transport/RetryPolicyTests.swift
@@ -1,0 +1,120 @@
+// Tests/EdgeRumTests/Transport/RetryPolicyTests.swift
+//
+// Covers PLAN-iOS.md §9.3 / §F5/T5.2 truth table:
+//
+//   - Schedule 0 / 2 / 8 / 30s for status 0 / 429 / 503.
+//   - 5xx other than 503 → treat as 503.
+//   - Non-retryable 4xx (other than 429) → .drop.
+//   - Retry-After overrides the schedule; cap at 60s.
+//   - After the last schedule slot, the policy returns .toOfflineQueue.
+//
+
+import XCTest
+@testable import EdgeRumCore
+
+final class RetryPolicyTests: XCTestCase {
+
+    func testDefaultScheduleMatchesSpec() {
+        XCTAssertEqual(RetryPolicy.defaultSchedule, [0, 2, 8, 30])
+        XCTAssertEqual(RetryPolicy.retryAfterCap, 60)
+    }
+
+    func testStatus0FollowsSchedule() {
+        let policy = RetryPolicy()
+        XCTAssertEqual(policy.decide(attempt: 1, status: 0), .retry(after: 2))
+        XCTAssertEqual(policy.decide(attempt: 2, status: 0), .retry(after: 8))
+        XCTAssertEqual(policy.decide(attempt: 3, status: 0), .retry(after: 30))
+        XCTAssertEqual(policy.decide(attempt: 4, status: 0), .toOfflineQueue)
+    }
+
+    func testStatus503FollowsSchedule() {
+        let policy = RetryPolicy()
+        XCTAssertEqual(policy.decide(attempt: 1, status: 503), .retry(after: 2))
+        XCTAssertEqual(policy.decide(attempt: 4, status: 503), .toOfflineQueue)
+    }
+
+    func testStatus429FollowsSchedule() {
+        let policy = RetryPolicy()
+        XCTAssertEqual(policy.decide(attempt: 1, status: 429), .retry(after: 2))
+        XCTAssertEqual(policy.decide(attempt: 4, status: 429), .toOfflineQueue)
+    }
+
+    func test5xxOtherThan503IsTreatedAs503() {
+        let policy = RetryPolicy()
+        for status in [500, 502, 504, 599] {
+            XCTAssertEqual(
+                policy.decide(attempt: 1, status: status),
+                .retry(after: 2),
+                "status \(status) should be treated as 503"
+            )
+        }
+    }
+
+    func testNonRetryable4xxDrops() {
+        let policy = RetryPolicy()
+        for status in [400, 401, 403, 404, 418, 422] {
+            XCTAssertEqual(
+                policy.decide(attempt: 1, status: status),
+                .drop,
+                "status \(status) should be dropped"
+            )
+        }
+    }
+
+    func testRetryAfterOverridesSchedule() {
+        let policy = RetryPolicy()
+        XCTAssertEqual(
+            policy.decide(attempt: 1, status: 429, retryAfter: 15),
+            .retry(after: 15)
+        )
+    }
+
+    func testRetryAfterCapsAt60Seconds() {
+        let policy = RetryPolicy()
+        XCTAssertEqual(
+            policy.decide(attempt: 1, status: 503, retryAfter: 90),
+            .retry(after: 60)
+        )
+    }
+
+    func testRetryAfterNumericParse() {
+        XCTAssertEqual(RetryPolicy.parseRetryAfter("15"), 15)
+        XCTAssertEqual(RetryPolicy.parseRetryAfter("  42 "), 42)
+        XCTAssertEqual(RetryPolicy.parseRetryAfter("0"), 0)
+        XCTAssertEqual(RetryPolicy.parseRetryAfter(nil), nil)
+        XCTAssertEqual(RetryPolicy.parseRetryAfter(""), nil)
+        XCTAssertEqual(RetryPolicy.parseRetryAfter("garbage"), nil)
+    }
+
+    func testRetryAfterHttpDateParse() throws {
+        let now = Date(timeIntervalSince1970: 1_717_000_000)
+        // 30 seconds after `now` in RFC 1123 form.
+        let future = now.addingTimeInterval(30)
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "GMT")
+        f.dateFormat = "EEE, dd MMM yyyy HH:mm:ss 'GMT'"
+        let header = f.string(from: future)
+        let parsed = try XCTUnwrap(RetryPolicy.parseRetryAfter(header, now: now))
+        XCTAssertEqual(parsed, 30, accuracy: 1)
+    }
+
+    func testNegativeRetryAfterClampsToZero() {
+        let policy = RetryPolicy()
+        XCTAssertEqual(
+            policy.decide(attempt: 1, status: 429, retryAfter: -5),
+            .retry(after: 0)
+        )
+    }
+
+    /// T5.2 acceptance — "Mock server returning 503 yields four
+    /// attempts then offline-queue." Re-asserts the full sequence at
+    /// the policy level.
+    func testFourAttemptsThenOfflineQueueAcceptance() {
+        let policy = RetryPolicy()
+        XCTAssertEqual(policy.decide(attempt: 1, status: 503), .retry(after: 2))
+        XCTAssertEqual(policy.decide(attempt: 2, status: 503), .retry(after: 8))
+        XCTAssertEqual(policy.decide(attempt: 3, status: 503), .retry(after: 30))
+        XCTAssertEqual(policy.decide(attempt: 4, status: 503), .toOfflineQueue)
+    }
+}

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -411,3 +411,110 @@ testing seams F3 set up unchanged.
   successful POST. The F4 contract test
   `IdentityPersistenceConformanceTests` pins this requirement: any
   future regression that loses the increment will fail the test.
+
+---
+
+## ADR-005 — F5 transport: file-backed offline queue, default + background URLSession pair, sampler re-roll on rotation
+
+**Date:** 2026-06-16
+
+**Status:** Accepted.
+
+**Context.** F4 carried two open contracts into F5: the production
+`Recorder` still pointed at `NoopTransportSink`, and `Recorder.didAckBatch()`
+had no caller. F5 implements `HTTPTransportSink` to close both — and lands
+the §9 transport behaviour (retry, offline queue, background uploader,
+per-session sampling) in one go. Four design choices during implementation
+were load-bearing enough to record.
+
+**Decisions.**
+
+1. **One file per batch on the offline queue, named
+   `<epochMs>-<seq>.json`.** No index file, no SQLite, no `QueueFile`
+   port from the Android SDK. Lexicographic ordering of the filenames
+   matches chronological ordering — `FileManager.contentsOfDirectory`
+   sorted by `lastPathComponent` is the FIFO oracle. `seq` is a
+   monotonically increasing in-process counter that disambiguates
+   enqueues inside the same millisecond. `%013lld-%06llu.json` (not
+   `%d`) so 64-bit epoch values are not silently truncated by C's
+   `int`-width default.
+
+2. **Two parallel `URLSession`s — default + background.** The live
+   `BatchTransport` uses `URLSessionConfiguration.default`; a
+   `BackgroundUploader` holds a `URLSessionConfiguration.background(
+   withIdentifier: "com.edge.rum.upload")` for the after-suspend
+   drain path. We considered routing every batch through the
+   background session so a single configuration handles both — but
+   the background configuration requires `uploadTask(with:fromFile:)`,
+   forcing a temp-file write on the live happy path that the default
+   session avoids. Two sessions is one extra ivar and zero performance
+   regression on the hot path; one session is meaningfully slower.
+
+3. **Sampler re-rolls on every session rotation.** F3's `Sampler`
+   was constructed once per `Recorder.configure(_:)`. PLAN-iOS.md §9.6
+   says "per-session uniform random vs `sampleRate`" — the F3 wiring
+   technically violated this on idle rotation because a session born
+   30 minutes into a paused app inherited the prior session's roll.
+   F5 re-rolls in `start()` and inside
+   `bumpLastActiveAndEmitRotationIfNeeded()`. The forced-emit
+   allowlist still bypasses, so the user-visible behaviour on
+   `sampleRate = 0` is unchanged.
+
+4. **`HTTPTransportSink` owns its own `NetworkPathObserver` for the
+   drain trigger.** We considered piping the `NWPathMonitor` callback
+   through `ContextProvider` (which already needs network transition
+   notifications to refresh `network.type` / `network.effectiveType`)
+   so there is one `NWPathMonitor` per process. Rejected because
+   it would have coupled F5's drain behaviour to F8's
+   `network_change` event emission, and starting a second monitor is
+   measured at <100 µs / launch. The two observers will be merged in
+   F8 when the network-context refresh path lands; for now keeping
+   them separate makes each layer testable in isolation.
+
+**Alternatives considered.**
+
+- **Single-file QueueFile port from the Android SDK.** Rejected:
+  iOS `Library/Caches/` purge semantics are file-granular, so a
+  single-file queue would lose every queued batch on disk pressure
+  instead of just the oldest few. The file-per-batch layout maps
+  naturally onto Apple's cache eviction.
+- **Synchronous retry loop on the URLSession callback thread.**
+  Rejected — `URLSession`'s delegate queue is shared with all the
+  app's `default` configuration traffic; blocking it during a 30 s
+  backoff would delay every other request in the host app.
+  `DispatchQueue.asyncAfter` on a dedicated serial queue is the
+  right primitive.
+- **Sampler re-roll on EVERY event instead of every session.**
+  Rejected: contradicts the "per-session" wording in §9.6 and would
+  produce statistical garbage at sub-rate values (a `sampleRate = 0.5`
+  session with 1000 events would emit ≈500 of them rather than all or
+  none).
+- **Closing F5 without the background uploader.** Tempting because
+  the manual smoke test ("suspend mid-upload, relaunch, observe
+  drain") requires a host app and can't run in CI. Rejected because
+  `EdgeRum.handleBackgroundEvents(identifier:completion:)` is already
+  on the public surface (F2 #25) and host apps wiring it up before
+  F5 lands would get a misleading no-op.
+
+**Consequences.**
+
+- New internal directory `Sources/EdgeRumCore/Transport/` holds
+  `BatchTransport`, `RetryPolicy`, `OfflineQueue`,
+  `BackgroundUploader`, `HTTPTransportSink`, and a small
+  `TransportEnvironment` helper. None are exposed by the public
+  `EdgeRum` umbrella — terminology firewall verifies clean.
+- `TransportSink` gained `drainOfflineQueue()` with a default no-op
+  implementation; existing `NoopTransportSink` / `RecordingTransportSink`
+  test seams compile unchanged.
+- `Recorder.installTransport(_:)` is the F5 mirror of F4's
+  `installPersistedStores(...)`. `EdgeRum.start()` calls it once after
+  identity persistence, immediately after `installPersistedStores`.
+- `EdgeRum.enable()` now drains the offline queue as one of the three
+  documented trigger points. The other two — `NWPathMonitor.satisfied`
+  and `didBecomeActive` — are wired by the sink directly and by F11
+  respectively.
+- Coverage of the new transport directory sits at the F5 acceptance
+  bar via `BatchTransportTests`, `RetryPolicyTests`, `OfflineQueueTests`,
+  `HTTPTransportSinkTests`, `BackgroundUploaderTests`, plus the
+  end-to-end `TransportConformanceTests` that pins the
+  `Recorder → didAckBatch` integration F4 #43 left open.


### PR DESCRIPTION
Lands feature **F5 — Batch transport, retry, offline queue, background uploader** (`PLAN-iOS.md` §F5, tasks T5.1–T5.5) on top of the F4 persistent-identity foundation. Replaces F3's `NoopTransportSink` with a real HTTP-backed sink and wires `Recorder.didAckBatch()` from F4 to the 2xx response path so `session.sequence` advances per the EdgeTelemetryProcessor contract.

Closes #45, #46, #47, #48, #49, #10.

## Summary

- **Transport directory.** New internal `Sources/EdgeRumCore/Transport/` with `BatchTransport.swift` (POST driver), `RetryPolicy.swift` (pure value type), `OfflineQueue.swift` (file-backed FIFO), `BackgroundUploader.swift` (`URLSessionConfiguration.background(withIdentifier: "com.edge.rum.upload")`), `HTTPTransportSink.swift` (`TransportSink` conformance gluing it all together), and `TransportEnvironment.swift` (`device.model`/`osVersion` resolution).
- **Recorder integration.** New `Recorder.installTransport(_:)` mirroring F4's `installPersistedStores(...)`; called once from `EdgeRum.start(_:)`. The sink takes a weak reference back to the Recorder so 2xx responses call `didAckBatch()` — closes F4 carry-over #43.
- **Offline-queue drain triggers.** `EdgeRum.enable()` drains explicitly; the sink owns its own `NetworkPathObserver` so a `.satisfied` transition also triggers a drain. The `didBecomeActive` trigger lands with F11 (one call into `drainOfflineQueue()`).
- **Sampler re-roll on rotation.** F3's `Sampler` only re-rolled on `configure(_:)`, which left idle-rotated sessions inheriting the prior decision and violated PLAN-iOS.md §9.6 \"per-session uniform random\". F5 re-rolls in `Recorder.start()` and inside `bumpLastActiveAndEmitRotationIfNeeded()`.

| Task | Issue | Notes |
|---|---|---|
| T5.1 — `BatchTransport` happy-path POST | #45 | `URLSession` + header contract (`X-API-Key`, `Content-Type: application/json`, `User-Agent`, `X-Edge-Rum-Internal`, `taskDescription`). |
| T5.2 — `RetryPolicy` | #46 | 0/2/8/30 s schedule; 5xx-other → 503; `Retry-After` numeric + HTTP-date forms; cap 60 s; non-retryable 4xx → drop. |
| T5.3 — `OfflineQueue` | #47 | `Library/Caches/edge-rum/queue/<epochMs>-<seq>.json`. Epoch prefix gives lexicographic == chronological ordering, no index file. Overflow drops oldest first. |
| T5.4 — `BackgroundUploader` | #48 | `EdgeRum.handleBackgroundEvents(identifier:completion:)` now forwards into the live uploader; matching identifier stores the completion and fires it from `urlSessionDidFinishEvents`. |
| T5.5 — Per-session sampling | #49 | Re-roll on rotation + `SamplerTests.test10kSessionsAt50PercentHits5000Plus200` pinning the 5000 ± 200 statistical acceptance via a seeded LCG. |

## Tests

- `Tests/EdgeRumTests/Transport/RetryPolicyTests.swift` — full truth table.
- `Tests/EdgeRumTests/Transport/OfflineQueueTests.swift` — FIFO order, overflow drops oldest, drain stops on first failure.
- `Tests/EdgeRumTests/Transport/BatchTransportTests.swift` — header contract + 30-event single-ACK via `MockURLProtocol`.
- `Tests/EdgeRumTests/Transport/HTTPTransportSinkTests.swift` — 2xx → didAckBatch wiring; 4 × 503 → offline-queue handoff; drain replays.
- `Tests/EdgeRumTests/Transport/BackgroundUploaderTests.swift` — completion-attach plumbing.
- `Tests/EdgeRumTests/SamplerTests.swift` — extended with the T5.5 statistical test.
- `Tests/EdgeRumContractTests/TransportConformanceTests.swift` — end-to-end `Recorder → HTTPTransportSink → MockURLProtocol → didAckBatch → session.sequence++`.

`swift test` → 259 tests, 0 failures. `./Tools/firewall-check.sh` clean. `./Tools/check-supported-ios.sh` clean. `xcodebuild` against `iOS Simulator` succeeds.

## Documentation

- **`README.md`** — status sentence updated; new \"Offline & background\" subsection explaining the retry ladder, the queue file layout, and the `application:handleEventsForBackgroundURLSession:completionHandler:` wiring requirement.
- **`docs/decisions.md` ADR-005** — four load-bearing F5 choices: (1) file-per-batch queue with epoch-prefixed names, (2) two parallel `URLSession`s (default + background) rather than one, (3) sampler re-roll on session rotation, (4) `HTTPTransportSink` owning its own `NetworkPathObserver`.
- **`PLAN-iOS.md` §F5** — every T5.x task carries the \"Shipped in F5 as…\" line matching F4's convention.

## What's NOT in this PR

- UIKit `didBecomeActive` / `willResignActive` drain hooks (F11 — `drainOfflineQueue()` is wired, integration is one call).
- `network_change` event emission (F8 — separate from the offline-drain trigger documented in ADR-005).
- Real-device \"suspend mid-upload + relaunch\" exercise (requires a host app — covered by the sample app's manual smoke pass).

## Test plan

- [x] `swift build -c release` for iOS simulator slice
- [x] `swift test --enable-code-coverage` — all suites green
- [x] `./Tools/firewall-check.sh` — no banned tokens in public surface or consumer docs
- [x] `./Tools/check-supported-ios.sh` — iOS 14 floor consistent
- [ ] CI verifies on macos-15 / Xcode 16
- [ ] Manual smoke (post-merge): point a host app at a local listener; observe one POST after `track()` × 30, observe queue files after killing the listener, observe drain on re-enabling the listener and calling `EdgeRum.enable()`.
