### PR TITLE
feat(F7): SwiftUI screen + tap capture — parity fix, tests, sample

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,31 @@
 # .github/workflows/ci.yml
 #
-# Four-job continuous integration for the EdgeRum SDK.
+# Five-job continuous integration for the EdgeRum SDK.
 #
 # Triggers on every pull request, every push to main, and manual dispatch.
 # Release-artifact builds live in release.yml and only fire on tag pushes.
 #
-#   build     — `swift build -c release` + `xcodebuild` against iOS device
-#               + simulator destinations.
-#   test      — `swift test --enable-code-coverage`.
-#   audit     — `Tools/check-supported-ios.sh` (iOS-floor consistency) +
-#               `Tools/firewall-check.sh` (Rule 1 — terminology firewall).
-#   pod-lint  — `pod lib lint EdgeRum.podspec --allow-warnings`.
+#   build        — `swift build -c release` + `xcodebuild` against iOS device
+#                  + simulator destinations.
+#   test         — `swift test --enable-code-coverage`.
+#   audit        — `Tools/check-supported-ios.sh` (iOS-floor consistency) +
+#                  `Tools/firewall-check.sh` (Rule 1 — terminology firewall).
+#   pod-lint     — `pod lib lint EdgeRum.podspec --allow-warnings`.
+#   sample-build — `xcodebuild` against the F7 SwiftUI sample app under
+#                  Samples/EdgeRumSwiftUISampleApp/.
 #
 # All jobs run on a macos-15 runner with the default Xcode 16 toolchain
 # and auto-invoke Tools/fetch-plcrashreporter.sh so the .binaryTarget
 # resolves before build.
 #
 # Per-task acceptance criteria mapped:
-#   - T1.1 (#2) — build job's swift build + xcodebuild step
-#   - T1.3 (#4) — test job's VersionPipelineTests
-#   - T1.4 (#5) — pod-lint job's `pod lib lint`
-#   - T1.5 (#6) — audit job (check-supported-ios.sh)
-#   - T2.7      — audit job (firewall-check.sh)
-#   - T1.2 (#3) — XCFramework build lives in release.yml (tag-only)
+#   - T1.1 (#2)  — build job's swift build + xcodebuild step
+#   - T1.3 (#4)  — test job's VersionPipelineTests
+#   - T1.4 (#5)  — pod-lint job's `pod lib lint`
+#   - T1.5 (#6)  — audit job (check-supported-ios.sh)
+#   - T2.7       — audit job (firewall-check.sh)
+#   - T1.2 (#3)  — XCFramework build lives in release.yml (tag-only)
+#   - T7.3 (#56) — sample-build job (xcodebuild SwiftUI sample app)
 
 name: CI
 
@@ -121,3 +124,31 @@ jobs:
         # --verbose so destination-not-found failures show the actual
         # destination string CocoaPods chose.
         run: pod lib lint EdgeRum.podspec --allow-warnings --verbose
+
+  sample-build:
+    name: xcodebuild SwiftUI sample (iOS simulator)
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode 16
+        run: sudo xcode-select -s /Applications/Xcode_16.app || true
+      - name: Fetch PLCrashReporter
+        # The sample app links against the local SwiftPM package at
+        # ../.., so the same binary-target dependency the SDK needs has
+        # to be in place before xcodebuild resolves the package graph.
+        run: ./Tools/fetch-plcrashreporter.sh
+      - name: xcodebuild — F7 SwiftUI sample
+        # Generic-simulator destination keeps us off concrete iOS
+        # runtime IDs the macos-15 image may or may not ship with.
+        # Code signing is force-disabled because we never install the
+        # built .app on a device from CI.
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp.xcodeproj \
+            -scheme EdgeRumSwiftUISampleApp \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath build/dd-sample \
+            -skipPackagePluginValidation \
+            CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
+            build | xcpretty || exit ${PIPESTATUS[0]}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@
 DerivedData/
 xcuserdata/
 
+## Sample apps — un-ignore their checked-in project files so the
+## generic `*.xcodeproj/` rule above doesn't swallow them.
+!Samples/**/*.xcodeproj/
+!Samples/**/*.xcodeproj/**
+
 ## SwiftPM
 Package.resolved
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,25 @@ concept escapes the public module.**
 
 ---
 
+## Commit / PR hygiene
+
+**Never** add AI co-author trailers to commit messages, PR titles, PR
+bodies, issue comments, code comments, or any other artifact. The
+following strings are banned without exception:
+
+- `Co-Authored-By: Claude <noreply@anthropic.com>`
+- `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
+  (and every other model-tagged variant)
+- `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
+- `🤖 Generated with Claude Code`
+- Any other "Generated with …" or "Co-Authored-By: Claude …" line
+
+This applies even when an example in a tool's documentation, a slash
+command, or a prior commit shows the trailer — those examples are
+illustrative of HEREDOC formatting, not a required line. If a prior
+commit already has it, fix the PR body via `gh pr edit` (safe); do
+not force-push to amend the commit without explicit authorization.
+
 ## The two rules that override everything else
 
 ### Rule 1 — The terminology firewall

--- a/PLAN-iOS.md
+++ b/PLAN-iOS.md
@@ -1898,21 +1898,34 @@ screen entry / exit. **Status.** `v1.0`. **Refs.** §6.1.
 #### F7 — SwiftUI screen capture
 
 **Goal.** Public `.edgeRumScreen` / `.edgeRumTrackTap` modifiers
-emitting allowlisted events. **Status.** `v1.0`. **Refs.** §6.2.
+emitting allowlisted events. **Status.** `v1.0` — shipped. **Refs.** §6.2.
 
 ##### T7.1 — `.edgeRumScreen` modifier `[M2]`
-- `.onAppear` → emit `navigation` with `navigation.kind = "swiftui"`.
-- `.onDisappear` → emit `screen.duration`.
+- `.onAppear` → emit `navigation` with `navigation.kind = "swiftui"`,
+  `navigation.screen` (mirror of UIKit key), `navigation.type = "viewDidAppear"`.
+- `.onDisappear` → emit `screen.duration` as a performance metric
+  (routed via `recordPerformance`, not `recordEvent`) with the F6
+  UIKit attribute schema: `screen.name`, `screen.kind = "swiftui"`,
+  `screen.duration_ms` (Int), `value` (Double seconds). When the
+  disappear has no paired appear, the emit is a silent no-op.
+- Caller-supplied attributes are applied first; SDK-owned keys
+  overwrite so the kind discriminator cannot be hidden.
 
 **Acceptance.** Modifier on a SwiftUI view emits both events with consistent screen name.
 
 ##### T7.2 — `.edgeRumTrackTap` modifier `[M2]`
-- Overlay tap recognizer; emit `user.interaction` with `interaction.kind = "tap"`.
+- `.simultaneousGesture(TapGesture())` → emit `user.interaction`
+  with `interaction.kind = "tap"`. Caller attrs first, SDK-owned
+  keys last.
 
 **Acceptance.** Tapping the modified view fires exactly one `user.interaction` event.
 
 ##### T7.3 — Sample SwiftUI app `[M2]`
-- `Samples/EdgeRumSwiftUISampleApp/` exercising both modifiers.
+- `Samples/EdgeRumSwiftUISampleApp/` exercising both modifiers, built
+  via a checked-in `.xcodeproj` that resolves the SDK as a local
+  Swift Package at `../..`. `.github/workflows/ci.yml` runs
+  `xcodebuild ... -destination 'generic/platform=iOS Simulator'`
+  on every PR.
 
 **Acceptance.** App builds and runs on iOS 14 simulator.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `edge-rum-ios` is the native iOS sibling of the [`edge-rum`](https://github.com/NCG-Africa/edge-rum) (web/Ionic/Capacitor) and [`edge-rum-android`](https://github.com/NCG-Africa/edge-rum-android) SDKs. It captures performance data, errors, native crashes, hangs, network requests, and user interactions on iOS apps and ships them as JSON to the EdgeTelemetryProcessor backend used by all three platforms.
 
-> **Status.** Public API surface (F2), the core pipeline (F3), persistent identity (F4), and the F5 transport layer are in place — events flow over HTTPS to the EdgeRum collector endpoint, the retry schedule survives transient failures, failed batches spill onto a file-backed offline queue, and a background `URLSession` finishes pending uploads after the host app is suspended. **F6 lights up the first capture surface — every UIKit screen entry now auto-emits a `navigation` event and every paired exit emits a `screen.duration` metric.** The remaining capture surfaces (HTTP / interaction / native crash) follow across F7–F18.
+> **Status.** Public API surface (F2), the core pipeline (F3), persistent identity (F4), and the F5 transport layer are in place — events flow over HTTPS to the EdgeRum collector endpoint, the retry schedule survives transient failures, failed batches spill onto a file-backed offline queue, and a background `URLSession` finishes pending uploads after the host app is suspended. **F6 (UIKit) and F7 (SwiftUI) light up the first capture surfaces — every screen entry now auto-emits a `navigation` event and every paired exit emits a `screen.duration` metric, whether the screen is presented through UIKit or SwiftUI.** The remaining capture surfaces (HTTP / native crash) follow across F8–F18.
 
 ## Supported iOS
 
@@ -108,8 +108,10 @@ struct CheckoutView: View {
 
 The two view modifiers are unconditional at the iOS 14 floor.
 
-- `.edgeRumScreen` records a screen entry on appear and the dwell on disappear. Works on every `View`.
+- `.edgeRumScreen` records a screen entry on appear and the dwell on disappear. Works on every `View`. The disappear emit is a `screen.duration` performance metric with the same attribute schema as the UIKit emit (`screen.name`, `screen.kind`, `screen.duration_ms`, `value`) so cross-platform dashboards see one shape.
 - `.edgeRumTrackTap` attaches a `.simultaneousGesture(TapGesture())` so it never swallows the host app's own gestures. **It will not fire on a SwiftUI `Button`** — buttons consume their touch before any simultaneous tap recognizer runs. Instrument `Button` actions directly as shown above.
+
+A working sample app lives at [`Samples/EdgeRumSwiftUISampleApp/`](Samples/EdgeRumSwiftUISampleApp/) — open the `.xcodeproj` in Xcode and Run on any iOS Simulator.
 
 ## Automatic screen capture
 

--- a/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp.xcodeproj/project.pbxproj
+++ b/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp.xcodeproj/project.pbxproj
@@ -1,0 +1,377 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		BF0000000000000000000001 /* EdgeRumSwiftUISampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10000000000000000000001 /* EdgeRumSwiftUISampleApp.swift */; };
+		BF0000000000000000000002 /* HomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10000000000000000000002 /* HomeScreen.swift */; };
+		BF0000000000000000000003 /* DetailScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10000000000000000000003 /* DetailScreen.swift */; };
+		BF0000000000000000000004 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F10000000000000000000005 /* Assets.xcassets */; };
+		BF0000000000000000000005 /* EdgeRum in Frameworks */ = {isa = PBXBuildFile; productRef = D10000000000000000000001 /* EdgeRum */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		F10000000000000000000001 /* EdgeRumSwiftUISampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeRumSwiftUISampleApp.swift; sourceTree = "<group>"; };
+		F10000000000000000000002 /* HomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScreen.swift; sourceTree = "<group>"; };
+		F10000000000000000000003 /* DetailScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailScreen.swift; sourceTree = "<group>"; };
+		F10000000000000000000004 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F10000000000000000000005 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		F10000000000000000000006 /* EdgeRumSwiftUISampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EdgeRumSwiftUISampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		BP0000000000000000000002 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF0000000000000000000005 /* EdgeRum in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		G10000000000000000000001 /* MainGroup */ = {
+			isa = PBXGroup;
+			children = (
+				G10000000000000000000002 /* EdgeRumSwiftUISampleApp */,
+				G10000000000000000000003 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		G10000000000000000000002 /* EdgeRumSwiftUISampleApp */ = {
+			isa = PBXGroup;
+			children = (
+				F10000000000000000000001 /* EdgeRumSwiftUISampleApp.swift */,
+				F10000000000000000000002 /* HomeScreen.swift */,
+				F10000000000000000000003 /* DetailScreen.swift */,
+				F10000000000000000000005 /* Assets.xcassets */,
+				F10000000000000000000004 /* Info.plist */,
+			);
+			path = EdgeRumSwiftUISampleApp;
+			sourceTree = "<group>";
+		};
+		G10000000000000000000003 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F10000000000000000000006 /* EdgeRumSwiftUISampleApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		T10000000000000000000001 /* EdgeRumSwiftUISampleApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL0000000000000000000002 /* Build configuration list for PBXNativeTarget "EdgeRumSwiftUISampleApp" */;
+			buildPhases = (
+				BP0000000000000000000001 /* Sources */,
+				BP0000000000000000000002 /* Frameworks */,
+				BP0000000000000000000003 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = EdgeRumSwiftUISampleApp;
+			packageProductDependencies = (
+				D10000000000000000000001 /* EdgeRum */,
+			);
+			productName = EdgeRumSwiftUISampleApp;
+			productReference = F10000000000000000000006 /* EdgeRumSwiftUISampleApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		P10000000000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+				TargetAttributes = {
+					T10000000000000000000001 = {
+						CreatedOnToolsVersion = 16.0;
+					};
+				};
+			};
+			buildConfigurationList = CL0000000000000000000001 /* Build configuration list for PBXProject "EdgeRumSwiftUISampleApp" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = G10000000000000000000001;
+			packageReferences = (
+				PR0000000000000000000001 /* XCLocalSwiftPackageReference "../.." */,
+			);
+			productRefGroup = G10000000000000000000003 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				T10000000000000000000001 /* EdgeRumSwiftUISampleApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		BP0000000000000000000003 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF0000000000000000000004 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		BP0000000000000000000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF0000000000000000000001 /* EdgeRumSwiftUISampleApp.swift in Sources */,
+				BF0000000000000000000002 /* HomeScreen.swift in Sources */,
+				BF0000000000000000000003 /* DetailScreen.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		BC0000000000000000000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		BC0000000000000000000002 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		BC0000000000000000000003 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = EdgeRumSwiftUISampleApp/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.edge.rum.samples.swiftui";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		BC0000000000000000000004 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGNING_ALLOWED = NO;
+				CODE_SIGNING_REQUIRED = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = EdgeRumSwiftUISampleApp/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.edge.rum.samples.swiftui";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CL0000000000000000000001 /* Build configuration list for PBXProject "EdgeRumSwiftUISampleApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC0000000000000000000001 /* Debug */,
+				BC0000000000000000000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CL0000000000000000000002 /* Build configuration list for PBXNativeTarget "EdgeRumSwiftUISampleApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC0000000000000000000003 /* Debug */,
+				BC0000000000000000000004 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		PR0000000000000000000001 /* XCLocalSwiftPackageReference "../.." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../..;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		D10000000000000000000001 /* EdgeRum */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = EdgeRum;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = P10000000000000000000001 /* Project object */;
+}

--- a/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp.xcodeproj/xcshareddata/xcschemes/EdgeRumSwiftUISampleApp.xcscheme
+++ b/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp.xcodeproj/xcshareddata/xcschemes/EdgeRumSwiftUISampleApp.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "T10000000000000000000001"
+               BuildableName = "EdgeRumSwiftUISampleApp.app"
+               BlueprintName = "EdgeRumSwiftUISampleApp"
+               ReferencedContainer = "container:EdgeRumSwiftUISampleApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "T10000000000000000000001"
+            BuildableName = "EdgeRumSwiftUISampleApp.app"
+            BlueprintName = "EdgeRumSwiftUISampleApp"
+            ReferencedContainer = "container:EdgeRumSwiftUISampleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "T10000000000000000000001"
+            BuildableName = "EdgeRumSwiftUISampleApp.app"
+            BlueprintName = "EdgeRumSwiftUISampleApp"
+            ReferencedContainer = "container:EdgeRumSwiftUISampleApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp/Assets.xcassets/Contents.json
+++ b/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp/DetailScreen.swift
+++ b/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp/DetailScreen.swift
@@ -1,0 +1,35 @@
+// Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp/DetailScreen.swift
+//
+// Pushing this screen makes HomeScreen disappear, which fires
+// HomeScreen's `screen.duration` performance entry. Tapping the
+// Button records a custom event via EdgeRum.track(...) — Button
+// consumes its own touch so .edgeRumTrackTap would not fire here.
+//
+
+import SwiftUI
+import EdgeRum
+
+struct DetailScreen: View {
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("Detail")
+                .font(.title)
+            Text("Pop back to record this screen's dwell on Home.")
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+
+            // Button consumes its touch — instrument the action
+            // directly rather than relying on .edgeRumTrackTap.
+            Button(action: {
+                EdgeRum.track("buy_button",
+                              attributes: ["product.id": "SKU-456"])
+            }) {
+                Text("Record purchase intent")
+                    .padding(.horizontal)
+                    .padding(.vertical, 8)
+            }
+        }
+        .padding()
+        .edgeRumScreen("Detail", attributes: ["funnel.step": 2])
+    }
+}

--- a/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp.swift
+++ b/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp.swift
@@ -1,0 +1,48 @@
+// Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp.swift
+//
+// F7 sample app entry point. Boots the SDK against a placeholder
+// collector endpoint (you'll see HTTP errors in Xcode's console —
+// that is expected; replace the apiKey/endpoint to point at a real
+// collector). Two screens exercise the public modifiers:
+//
+//   - HomeScreen      → .edgeRumScreen("Home") + .edgeRumTrackTap on a card.
+//   - DetailScreen    → .edgeRumScreen("Detail") + a Button that calls
+//                       EdgeRum.track("buy_button", ...) directly.
+//
+// Navigate Home → Detail and back to see `screen.duration` fire on
+// each disappear in the console log (config.debug == true).
+//
+
+import SwiftUI
+import EdgeRum
+
+@main
+struct EdgeRumSwiftUISampleApp: App {
+
+    init() {
+        var config = EdgeRumConfig(
+            apiKey: "edge_sample_replace_me",
+            endpoint: URL(string: "https://localhost/collector")!
+        )
+        config.appName = "EdgeRumSwiftUISample"
+        config.appVersion = "1.0.0"
+        config.environment = .development
+        // debug = true relaxes the https-scheme precondition so the
+        // placeholder endpoint above doesn't crash the app on launch.
+        // Set this to false when pointing at a real https collector.
+        config.debug = true
+        EdgeRum.start(config)
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            NavigationView {
+                HomeScreen()
+            }
+            // SwiftUI on iOS 14 picks the column style by default on
+            // iPad; force a stack to keep the sample identical across
+            // device classes.
+            .navigationViewStyle(.stack)
+        }
+    }
+}

--- a/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp/HomeScreen.swift
+++ b/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp/HomeScreen.swift
@@ -1,0 +1,60 @@
+// Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp/HomeScreen.swift
+//
+// Exercises:
+//   - .edgeRumScreen("Home") → emits a `navigation` event on appear
+//     and a `screen.duration` performance entry on disappear.
+//   - .edgeRumTrackTap on a non-Button view → emits one
+//     `user.interaction` event per tap. Buttons consume their touch
+//     before any simultaneous tap recognizer runs, so for Button
+//     instrumentation we call EdgeRum.track(...) directly in the
+//     action closure (see DetailScreen).
+//
+// Note: if a SwiftUI screen is also presented via UIHostingController
+// (e.g. embedded in a UIKit container), the F6 swizzle would emit a
+// `navigation` event for that hosted controller as well. To avoid a
+// double-emit on the same screen, choose ONE of the two integration
+// paths per screen. The sample picks the modifier path.
+//
+
+import SwiftUI
+import EdgeRum
+
+struct HomeScreen: View {
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("EdgeRum SwiftUI sample")
+                .font(.title2)
+                .multilineTextAlignment(.center)
+
+            // Non-Button tap-target — .edgeRumTrackTap fires here.
+            ProductCard(sku: "SKU-456")
+                .edgeRumTrackTap("product_card",
+                                 attributes: ["product.id": "SKU-456"])
+
+            NavigationLink("Open detail", destination: DetailScreen())
+                .padding()
+        }
+        .padding()
+        .edgeRumScreen("Home", attributes: ["funnel.step": 1])
+    }
+}
+
+struct ProductCard: View {
+    let sku: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Product card")
+                .font(.headline)
+            Text("Tap me — emits user.interaction")
+                .font(.footnote)
+                .foregroundColor(.secondary)
+            Text("SKU: \(sku)")
+                .font(.footnote)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.secondary.opacity(0.1))
+        .cornerRadius(12)
+    }
+}

--- a/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp/Info.plist
+++ b/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>EdgeRum SwiftUI Sample</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Samples/EdgeRumSwiftUISampleApp/README.md
+++ b/Samples/EdgeRumSwiftUISampleApp/README.md
@@ -1,0 +1,43 @@
+# EdgeRum SwiftUI sample
+
+A minimal SwiftUI app that exercises the public `.edgeRumScreen` and
+`.edgeRumTrackTap` view modifiers from the [`EdgeRum`](../../) SDK.
+
+## What it does
+
+- Boots the SDK from `EdgeRumSwiftUISampleApp.init()` with a
+  placeholder API key (`"edge_sample_replace_me"`) and a placeholder
+  collector endpoint (`https://localhost/collector`). HTTP errors in
+  the Xcode console are expected — replace both values to point at a
+  real collector.
+- `HomeScreen` carries `.edgeRumScreen("Home")` and a `ProductCard`
+  with `.edgeRumTrackTap("product_card")`.
+- `DetailScreen` carries `.edgeRumScreen("Detail")` and a SwiftUI
+  `Button` whose action calls `EdgeRum.track("buy_button", ...)`
+  directly — `Button` consumes its touch before any simultaneous tap
+  recognizer runs, so `.edgeRumTrackTap` would not fire here.
+
+## Run it
+
+1. Open `EdgeRumSwiftUISampleApp.xcodeproj` in Xcode 16+.
+2. Wait for SwiftPM to resolve the SDK from `../..` (the repository
+   root).
+3. Pick an iOS Simulator destination and Run.
+
+The SDK's `debug == true` logging routes through `os_log` — open
+Console.app and filter by subsystem `com.edge.rum` to watch the
+emitted events.
+
+## CI
+
+The repository's CI builds this sample on every PR via a `xcodebuild
+-destination 'generic/platform=iOS Simulator'` step. See the
+`sample-build` job in `.github/workflows/ci.yml`.
+
+## Notes on UIHostingController
+
+If a SwiftUI screen is ALSO presented through a `UIHostingController`
+inside a UIKit container, the F6 UIKit swizzle would emit a second
+`navigation` event for the hosted controller. To avoid a double-emit
+on the same screen, choose one of the two integration paths per
+screen — the sample picks the `.edgeRumScreen` modifier path.

--- a/Sources/EdgeRum/SwiftUI/ViewModifiers.swift
+++ b/Sources/EdgeRum/SwiftUI/ViewModifiers.swift
@@ -1,11 +1,17 @@
 // Sources/EdgeRum/SwiftUI/ViewModifiers.swift
 //
-// Refs: PLAN-iOS.md §3.2, §F2/T2.6, §6.2; CLAUDE.md "SwiftUI conventions".
+// Refs: PLAN-iOS.md §3.2, §F2/T2.6, §6.2, §F7; CLAUDE.md "SwiftUI conventions".
 //
 // The two public modifiers emit existing event names (`navigation`,
 // `screen.duration`, `user.interaction`) with a `kind` discriminator
 // so the backend can tell SwiftUI traffic apart from UIKit traffic
 // without a new event name in the allowlist.
+//
+// The disappear path routes through `recordPerformance` and the
+// attribute schema mirrors the F6 UIKit emitter (`screen.name`,
+// `screen.kind`, `screen.duration_ms`, `value`) so the backend's
+// `screen.duration` metric dispatcher sees an identical shape for
+// UIKit and SwiftUI screens.
 //
 
 #if canImport(SwiftUI)
@@ -26,6 +32,12 @@ import EdgeRumCore
 internal enum SwiftUIEmitter {
 
     /// `.edgeRumScreen` on-appear → one `navigation` event.
+    ///
+    /// Attribute precedence: caller-supplied attributes are applied
+    /// first, then SDK-owned keys (`navigation.screen`,
+    /// `navigation.kind`, `navigation.type`) overwrite. A host
+    /// passing `"navigation.kind": "host-supplied"` therefore cannot
+    /// hide the discriminator from the backend.
     internal static func emitScreenAppear(
         name: String,
         attributes: [String: AttributeValue]?,
@@ -35,12 +47,21 @@ internal enum SwiftUIEmitter {
     ) {
         startStore.recordStart(name: name, at: clock.now)
         var payload: [String: AttributeValue] = attributes ?? [:]
+        // SDK-owned keys win on conflict — apply last.
+        payload["navigation.screen"] = .string(name)
         payload["navigation.kind"] = .string("swiftui")
-        payload["navigation.name"] = .string(name)
+        payload["navigation.type"] = .string("viewDidAppear")
         recorder.recordEvent(name: "navigation", attributes: payload)
     }
 
-    /// `.edgeRumScreen` on-disappear → one `screen.duration` event.
+    /// `.edgeRumScreen` on-disappear → one `screen.duration` metric.
+    ///
+    /// Routed through `recordPerformance` (metric, not event) with
+    /// the F6 UIKit attribute schema so the backend's
+    /// `screen.duration` dispatcher handles UIKit and SwiftUI rows
+    /// identically. If no matching `emitScreenAppear` was seen for
+    /// `name`, the call is a silent no-op — matches the UIKit
+    /// "no paired appear → skip" behaviour.
     internal static func emitScreenDisappear(
         name: String,
         attributes: [String: AttributeValue]?,
@@ -48,23 +69,30 @@ internal enum SwiftUIEmitter {
         clock: Clock = Recorder.shared.clock,
         startStore: SwiftUIScreenStartStore = .shared
     ) {
-        let dwellMs = startStore.consumeDwellMs(name: name, now: clock.now)
-        var payload: [String: AttributeValue] = attributes ?? [:]
-        payload["navigation.kind"] = .string("swiftui")
-        payload["navigation.name"] = .string(name)
-        if let dwellMs {
-            payload["duration_ms"] = .int(dwellMs)
+        guard let dwell = startStore.consumeDwell(name: name, now: clock.now) else {
+            return
         }
-        recorder.recordEvent(name: "screen.duration", attributes: payload)
+        var payload: [String: AttributeValue] = attributes ?? [:]
+        // SDK-owned keys win on conflict — apply last.
+        payload["screen.name"] = .string(name)
+        payload["screen.kind"] = .string("swiftui")
+        payload["screen.duration_ms"] = .int(dwell.ms)
+        payload["value"] = .double(dwell.seconds)
+        recorder.recordPerformance(name: "screen.duration", attributes: payload)
     }
 
     /// `.edgeRumTrackTap` → one `user.interaction` event.
+    ///
+    /// Attribute precedence is the same as `emitScreenAppear`:
+    /// caller-supplied attributes first, SDK-owned `interaction.*`
+    /// keys last so the discriminator cannot be overwritten.
     internal static func emitTap(
         name: String,
         attributes: [String: AttributeValue]?,
         recorder: Recording = Recorder.shared
     ) {
         var payload: [String: AttributeValue] = attributes ?? [:]
+        // SDK-owned keys win on conflict — apply last.
         payload["interaction.kind"] = .string("tap")
         payload["interaction.name"] = .string(name)
         recorder.recordEvent(name: "user.interaction", attributes: payload)
@@ -72,10 +100,19 @@ internal enum SwiftUIEmitter {
 }
 
 /// Pairs a screen name with its `onAppear` timestamp so the matching
-/// `onDisappear` event can carry the dwell in `duration_ms`. Backed
-/// by an `NSLock` so concurrent screens don't trip each other.
+/// `onDisappear` emit can carry the dwell as both an `Int` ms count
+/// and a `Double` seconds count (mirrors F6 UIKit). Backed by an
+/// `NSLock` so concurrent screens don't trip each other.
 internal final class SwiftUIScreenStartStore: @unchecked Sendable {
     internal static let shared = SwiftUIScreenStartStore()
+
+    /// Result of `consumeDwell` — both representations the wire
+    /// schema needs, computed from the same `timeIntervalSince`
+    /// call so they cannot disagree.
+    internal struct Dwell: Equatable {
+        internal let seconds: Double
+        internal let ms: Int
+    }
 
     private let lock = NSLock()
     private var starts: [String: Date] = [:]
@@ -88,12 +125,22 @@ internal final class SwiftUIScreenStartStore: @unchecked Sendable {
         lock.unlock()
     }
 
-    internal func consumeDwellMs(name: String, now: Date) -> Int? {
+    /// Pop the start timestamp for `name` and return the dwell. Returns
+    /// `nil` when no paired `recordStart` is present — the caller is
+    /// expected to skip the emit in that case.
+    internal func consumeDwell(name: String, now: Date) -> Dwell? {
         lock.lock()
         let start = starts.removeValue(forKey: name)
         lock.unlock()
         guard let start else { return nil }
-        return Int((now.timeIntervalSince(start) * 1000.0).rounded())
+        let raw = now.timeIntervalSince(start)
+        let safe = max(0.0, raw)
+        return Dwell(seconds: safe, ms: Int((safe * 1000.0).rounded()))
+    }
+
+    /// Backwards-compatible helper for callers that only need ms.
+    internal func consumeDwellMs(name: String, now: Date) -> Int? {
+        consumeDwell(name: name, now: now)?.ms
     }
 
     internal func reset() {
@@ -113,11 +160,13 @@ internal final class SwiftUIScreenStartStore: @unchecked Sendable {
 @available(macOS 10.15, *)
 public extension View {
 
-    /// Record screen-enter and screen-exit events for a SwiftUI view.
+    /// Record screen-enter and screen-exit performance data for a
+    /// SwiftUI view.
     ///
-    /// Emits `navigation` on `.onAppear` and `screen.duration` on
-    /// `.onDisappear`, both tagged with `"navigation.kind": "swiftui"`
-    /// so the backend can distinguish SwiftUI traffic from UIKit.
+    /// Emits a `navigation` event on `.onAppear` and a
+    /// `screen.duration` performance entry on `.onDisappear`, both
+    /// tagged with `"swiftui"` so the backend can distinguish
+    /// SwiftUI traffic from UIKit.
     ///
     /// ```swift
     /// CheckoutView()

--- a/Tests/EdgeRumContractTests/SwiftUIWireConformanceTests.swift
+++ b/Tests/EdgeRumContractTests/SwiftUIWireConformanceTests.swift
@@ -1,0 +1,136 @@
+// Tests/EdgeRumContractTests/SwiftUIWireConformanceTests.swift
+//
+// F7 — End-to-end wire conformance for the SwiftUI emit shapes.
+//
+// The unit-level `SwiftUIModifierTests` in `Tests/EdgeRumTests/`
+// drives the emitter against a `ProbeRecorder` to lock argument
+// shape. This contract test pipes those same emits through a real
+// `Recorder` + `RecordingTransportSink` and validates the assembled
+// envelope against `WireAssertions` — the same gate every other
+// wire-touching path crosses.
+//
+// Without this test, a future change in `SwiftUIEmitter` could emit
+// an attribute the backend silently drops; the probe-level tests
+// would still pass.
+//
+// Refs: PLAN-iOS.md §6.2, §7, §F7; CLAUDE.md "Testing conventions".
+//
+
+#if canImport(SwiftUI)
+import XCTest
+import EdgeRumCore
+@testable import EdgeRum
+
+final class SwiftUIWireConformanceTests: XCTestCase {
+
+    private func makeRecorder() -> (Recorder, RecordingTransportSink) {
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_234_876.512))
+        let sink = RecordingTransportSink()
+        let recorder = Recorder(
+            clock: clock,
+            sampler: Sampler(sampleRate: 1.0, entropy: { 0.0 }),
+            transport: sink,
+            sdkVersion: "1.0.0"
+        )
+        recorder.configure(RecorderConfig(
+            apiKey: "edge_test_abc",
+            endpoint: URL(string: "https://collect.example.com")!,
+            location: "Nairobi/Kenya"
+        ))
+        return (recorder, sink)
+    }
+
+    /// `.edgeRumScreen` on-appear → a wire-valid `navigation` event
+    /// with `navigation.kind = "swiftui"`.
+    func testSwiftUIScreenAppearProducesWireValidNavigation() throws {
+        let (recorder, sink) = makeRecorder()
+        let store = SwiftUIScreenStartStore()
+
+        SwiftUIEmitter.emitScreenAppear(
+            name: "Checkout",
+            attributes: ["funnel.step": 3],
+            recorder: recorder,
+            clock: recorder.clock,
+            startStore: store
+        )
+        recorder.flush(reason: .manual)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?["type"] as? String, "event")
+        XCTAssertEqual(events.first?["eventName"] as? String, "navigation")
+        let attrs = try XCTUnwrap(events.first?["attributes"] as? [String: Any])
+        try WireAssertions.assertIdentityAttributes(attrs)
+        XCTAssertEqual(attrs["navigation.kind"] as? String, "swiftui")
+        XCTAssertEqual(attrs["navigation.screen"] as? String, "Checkout")
+        XCTAssertEqual(attrs["navigation.type"] as? String, "viewDidAppear")
+        XCTAssertEqual(attrs["funnel.step"] as? Int, 3)
+    }
+
+    /// `.edgeRumScreen` on-disappear → a wire-valid `screen.duration`
+    /// METRIC carrying both `screen.duration_ms` (Int) and the
+    /// top-level scalar `value` (Double seconds). Mirrors the F6
+    /// UIKit shape; pins the F7 parity fix.
+    func testSwiftUIScreenDisappearProducesWireValidScreenDurationMetric() throws {
+        let (recorder, sink) = makeRecorder()
+        let store = SwiftUIScreenStartStore()
+
+        // Manual appear/disappear stamps so the dwell is deterministic
+        // against the FixedClock — the emitter pulls `clock.now` once
+        // per call which would give us a zero dwell otherwise.
+        let appearAt = Date(timeIntervalSince1970: 1_717_234_870.000)
+        store.recordStart(name: "Checkout", at: appearAt)
+
+        SwiftUIEmitter.emitScreenDisappear(
+            name: "Checkout",
+            attributes: nil,
+            recorder: recorder,
+            clock: recorder.clock,
+            startStore: store
+        )
+        recorder.flush(reason: .manual)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?["type"] as? String, "metric")
+        XCTAssertEqual(events.first?["metricName"] as? String, "screen.duration")
+        let topValue = try XCTUnwrap(events.first?["value"] as? Double)
+        XCTAssertEqual(topValue, 6.512, accuracy: 0.002)
+        let attrs = try XCTUnwrap(events.first?["attributes"] as? [String: Any])
+        try WireAssertions.assertIdentityAttributes(attrs)
+        XCTAssertEqual(attrs["screen.name"] as? String, "Checkout")
+        XCTAssertEqual(attrs["screen.kind"] as? String, "swiftui")
+        let durationMs = try XCTUnwrap(attrs["screen.duration_ms"] as? Int)
+        XCTAssertEqual(durationMs, 6512)
+    }
+
+    /// `.edgeRumTrackTap` → a wire-valid `user.interaction` event
+    /// with `interaction.kind = "tap"`.
+    func testSwiftUITapProducesWireValidUserInteraction() throws {
+        let (recorder, sink) = makeRecorder()
+
+        SwiftUIEmitter.emitTap(
+            name: "buy_button",
+            attributes: ["product.id": "SKU-123"],
+            recorder: recorder
+        )
+        recorder.flush(reason: .manual)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?["type"] as? String, "event")
+        XCTAssertEqual(events.first?["eventName"] as? String, "user.interaction")
+        let attrs = try XCTUnwrap(events.first?["attributes"] as? [String: Any])
+        try WireAssertions.assertIdentityAttributes(attrs)
+        XCTAssertEqual(attrs["interaction.kind"] as? String, "tap")
+        XCTAssertEqual(attrs["interaction.name"] as? String, "buy_button")
+        XCTAssertEqual(attrs["product.id"] as? String, "SKU-123")
+    }
+}
+#endif

--- a/Tests/EdgeRumTests/SwiftUIModifierTests.swift
+++ b/Tests/EdgeRumTests/SwiftUIModifierTests.swift
@@ -4,12 +4,14 @@ import XCTest
 import EdgeRumCore
 
 /// Confirms the two SwiftUI view modifiers emit the right events with
-/// the right `kind` discriminator. We do not render any SwiftUI
-/// hierarchy — the modifier's behaviour is encoded in the
+/// the right `kind` discriminator and that the F7 disappear path
+/// routes through `recordPerformance` with the F6-aligned attribute
+/// schema (`screen.name`, `screen.kind`, `screen.duration_ms`,
+/// `value`). The modifier's behaviour is encoded in the
 /// `SwiftUIEmitter` static functions, which we invoke directly with
-/// a fake recorder.
+/// a fake recorder — no SwiftUI rendering hierarchy is required.
 ///
-/// Refs: PLAN-iOS.md §3.2, §6.2, §F2/T2.6.
+/// Refs: PLAN-iOS.md §3.2, §6.2, §F2/T2.6, §F7.
 @available(macOS 10.15, *)
 final class SwiftUIModifierTests: XCTestCase {
 
@@ -18,9 +20,14 @@ final class SwiftUIModifierTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        // A four-entry queue covers the longest test (interleave +
+        // nested) without per-test reconstruction. Tests that need
+        // fewer reads simply consume a prefix.
         let clock = AdvancingClock(times: [
             Date(timeIntervalSince1970: 1_000_000.0),
-            Date(timeIntervalSince1970: 1_000_001.5) // dwell = 1500ms
+            Date(timeIntervalSince1970: 1_000_001.5), // +1500ms
+            Date(timeIntervalSince1970: 1_000_002.5), // +2500ms
+            Date(timeIntervalSince1970: 1_000_003.5)  // +3500ms
         ])
         recorder = ProbeRecorder(clock: clock)
         startStore = SwiftUIScreenStartStore()
@@ -31,6 +38,8 @@ final class SwiftUIModifierTests: XCTestCase {
         startStore = nil
         super.tearDown()
     }
+
+    // MARK: - emitScreenAppear
 
     func testEmitScreenAppearRecordsNavigationWithSwiftUIKind() {
         SwiftUIEmitter.emitScreenAppear(
@@ -48,11 +57,14 @@ final class SwiftUIModifierTests: XCTestCase {
         }
         XCTAssertEqual(name, "navigation")
         XCTAssertEqual(attributes["navigation.kind"], .string("swiftui"))
-        XCTAssertEqual(attributes["navigation.name"], .string("Checkout"))
+        XCTAssertEqual(attributes["navigation.screen"], .string("Checkout"))
+        XCTAssertEqual(attributes["navigation.type"], .string("viewDidAppear"))
         XCTAssertEqual(attributes["funnel.step"], .int(3))
     }
 
-    func testEmitScreenDisappearEmitsScreenDurationWithDwell() {
+    // MARK: - emitScreenDisappear
+
+    func testEmitScreenDisappearRoutesAsPerformanceMetric() {
         SwiftUIEmitter.emitScreenAppear(
             name: "Checkout",
             attributes: nil,
@@ -70,14 +82,144 @@ final class SwiftUIModifierTests: XCTestCase {
 
         let calls = recorder.calls
         XCTAssertEqual(calls.count, 2)
-        guard case let .event(name, attributes) = calls[1] else {
-            return XCTFail("Expected .event for screen.duration, got \(calls[1])")
+        // F7 parity fix — screen.duration is a metric, not an event.
+        guard case let .performance(name, _) = calls[1] else {
+            return XCTFail("Expected .performance for screen.duration, got \(calls[1])")
         }
         XCTAssertEqual(name, "screen.duration")
-        XCTAssertEqual(attributes["navigation.kind"], .string("swiftui"))
-        XCTAssertEqual(attributes["navigation.name"], .string("Checkout"))
-        XCTAssertEqual(attributes["duration_ms"], .int(1500))
     }
+
+    func testScreenAttributesUseF6AlignedKeys() {
+        SwiftUIEmitter.emitScreenAppear(
+            name: "Checkout",
+            attributes: nil,
+            recorder: recorder,
+            clock: recorder.clock,
+            startStore: startStore
+        )
+        SwiftUIEmitter.emitScreenDisappear(
+            name: "Checkout",
+            attributes: nil,
+            recorder: recorder,
+            clock: recorder.clock,
+            startStore: startStore
+        )
+
+        let calls = recorder.calls
+        XCTAssertEqual(calls.count, 2)
+        guard case let .performance(_, attributes) = calls[1] else {
+            return XCTFail("Expected .performance for screen.duration")
+        }
+        XCTAssertEqual(attributes["screen.name"], .string("Checkout"))
+        XCTAssertEqual(attributes["screen.kind"], .string("swiftui"))
+        XCTAssertEqual(attributes["screen.duration_ms"], .int(1500))
+        XCTAssertEqual(attributes["value"], .double(1.5))
+    }
+
+    func testMultipleScreensInterleave() {
+        // A appear (t=0), B appear (t=+1.5s), B disappear (t=+2.5s →
+        // dwell 1000ms), A disappear (t=+3.5s → dwell 3500ms). Pinned
+        // to the four-timestamp setUp queue.
+        SwiftUIEmitter.emitScreenAppear(
+            name: "A", attributes: nil,
+            recorder: recorder, clock: recorder.clock, startStore: startStore
+        )
+        SwiftUIEmitter.emitScreenAppear(
+            name: "B", attributes: nil,
+            recorder: recorder, clock: recorder.clock, startStore: startStore
+        )
+        SwiftUIEmitter.emitScreenDisappear(
+            name: "B", attributes: nil,
+            recorder: recorder, clock: recorder.clock, startStore: startStore
+        )
+        SwiftUIEmitter.emitScreenDisappear(
+            name: "A", attributes: nil,
+            recorder: recorder, clock: recorder.clock, startStore: startStore
+        )
+
+        let calls = recorder.calls
+        XCTAssertEqual(calls.count, 4)
+        guard case let .performance(_, bAttrs) = calls[2] else {
+            return XCTFail("Expected B disappear at calls[2]")
+        }
+        guard case let .performance(_, aAttrs) = calls[3] else {
+            return XCTFail("Expected A disappear at calls[3]")
+        }
+        XCTAssertEqual(bAttrs["screen.name"], .string("B"))
+        XCTAssertEqual(bAttrs["screen.duration_ms"], .int(1000))
+        XCTAssertEqual(aAttrs["screen.name"], .string("A"))
+        XCTAssertEqual(aAttrs["screen.duration_ms"], .int(3500))
+    }
+
+    func testNestedSameNameScreensDocumentedLimitation() {
+        // Two appears overwrite each other in the store; the first
+        // disappear consumes the latest start; the second disappear
+        // finds no paired start and is a silent no-op.
+        SwiftUIEmitter.emitScreenAppear(
+            name: "A", attributes: nil,
+            recorder: recorder, clock: recorder.clock, startStore: startStore
+        )
+        SwiftUIEmitter.emitScreenAppear(
+            name: "A", attributes: nil,
+            recorder: recorder, clock: recorder.clock, startStore: startStore
+        )
+        SwiftUIEmitter.emitScreenDisappear(
+            name: "A", attributes: nil,
+            recorder: recorder, clock: recorder.clock, startStore: startStore
+        )
+        SwiftUIEmitter.emitScreenDisappear(
+            name: "A", attributes: nil,
+            recorder: recorder, clock: recorder.clock, startStore: startStore
+        )
+
+        // 2 appears + 1 disappear (the second disappear is dropped).
+        XCTAssertEqual(recorder.calls.count, 3)
+        guard case .performance = recorder.calls[2] else {
+            return XCTFail("Expected the third call to be the only disappear emit")
+        }
+    }
+
+    func testHostAttributeCannotOverrideKindDiscriminator() {
+        // Caller maliciously / accidentally sets the discriminator —
+        // the emitter must overwrite it back to "swiftui".
+        SwiftUIEmitter.emitScreenAppear(
+            name: "Checkout",
+            attributes: [
+                "navigation.kind": .string("host-supplied"),
+                "navigation.screen": .string("HostScreenName"),
+                "navigation.type": .string("hostEvent")
+            ],
+            recorder: recorder,
+            clock: recorder.clock,
+            startStore: startStore
+        )
+
+        guard case let .event(_, attributes) = recorder.calls[0] else {
+            return XCTFail("Expected .event for navigation")
+        }
+        XCTAssertEqual(attributes["navigation.kind"], .string("swiftui"))
+        XCTAssertEqual(attributes["navigation.screen"], .string("Checkout"))
+        XCTAssertEqual(attributes["navigation.type"], .string("viewDidAppear"))
+    }
+
+    func testTapHostAttributeCannotOverrideKindDiscriminator() {
+        SwiftUIEmitter.emitTap(
+            name: "buy_button",
+            attributes: [
+                "interaction.kind": .string("host-supplied"),
+                "interaction.name": .string("HostName")
+            ],
+            recorder: recorder
+        )
+
+        guard case let .event(_, attributes) = recorder.calls[0] else {
+            return XCTFail("Expected .event for user.interaction")
+        }
+        XCTAssertEqual(attributes["interaction.kind"], .string("tap"))
+        XCTAssertEqual(attributes["interaction.name"], .string("buy_button"))
+    }
+
+    // MARK: - emitTap
 
     func testEmitTapRecordsUserInteractionWithTapKind() {
         SwiftUIEmitter.emitTap(
@@ -97,12 +239,78 @@ final class SwiftUIModifierTests: XCTestCase {
         XCTAssertEqual(attributes["product.id"], .string("SKU-123"))
     }
 
+    // MARK: - Default-recorder routing
+
+    func testDefaultsRouteThroughRecorderShared() {
+        // Exercise the no-args modifier path (`recorder: Recorder.shared`)
+        // by swapping the shared instance with a probe. `tearDown`
+        // restores so sibling tests are unaffected.
+        let probe = ProbeRecorder()
+        let previous = Recorder.installShared(probe)
+        defer { Recorder.installShared(previous) }
+
+        SwiftUIEmitter.emitTap(name: "card", attributes: nil)
+
+        let calls = probe.calls
+        XCTAssertEqual(calls.count, 1)
+        guard case let .event(name, _) = calls[0] else {
+            return XCTFail("Expected .event for user.interaction via shared recorder")
+        }
+        XCTAssertEqual(name, "user.interaction")
+    }
+
+    // MARK: - Missing-start handling
+
+    func testMissingStartOnDisappearIsSilent() {
+        SwiftUIEmitter.emitScreenDisappear(
+            name: "Phantom",
+            attributes: nil,
+            recorder: recorder,
+            clock: recorder.clock,
+            startStore: startStore
+        )
+        XCTAssertEqual(recorder.calls.count, 0,
+                       "Disappear without paired appear must be a silent no-op")
+    }
+
+    // MARK: - SwiftUIScreenStartStore
+
     func testScreenStartStoreConsumeIsOneShot() {
         let now = Date(timeIntervalSince1970: 1_000_000)
         startStore.recordStart(name: "A", at: now)
         XCTAssertEqual(startStore.consumeDwellMs(name: "A", now: now.addingTimeInterval(0.250)), 250)
         XCTAssertNil(startStore.consumeDwellMs(name: "A", now: now.addingTimeInterval(0.500)),
                      "Second consume for the same screen should return nil")
+    }
+
+    func testScreenStartStoreDwellExposesSecondsAndMs() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        startStore.recordStart(name: "A", at: now)
+        let dwell = startStore.consumeDwell(name: "A", now: now.addingTimeInterval(0.4567))
+        XCTAssertNotNil(dwell)
+        XCTAssertEqual(dwell?.ms, 457)
+        XCTAssertEqual(dwell?.seconds ?? 0, 0.4567, accuracy: 0.0001)
+    }
+
+    func testScreenStartStoreThreadSafety() {
+        let store = SwiftUIScreenStartStore()
+        let iterations = 50
+        let group = DispatchGroup()
+        let now = Date()
+        for i in 0..<iterations {
+            group.enter()
+            DispatchQueue.global().async {
+                let name = "screen_\(i)"
+                store.recordStart(name: name, at: now)
+                _ = store.consumeDwell(name: name, now: now.addingTimeInterval(0.01))
+                group.leave()
+            }
+        }
+        let result = group.wait(timeout: .now() + 5.0)
+        XCTAssertEqual(result, .success, "Thread-safety burst should complete within 5s")
+        // After every recorded start was consumed, the internal map
+        // must be empty — verified by another consume returning nil.
+        XCTAssertNil(store.consumeDwell(name: "screen_0", now: now))
     }
 }
 #endif

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -611,3 +611,60 @@ keys) is already pinned by §6.1 and `Recorder.allowedEventNames`.
   installed; re-enabling resumes capture without a re-install. The
   `previousScreen` pointer is not reset on disable — the next emit
   on enable chains correctly off the last screen seen.
+
+---
+
+## ADR-007 — F7 SwiftUI sample app uses a checked-in `.xcodeproj`
+
+**Date:** 2026-06-16
+
+**Status:** Accepted.
+
+**Context.** F7's `T7.3` requires a working SwiftUI sample app under
+`Samples/EdgeRumSwiftUISampleApp/` that builds against the in-repo SDK
+and exercises both public view modifiers. CI must build this sample on
+every PR so a future change in the public surface that breaks
+consumers fails before merge.
+
+Three project shapes were considered:
+
+1. A hand-rolled, checked-in `.xcodeproj` whose `project.pbxproj`
+   lives in version control verbatim.
+2. An XcodeGen `project.yml` regenerated from a declarative spec at
+   build time (CI installs XcodeGen via Homebrew).
+3. A Tuist `Project.swift` evaluated by the Tuist CLI at build time.
+
+**Decision.** Take option (1). The sample target is small (three Swift
+files, one Info.plist, one asset catalog, one scheme) and stable
+enough that pbxproj churn is bounded.
+
+**Why not XcodeGen or Tuist.** Both introduce a tool dependency on
+every CI run and on every contributor's machine. XcodeGen's spec is
+short but the manifest format is one more thing reviewers must learn,
+and a regenerated pbxproj can drift silently from what Xcode-the-IDE
+would produce when contributors add files. Tuist is overkill for a
+single sample target. The pbxproj diff noise inherent in option (1)
+is a real but acceptable cost — the sample's footprint is unlikely
+to change often.
+
+**Consequences.**
+
+- `Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp.xcodeproj`
+  is checked into the repo with its shared scheme under
+  `xcshareddata/xcschemes/`. Without the shared scheme, `xcodebuild
+  -scheme EdgeRumSwiftUISampleApp` would fail in CI because user
+  schemes live under `xcuserdata/` (gitignored).
+- The SDK dep is resolved via an `XCLocalSwiftPackageReference` to
+  `../..`, the repo root. The first CI run on a fresh runner still
+  pulls `opentelemetry-swift-core` from network, but the SDK targets
+  themselves resolve from the checkout — no GitHub release is needed.
+- `.github/workflows/ci.yml` gains a `sample-build` job that runs
+  `xcodebuild ... -destination 'generic/platform=iOS Simulator' build`
+  on every PR. Generic-simulator destination avoids the macos-15
+  runner's iOS-runtime-version drift.
+- Contributors who add files to the sample MUST add them to the
+  pbxproj — `swift build` does not touch the sample, so a missing
+  reference is not caught until CI's sample-build job fires.
+- A future migration to XcodeGen is not blocked. The spec can be
+  written from the checked-in pbxproj at any time; the ADR stays in
+  the file marked `Superseded by: ADR-NNN` if that happens.


### PR DESCRIPTION
## Summary

- Aligns the scaffolded `.edgeRumScreen` / `.edgeRumTrackTap` modifiers with the F6 UIKit wire shape — `screen.duration` now routes through `recordPerformance` with the F6 attribute schema (`screen.name`, `screen.kind = "swiftui"`, `screen.duration_ms`, `value`) so the backend's metric dispatcher handles UIKit and SwiftUI rows identically. Skips silently when a disappear has no paired appear (UIKit parity).
- Hardens unit tests from 4 → 13 cases and adds a new contract test (`Tests/EdgeRumContractTests/SwiftUIWireConformanceTests.swift`) that pipes the modifier emits through a real `Recorder` + `RecordingTransportSink` and validates each batch with `WireAssertions`.
- Ships `Samples/EdgeRumSwiftUISampleApp/` (T7.3) — checked-in `.xcodeproj`, shared scheme, three screens, local SwiftPM dep on `../..`. A new `sample-build` CI job (Xcode 16, generic iOS Simulator destination) gates it on every PR.
- README status block covers F6 + F7; `PLAN-iOS.md` §F7 is marked shipped; `docs/decisions.md` gains ADR-007 explaining the checked-in `.xcodeproj` choice over XcodeGen/Tuist.

## Why a parity fix was needed

The F2 scaffold routed `screen.duration` through `recordEvent` and used `navigation.name` / `duration_ms` — but F6's UIKit emitter routes through `recordPerformance` with `screen.name` / `screen.duration_ms` / `value`. If shipped as-is, cross-platform analytics filtering by `screen.name` or by `type == "metric"` would silently miss every iOS-SwiftUI screen.

## Public surface

No new public Swift symbols. `View.edgeRumScreen(_:attributes:)` and `View.edgeRumTrackTap(_:attributes:)` keep the F2 signatures. The change is in the internal `SwiftUIEmitter` and `SwiftUIScreenStartStore` (added a `Dwell` return type carrying both ms Int and seconds Double).

## Test plan

- [x] `swift test --enable-code-coverage` — 278 tests pass locally on macOS host.
- [x] `swift build -c release` — green.
- [x] `Tools/firewall-check.sh` — clean (no banned terms in public surface, README diff, or `docs/*.md`).
- [x] Sample sources import only `EdgeRum` + `SwiftUI` — no internal-target leak.
- [ ] CI `sample-build` job builds the sample under Xcode 16 — verified on PR run.
- [ ] CI full suite (`build`, `test`, `audit`, `pod-lint`, `sample-build`) — all green.
- [ ] Reviewer spot-check: open `Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp.xcodeproj`, Run on an iOS Simulator, navigate Home → Detail and back, watch `os_log` (subsystem `com.edge.rum`) for `navigation` (`navigation.kind = "swiftui"`), `screen.duration` (metric, `screen.kind = "swiftui"`), `user.interaction` (`interaction.kind = "tap"`).

## Issues closed

Closes #54
Closes #55
Closes #56
Refs #12

(F7 epic #12 is a tracking issue — it'll be closed manually after merge with a "all three tasks done" comment.)

## Local-toolchain note

This branch was developed on Xcode 26.2; CI uses Xcode 16. The full-suite `swift build` + `swift test` ran clean locally (macOS host target). `xcodebuild` of the sample app for the iOS Simulator surfaces a pre-existing F6 issue under the iOS 26 SDK (`UIViewController.accessibilityIdentifier`), which is out of F7's scope — CI's Xcode 16 toolchain is the source of truth for sample-build greenness.