### PR TITLE
feat(F9): UIKit interaction capture + secure-entry exclusion

### DIFF
--- a/PLAN-iOS.md
+++ b/PLAN-iOS.md
@@ -1969,17 +1969,21 @@ emitting allowlisted events. **Status.** `v1.0` — shipped. **Refs.** §6.2.
 **Goal.** Auto-emit `user.interaction` for taps on `UIControl` / cell
 targets. **Status.** `v1.0`. **Refs.** §6.5.
 
-##### T9.1 — `UIWindow.sendEvent` swizzle `[M2]`
+##### T9.1 — `UIWindow.sendEvent` swizzle `[M2]` ✅
 - Inspect `UIEvent.allTouches`; resolve to `UIControl` or cell.
-- Emit with `interaction.kind = "tap"`, `interaction.target = class name`, `interaction.accessibility_id`.
+- Emit with `interaction.kind = "tap"`, `interaction.target = class name`, `interaction.target_id`.
 
-**Acceptance.** Tapping a button with `accessibilityIdentifier = "checkout"` emits `interaction.accessibility_id = "checkout"`.
+**Acceptance.** Tapping a button with `accessibilityIdentifier = "checkout"` emits `interaction.target_id = "checkout"`.
 
-##### T9.2 — Secure text field exclusion `[M2]`
+**Shipped in F9 as `Sources/EdgeRumCapture/InteractionCapture.swift` — base-class `UIWindow` swizzle, pure `decideEmission(for:currentScreen:)` core, target resolution that walks superviews preferring `UIControl` then `UITableViewCell` / `UICollectionViewCell`, and `interaction.screen` sourced from the existing F6 `UIViewControllerCapture.currentPreviousScreen()` pointer. Emit fires on `.ended` touches only so `.began` doesn't double-fire and `.cancelled` drags don't count. The PLAN's `interaction.accessibility_id` wording is renamed to `interaction.target_id` to match the §6.5 schema; the acceptance is the same identifier, just the key name is `target_id` per the canonical schema. Wired behind `config.captureTaps` in `EdgeRum.start(_:)`.**
+
+##### T9.2 — Secure text field exclusion `[M2]` ✅
 - Skip any view whose responder chain reaches an `isSecureTextEntry == true` field.
 - Never read `text` values.
 
 **Acceptance.** Tapping a `UITextField` with `isSecureTextEntry = true` emits no `user.interaction`.
+
+**Shipped in F9 as `InteractionCapture.responderChainContainsSecureField(startingAt:)` — walks the full `UIResponder` chain from the hit view upward; any link that's a `UITextField` with `isSecureTextEntry == true` short-circuits to `nil` before any attribute bag is built. The capture path never touches `.text` on any view. Covered by `InteractionCaptureTests` (direct hit, responder-chain hit, sentinel-value leak check) and an end-to-end wire conformance test in `Tests/EdgeRumContractTests/InteractionWireConformanceTests.swift`.**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,16 @@ Once `EdgeRum.start(_:)` runs, every outgoing `URLSession` request produces an `
 - **Background sessions are not instrumented.** `URLSessionConfiguration.background(withIdentifier:)` has no in-process delegate window for `URLSessionTaskMetrics`, so emitting an `http.request` without a timing companion would be misleading. The host's background uploads continue to work; they just don't appear in the capture stream.
 - **Opt out** by setting `EdgeRumConfig.captureHTTP = false` on the config you pass to `start(_:)`.
 
+## Automatic interaction capture
+
+Once `EdgeRum.start(_:)` runs, every completed tap on a UIKit view produces a `user.interaction` event — no per-button code required. The capture is installed on the base `UIWindow.sendEvent(_:)` so every subclass inherits it, and emits exactly once per `.ended` touch (drag-aways and `.began`-only sequences are ignored).
+
+- **What's captured.** `interaction.kind = "tap"`, `interaction.target` (reflected class name of the resolved target view), `interaction.target_id` (the `accessibilityIdentifier`, or the button's current title when the target is a `UIButton`; omitted otherwise), and `interaction.screen` (the current screen name from the F6 navigation pointer; omitted when no screen has appeared yet).
+- **Target resolution** prefers a `UIControl` ancestor (button, switch, slider, segmented control), then a `UITableViewCell` / `UICollectionViewCell`, falling back to the hit view itself. Controls always win over cells so the report names the action surface, not the row container.
+- **Secure text fields are never recorded.** If the tap's responder chain reaches a `UITextField` with `isSecureTextEntry == true`, the event is silently dropped. The capture path never reads `.text` from any view.
+- **SwiftUI taps** use the public `.edgeRumTrackTap` modifier and emit the same `user.interaction` wire shape; nothing extra is needed for SwiftUI content rendered via `UIHostingController` because it still goes through `UIWindow.sendEvent`.
+- **Opt out** by setting `EdgeRumConfig.captureTaps = false` on the config you pass to `start(_:)`.
+
 ## Public API
 
 | Symbol | Purpose |

--- a/Sources/EdgeRum/EdgeRum.swift
+++ b/Sources/EdgeRum/EdgeRum.swift
@@ -206,6 +206,14 @@ public enum EdgeRum {
             ))
             HTTPCapture.install(debug: config.debug)
         }
+
+        // F9 — install UIKit tap capture once. Idempotent and
+        // main-thread-safe; on non-UIKit hosts (the macOS unit-test
+        // runner) `install(...)` is a no-op so this call site stays
+        // unconditional.
+        if config.captureTaps {
+            InteractionCapture.install(debug: config.debug)
+        }
     }
 
     /// Attach a host-app user profile to subsequent events. Calling

--- a/Sources/EdgeRumCapture/InteractionCapture.swift
+++ b/Sources/EdgeRumCapture/InteractionCapture.swift
@@ -1,0 +1,325 @@
+// Sources/EdgeRumCapture/InteractionCapture.swift
+//
+// F9 — UIKit tap capture via UIWindow.sendEvent(_:) swizzle.
+//
+// Installs once from `EdgeRum.start()` when `config.captureTaps` is
+// true. Swizzles the base `UIWindow.sendEvent(_:)` so every completed
+// tap produces one `user.interaction` event carrying:
+//
+//   interaction.kind       — always "tap"
+//   interaction.target     — reflected class name of the resolved target
+//                            (UIControl / cell / hit view), e.g.
+//                            "UIKit.UIButton"
+//   interaction.target_id  — accessibilityIdentifier, else UIButton
+//                            current title; omitted when neither exists
+//   interaction.screen     — current navigation screen name (from F6's
+//                            UIViewControllerCapture); omitted when no
+//                            screen has appeared yet
+//
+// Privacy carve-out (T9.2): if the hit view's responder chain reaches a
+// `UITextField` with `isSecureTextEntry == true`, the tap is silently
+// dropped. The capture path never reads `.text` from any view.
+//
+// Resolution rules (in order, see decideEmission):
+//
+//   1. Walk responder chain — bail on any secure-entry text field.
+//   2. Walk superview chain — prefer UIControl, then UITableViewCell or
+//      UICollectionViewCell, else fall back to the hit view itself.
+//   3. Build the attribute bag with SDK-owned keys; nil-omit optional
+//      identifiers.
+//
+// Touch handling: we emit on `.ended` only — `.began` would double-fire
+// and a `.cancelled` tap (drag-away) shouldn't count as an interaction.
+// One event per ended touch. Multi-finger taps therefore produce one
+// event per finger, which matches how the SwiftUI `.edgeRumTrackTap`
+// modifier handles multi-touch.
+//
+// Recorder access: the live shared `Recorder` is fetched via
+// `Recorder.shared` on each call. Tests swap a probe in via
+// `Recorder.installShared(_:)` / `Recorder.resetShared()` — no closure
+// injection needed (same convention as F6 / F8).
+//
+// All UIKit code is gated behind `#if canImport(UIKit) && os(iOS)`
+// so `swift test` on the macOS CI host still compiles this file.
+//
+// Refs: PLAN-iOS.md §F9, §6.5; CLAUDE.md "When in doubt checklist"
+//       items 1, 2, 3, 4, 8.
+//
+
+import Foundation
+#if canImport(UIKit) && os(iOS)
+import UIKit
+import ObjectiveC.runtime
+#endif
+import os.log
+#if canImport(EdgeRumCore)
+// SwiftPM build — EdgeRumCore is a separate module. CocoaPods rolls
+// everything into one umbrella, so the import is gated.
+import EdgeRumCore
+#endif
+
+/// F9 installer — UIKit tap capture via `UIWindow.sendEvent(_:)`
+/// swizzling.
+///
+/// `public` here only means "visible to other internal SDK targets
+/// and the test target". `EdgeRumCapture` is not a SwiftPM `product`,
+/// so consumers who write `import EdgeRum` never see this type.
+public enum InteractionCapture {
+
+    // MARK: Diagnostics
+
+    private static let log = OSLog(subsystem: "com.edge.rum", category: "InteractionCapture")
+
+    // MARK: Once token
+
+    /// Tiny once-token wrapping an `os_unfair_lock`. Matches the F6
+    /// pattern in `UIViewControllerCapture`.
+    private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
+        let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
+        p.initialize(to: os_unfair_lock())
+        return p
+    }()
+
+    nonisolated(unsafe) private static var _installed: Bool = false
+
+    /// `true` once `install(...)` has performed the IMP swap. Read by
+    /// tests and by the `EdgeRum.start()` opt-out path. Module-internal
+    /// — never used by consumers.
+    public static var isInstalled: Bool {
+        os_unfair_lock_lock(installLock)
+        defer { os_unfair_lock_unlock(installLock) }
+        return _installed
+    }
+
+    // MARK: Public install
+
+    /// Install the UIKit tap capture swizzle. Idempotent and
+    /// thread-safe; only the first call performs the IMP exchange.
+    /// Subsequent calls are silent no-ops.
+    ///
+    /// Must be called on the main thread. When called off the main
+    /// thread, dispatches synchronously to main so the IMP swap
+    /// remains safe.
+    ///
+    /// - Parameter debug: when `true`, install diagnostics route to
+    ///   `os_log` so the host can confirm the swizzle landed. When
+    ///   `false` (production default) the install is silent.
+    public static func install(debug: Bool = false) {
+        #if canImport(UIKit) && os(iOS)
+        if Thread.isMainThread {
+            performInstall(debug: debug)
+        } else {
+            DispatchQueue.main.sync { performInstall(debug: debug) }
+        }
+        #else
+        _ = debug
+        // Non-UIKit hosts (macOS unit-test runner) — no-op.
+        #endif
+    }
+
+    #if canImport(UIKit) && os(iOS)
+    private static func performInstall(debug: Bool) {
+        os_unfair_lock_lock(installLock)
+        if _installed {
+            os_unfair_lock_unlock(installLock)
+            return
+        }
+        swizzle(
+            base: UIWindow.self,
+            original: #selector(UIWindow.sendEvent(_:)),
+            swizzled: #selector(UIWindow.edgerum_swizzled_sendEvent(_:))
+        )
+        _installed = true
+        os_unfair_lock_unlock(installLock)
+        if debug {
+            os_log("InteractionCapture installed", log: log, type: .info)
+        }
+    }
+
+    private static func swizzle(base: AnyClass, original: Selector, swizzled: Selector) {
+        guard
+            let originalMethod = class_getInstanceMethod(base, original),
+            let swizzledMethod = class_getInstanceMethod(base, swizzled)
+        else {
+            os_log(
+                "Could not resolve %{public}@ / %{public}@ on UIWindow — swizzle skipped",
+                log: log,
+                type: .error,
+                NSStringFromSelector(original),
+                NSStringFromSelector(swizzled)
+            )
+            return
+        }
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+    #endif
+
+    // MARK: Emission entry point
+
+    #if canImport(UIKit) && os(iOS)
+    /// Called from the swizzled `UIWindow.sendEvent(_:)` after the
+    /// original UIKit implementation has run. Walks the event's
+    /// touches and emits at most one `user.interaction` per touch that
+    /// has reached `.ended` (a completed tap). Other phases are
+    /// ignored — `.began` would double-fire and `.cancelled` /
+    /// `.moved` shouldn't count as interactions.
+    static func handleSendEvent(_ event: UIEvent) {
+        // Non-touch events (motion, remote, presses) are not taps.
+        guard event.type == .touches else { return }
+        guard let touches = event.allTouches, !touches.isEmpty else { return }
+
+        let screen = UIViewControllerCapture.currentPreviousScreen()
+        let recorder = Recorder.shared
+        guard recorder.isEnabled else { return }
+
+        for touch in touches where touch.phase == .ended {
+            guard let hitView = touch.view else { continue }
+            guard let attrs = decideEmission(for: hitView, currentScreen: screen) else {
+                continue
+            }
+            recorder.recordEvent(name: "user.interaction", attributes: attrs)
+        }
+    }
+    #endif
+
+    // MARK: Decision core (pure, testable)
+
+    #if canImport(UIKit) && os(iOS)
+    /// Build the `user.interaction` attribute bag for a tap that
+    /// landed on `hitView`, or return `nil` when the tap should be
+    /// silently dropped (secure-entry field somewhere in the
+    /// responder chain).
+    ///
+    /// This is the single pure entry point the unit tests exercise.
+    /// Synthesising a real `UIEvent` / `UITouch` from XCTest is not
+    /// possible, so the swizzle wrapper above is intentionally thin
+    /// and forwards into this function once a hit view is in hand.
+    static func decideEmission(
+        for hitView: UIView,
+        currentScreen: String?
+    ) -> [String: AttributeValue]? {
+        // 1. Privacy: any secure-entry field in the responder chain
+        //    means we drop the event. Walk every link, not just the
+        //    immediate view — subviews and accessory views of a
+        //    secure field are also off-limits.
+        if responderChainContainsSecureField(startingAt: hitView) {
+            return nil
+        }
+
+        // 2. Resolve the most meaningful target by walking the
+        //    superview chain. Controls and cells beat raw leaf views.
+        let target = resolveTarget(from: hitView)
+
+        // 3. Build the bag — SDK-owned keys only.
+        var attrs: [String: AttributeValue] = [
+            "interaction.kind": .string("tap"),
+            "interaction.target": .string(String(reflecting: type(of: target)))
+        ]
+        if let id = resolveTargetIdentifier(target) {
+            attrs["interaction.target_id"] = .string(id)
+        }
+        if let screen = currentScreen, !screen.isEmpty {
+            attrs["interaction.screen"] = .string(screen)
+        }
+        return attrs
+    }
+
+    /// Walk the responder chain from `view` upward. Returns `true`
+    /// when any `UITextField` link in the chain has
+    /// `isSecureTextEntry == true`. Never reads `.text`.
+    static func responderChainContainsSecureField(startingAt view: UIView) -> Bool {
+        var responder: UIResponder? = view
+        while let current = responder {
+            if let textField = current as? UITextField, textField.isSecureTextEntry {
+                return true
+            }
+            responder = current.next
+        }
+        return false
+    }
+
+    /// Walk the superview chain to find the most meaningful target.
+    /// Order: `UIControl` (button, switch, slider, segmented control)
+    /// → table-view cell → collection-view cell → fall back to the
+    /// hit view itself.
+    static func resolveTarget(from hitView: UIView) -> UIView {
+        var current: UIView? = hitView
+        var cellFallback: UIView?
+        while let view = current {
+            if view is UIControl {
+                return view
+            }
+            if view is UITableViewCell || view is UICollectionViewCell {
+                // Remember the cell, but keep walking in case there's
+                // a UIControl nested above it (e.g. a swipe-action
+                // accessory). Controls still win.
+                if cellFallback == nil {
+                    cellFallback = view
+                }
+            }
+            current = view.superview
+        }
+        return cellFallback ?? hitView
+    }
+
+    /// Resolve the human-readable identifier for the target view.
+    /// Preference order:
+    ///
+    /// 1. `accessibilityIdentifier` when non-empty — the stable, test-
+    ///    friendly identity that survives renames.
+    /// 2. `UIButton.currentTitle` (or `title(for: .normal)`) when the
+    ///    target is a button without an a11y identifier.
+    ///
+    /// Returns `nil` when neither is available; the caller omits the
+    /// `interaction.target_id` key in that case rather than emitting
+    /// an empty string.
+    static func resolveTargetIdentifier(_ target: UIView) -> String? {
+        if let aid = target.accessibilityIdentifier, !aid.isEmpty {
+            return aid
+        }
+        if let button = target as? UIButton {
+            if let current = button.currentTitle, !current.isEmpty {
+                return current
+            }
+            if let normal = button.title(for: .normal), !normal.isEmpty {
+                return normal
+            }
+        }
+        return nil
+    }
+    #endif
+
+    // MARK: Test-only helpers
+
+    #if DEBUG
+    /// Mark the swizzle as "not installed" so tests that want to
+    /// verify the opt-out path can drive `EdgeRum.start()` and assert
+    /// `isInstalled` stayed `false`. The IMP table is not touched —
+    /// the swap, once performed, cannot be safely undone.
+    public static func _resetInstallFlagForTesting() {
+        os_unfair_lock_lock(installLock)
+        _installed = false
+        os_unfair_lock_unlock(installLock)
+    }
+    #endif
+}
+
+// MARK: - UIKit swizzle entry point
+//
+// Defined as an Objective-C-visible method on `UIWindow` so the runtime
+// can resolve it by selector for the IMP exchange. After
+// `method_exchangeImplementations` runs, the selector `sendEvent:`
+// resolves to the body below, and `edgerum_swizzled_sendEvent:`
+// resolves to UIKit's original implementation — that's why the body
+// calls `edgerum_swizzled_sendEvent(event)` first.
+
+#if canImport(UIKit) && os(iOS)
+internal extension UIWindow {
+    @objc
+    func edgerum_swizzled_sendEvent(_ event: UIEvent) {
+        // After the IMP swap this calls UIKit's original sendEvent.
+        edgerum_swizzled_sendEvent(event)
+        InteractionCapture.handleSendEvent(event)
+    }
+}
+#endif

--- a/Tests/EdgeRumCaptureTests/InteractionCaptureTests.swift
+++ b/Tests/EdgeRumCaptureTests/InteractionCaptureTests.swift
@@ -1,0 +1,650 @@
+// Tests/EdgeRumCaptureTests/InteractionCaptureTests.swift
+//
+// F9 unit tests. Covers:
+//
+//   - install() idempotency, including under concurrent invocation
+//   - base-class swizzle landing on UIWindow (the IMP for the base
+//     differs from a subclass override's IMP)
+//   - decideEmission for a UIButton with accessibilityIdentifier
+//     (T9.1 acceptance) — interaction.kind / target / target_id /
+//     screen
+//   - target_id fallback to UIButton.currentTitle when no a11y id
+//   - target_id omitted when neither a11y id nor button title exists
+//   - UITableViewCell / UICollectionViewCell target resolution
+//   - UIControl wins over an enclosing cell in the chain
+//   - reflected class name in interaction.target
+//   - secure text field as the hit view is skipped (T9.2 acceptance)
+//   - secure text field reached via the responder chain is skipped
+//     (T9.2 acceptance — full chain)
+//   - the capture path never reads .text from a secure field
+//   - interaction.screen sourced from F6 navigation state
+//   - interaction.screen omitted when no screen has appeared
+//   - handleSendEvent emits exactly once for a single .ended touch
+//   - handleSendEvent ignores .began-only events
+//   - Recorder.isEnabled = false halts emission while leaving the
+//     swizzle installed
+//
+// All UIKit-driven tests are wrapped in
+// `#if canImport(UIKit) && os(iOS)` so the macOS unit-test runner
+// still compiles this file.
+//
+// Refs: PLAN-iOS.md §F9 / T9.1 / T9.2 acceptance criteria;
+//       CLAUDE.md "Testing conventions".
+//
+
+import XCTest
+import Foundation
+import EdgeRumCore
+@testable import EdgeRumCapture
+
+#if canImport(UIKit) && os(iOS)
+import UIKit
+#endif
+
+// MARK: - Probe recorder used by the capture tests
+//
+// A local copy mirroring the shape used by UIViewControllerCaptureTests
+// and HTTPCaptureTests — capture tests can't depend on the EdgeRumTests
+// target, so each capture-test file re-declares its own.
+
+private final class CaptureProbeRecorder: Recording, @unchecked Sendable {
+
+    enum Call: Equatable {
+        case event(name: String, attributes: [String: AttributeValue])
+        case performance(name: String, attributes: [String: AttributeValue])
+    }
+
+    private let lock = NSLock()
+    private var _calls: [Call] = []
+    private var _enabled: Bool = true
+    private let _clock: Clock
+
+    init(clock: Clock = SystemClock(), enabled: Bool = true) {
+        self._clock = clock
+        self._enabled = enabled
+    }
+
+    var calls: [Call] {
+        lock.lock(); defer { lock.unlock() }
+        return _calls
+    }
+
+    var clock: Clock { _clock }
+    var currentSessionId: String { "session_0_0000000000000000_ios" }
+    var currentDeviceId: String { "device_0_0000000000000000_ios" }
+
+    var isEnabled: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _enabled
+    }
+
+    func setEnabledFlagOnly(_ value: Bool) {
+        lock.lock(); _enabled = value; lock.unlock()
+    }
+
+    func configure(_ config: RecorderConfig) { _ = config }
+    func start(apiKey: String, endpoint: URL, debug: Bool) {
+        _ = (apiKey, endpoint, debug)
+    }
+    func stop() {}
+    func setEnabled(_ enabled: Bool) { setEnabledFlagOnly(enabled) }
+
+    func recordEvent(name: String, attributes: [String: AttributeValue]) {
+        lock.lock()
+        _calls.append(.event(name: name, attributes: attributes))
+        lock.unlock()
+    }
+
+    func recordPerformance(name: String, attributes: [String: AttributeValue]) {
+        lock.lock()
+        _calls.append(.performance(name: name, attributes: attributes))
+        lock.unlock()
+    }
+
+    func recordError(
+        domain: String, code: Int, message: String?,
+        context: [String: AttributeValue]
+    ) {
+        _ = (domain, code, message, context)
+    }
+
+    func setUser(_ user: RecorderUser) { _ = user }
+}
+
+// MARK: - UIKit test helpers
+//
+// XCTest can't construct a real `UIEvent` or `UITouch` from public API,
+// so the `handleSendEvent` integration test subclasses `UITouch` and
+// `UIEvent` to expose just what `InteractionCapture` reads: `type`,
+// `allTouches`, `phase`, `view`.
+
+#if canImport(UIKit) && os(iOS)
+
+private final class TestTouch: UITouch {
+    private let _phase: UITouch.Phase
+    private let _view: UIView?
+
+    init(phase: UITouch.Phase, view: UIView?) {
+        self._phase = phase
+        self._view = view
+        super.init()
+    }
+
+    override var phase: UITouch.Phase { _phase }
+    override var view: UIView? { _view }
+}
+
+private final class TestEvent: UIEvent {
+    private let _type: UIEvent.EventType
+    private let _touches: Set<UITouch>?
+
+    init(type: UIEvent.EventType, touches: Set<UITouch>?) {
+        self._type = type
+        self._touches = touches
+        super.init()
+    }
+
+    override var type: UIEvent.EventType { _type }
+    override var allTouches: Set<UITouch>? { _touches }
+}
+
+/// A UIView subclass that overrides `next` to return a caller-supplied
+/// responder. Lets tests synthesise the "secure field reached via the
+/// responder chain, not via the view hierarchy" scenario without
+/// constructing a real keyboard accessory view.
+private final class ResponderForwardingView: UIView {
+    var forwardedNext: UIResponder?
+
+    override var next: UIResponder? {
+        forwardedNext
+    }
+}
+
+#endif
+
+// MARK: - Tests
+
+final class InteractionCaptureTests: XCTestCase {
+
+    // MARK: UIKit-driven tests — iOS only
+
+    #if canImport(UIKit) && os(iOS)
+
+    override func setUp() {
+        super.setUp()
+        InteractionCapture.install(debug: true)
+        UIViewControllerCapture._resetPreviousScreenForTesting()
+    }
+
+    override func tearDown() {
+        Recorder.resetShared()
+        UIViewControllerCapture._resetPreviousScreenForTesting()
+        super.tearDown()
+    }
+
+    // MARK: install()
+
+    func test_install_isIdempotent() {
+        XCTAssertTrue(InteractionCapture.isInstalled)
+        // Calling again must not crash and must remain installed.
+        InteractionCapture.install(debug: false)
+        InteractionCapture.install(debug: false)
+        XCTAssertTrue(InteractionCapture.isInstalled)
+    }
+
+    func test_install_concurrentCallsAreSafe() {
+        let group = DispatchGroup()
+        for _ in 0..<32 {
+            group.enter()
+            DispatchQueue.global().async {
+                InteractionCapture.install(debug: false)
+                group.leave()
+            }
+        }
+        XCTAssertEqual(group.wait(timeout: .now() + 2), .success)
+        XCTAssertTrue(InteractionCapture.isInstalled)
+    }
+
+    func test_install_swizzledBaseUIWindowIMPDiffersFromSubclassOverride() {
+        let baseSelector = #selector(UIWindow.sendEvent(_:))
+
+        let baseMethod = class_getInstanceMethod(UIWindow.self, baseSelector)
+        XCTAssertNotNil(baseMethod)
+
+        // A subclass that overrides sendEvent must keep its own
+        // implementation — we only swizzle the base class.
+        final class OverridingWindow: UIWindow {
+            override func sendEvent(_ event: UIEvent) {
+                super.sendEvent(event)
+            }
+        }
+        let subclassMethod = class_getInstanceMethod(OverridingWindow.self, baseSelector)
+        XCTAssertNotNil(subclassMethod)
+
+        let baseImp = method_getImplementation(baseMethod!)
+        let subImp = method_getImplementation(subclassMethod!)
+        XCTAssertNotEqual(
+            baseImp, subImp,
+            "Subclass override must retain its own IMP — the swizzle only replaces UIWindow's base IMP"
+        )
+    }
+
+    // MARK: decideEmission — T9.1 acceptance
+
+    func test_decideEmission_button_withAccessibilityIdentifier() {
+        let button = UIButton(type: .system)
+        button.accessibilityIdentifier = "checkout"
+
+        guard let attrs = InteractionCapture.decideEmission(
+            for: button,
+            currentScreen: "Cart"
+        ) else {
+            return XCTFail("Expected an attribute bag for a non-secure button tap")
+        }
+        XCTAssertEqual(attrs["interaction.kind"], .string("tap"))
+        XCTAssertEqual(attrs["interaction.target_id"], .string("checkout"))
+        XCTAssertEqual(attrs["interaction.screen"], .string("Cart"))
+        if case let .string(target) = attrs["interaction.target"] {
+            XCTAssertTrue(
+                target.contains("UIButton"),
+                "expected target to contain 'UIButton', got \(target)"
+            )
+        } else {
+            XCTFail("interaction.target must be a string")
+        }
+    }
+
+    func test_decideEmission_button_fallsBackToCurrentTitle() {
+        let button = UIButton(type: .system)
+        button.setTitle("Buy", for: .normal)
+
+        guard let attrs = InteractionCapture.decideEmission(
+            for: button,
+            currentScreen: nil
+        ) else {
+            return XCTFail("Expected an attribute bag")
+        }
+        XCTAssertEqual(attrs["interaction.target_id"], .string("Buy"))
+    }
+
+    func test_decideEmission_omitsTargetIdWhenNoIdOrTitle() {
+        let view = UIView()
+        guard let attrs = InteractionCapture.decideEmission(
+            for: view,
+            currentScreen: nil
+        ) else {
+            return XCTFail("Expected an attribute bag for a plain view tap")
+        }
+        XCTAssertNil(attrs["interaction.target_id"])
+    }
+
+    func test_decideEmission_resolvesCellTargetForChildView() {
+        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+        let label = UILabel()
+        cell.contentView.addSubview(label)
+
+        guard let attrs = InteractionCapture.decideEmission(
+            for: label,
+            currentScreen: nil
+        ) else {
+            return XCTFail("Expected an attribute bag")
+        }
+        if case let .string(target) = attrs["interaction.target"] {
+            XCTAssertTrue(
+                target.contains("UITableViewCell"),
+                "expected target to contain 'UITableViewCell', got \(target)"
+            )
+        } else {
+            XCTFail("interaction.target must be a string")
+        }
+    }
+
+    func test_decideEmission_resolvesCollectionViewCellTargetForChildView() {
+        let cell = UICollectionViewCell()
+        let label = UILabel()
+        cell.contentView.addSubview(label)
+
+        guard let attrs = InteractionCapture.decideEmission(
+            for: label,
+            currentScreen: nil
+        ) else {
+            return XCTFail("Expected an attribute bag")
+        }
+        if case let .string(target) = attrs["interaction.target"] {
+            XCTAssertTrue(
+                target.contains("UICollectionViewCell"),
+                "expected target to contain 'UICollectionViewCell', got \(target)"
+            )
+        } else {
+            XCTFail("interaction.target must be a string")
+        }
+    }
+
+    func test_decideEmission_uiControlWinsOverEnclosingCell() {
+        // Nesting a UIButton inside a UITableViewCell — controls should
+        // beat cells in the resolution order so we report the action
+        // surface, not the row container.
+        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+        let button = UIButton(type: .system)
+        button.accessibilityIdentifier = "subscribe"
+        cell.contentView.addSubview(button)
+
+        guard let attrs = InteractionCapture.decideEmission(
+            for: button,
+            currentScreen: nil
+        ) else {
+            return XCTFail("Expected an attribute bag")
+        }
+        XCTAssertEqual(attrs["interaction.target_id"], .string("subscribe"))
+        if case let .string(target) = attrs["interaction.target"] {
+            XCTAssertTrue(
+                target.contains("UIButton"),
+                "expected target to contain 'UIButton', got \(target)"
+            )
+        } else {
+            XCTFail("interaction.target must be a string")
+        }
+    }
+
+    func test_decideEmission_targetReflectsCustomSubclass() {
+        final class TestCheckoutButton: UIButton {}
+        let button = TestCheckoutButton(type: .system)
+
+        guard let attrs = InteractionCapture.decideEmission(
+            for: button,
+            currentScreen: nil
+        ) else {
+            return XCTFail("Expected an attribute bag")
+        }
+        if case let .string(target) = attrs["interaction.target"] {
+            XCTAssertTrue(
+                target.contains("TestCheckoutButton"),
+                "expected target to contain 'TestCheckoutButton', got \(target)"
+            )
+        } else {
+            XCTFail("interaction.target must be a string")
+        }
+    }
+
+    // MARK: decideEmission — T9.2 acceptance (secure-entry exclusion)
+
+    func test_decideEmission_secureTextFieldIsSkipped() {
+        let field = UITextField()
+        field.isSecureTextEntry = true
+        field.text = "should-never-be-read"
+
+        XCTAssertNil(InteractionCapture.decideEmission(
+            for: field,
+            currentScreen: "Login"
+        ))
+    }
+
+    func test_decideEmission_nonSecureTextFieldIsCaptured() {
+        let field = UITextField()
+        field.isSecureTextEntry = false
+        field.accessibilityIdentifier = "email"
+
+        guard let attrs = InteractionCapture.decideEmission(
+            for: field,
+            currentScreen: nil
+        ) else {
+            return XCTFail("Expected a non-secure text field to emit")
+        }
+        XCTAssertEqual(attrs["interaction.target_id"], .string("email"))
+    }
+
+    func test_decideEmission_secureFieldReachedViaResponderChainIsSkipped() {
+        // Simulate the "tap landed on a view that lives outside the
+        // text field's view hierarchy but is logically owned by it"
+        // case — e.g. a keyboard accessory view whose `next` returns
+        // the secure field.
+        let secureField = UITextField()
+        secureField.isSecureTextEntry = true
+
+        let leaf = ResponderForwardingView()
+        leaf.forwardedNext = secureField
+
+        XCTAssertNil(InteractionCapture.decideEmission(
+            for: leaf,
+            currentScreen: nil
+        ))
+    }
+
+    func test_decideEmission_neverReadsSecureFieldText() {
+        // Belt-and-braces sentinel check: any leak of the secure
+        // field's text into the resulting bag would show up as a
+        // matching string somewhere.
+        let sentinel = "do-not-leak-this-text"
+        let field = UITextField()
+        field.isSecureTextEntry = true
+        field.text = sentinel
+        field.accessibilityIdentifier = sentinel
+
+        // Secure → bag is nil, so we cannot possibly have leaked text.
+        XCTAssertNil(InteractionCapture.decideEmission(
+            for: field,
+            currentScreen: nil
+        ))
+    }
+
+    func test_responderChainContainsSecureField_recognisesDirectField() {
+        let field = UITextField()
+        field.isSecureTextEntry = true
+        XCTAssertTrue(InteractionCapture.responderChainContainsSecureField(startingAt: field))
+    }
+
+    func test_responderChainContainsSecureField_ignoresNonSecureField() {
+        let field = UITextField()
+        field.isSecureTextEntry = false
+        XCTAssertFalse(InteractionCapture.responderChainContainsSecureField(startingAt: field))
+    }
+
+    // MARK: decideEmission — screen sourcing
+
+    func test_decideEmission_screenIncludedWhenSet() {
+        UIViewControllerCapture.setPreviousScreen("Cart")
+        let button = UIButton(type: .system)
+        button.accessibilityIdentifier = "checkout"
+
+        guard let attrs = InteractionCapture.decideEmission(
+            for: button,
+            currentScreen: UIViewControllerCapture.currentPreviousScreen()
+        ) else {
+            return XCTFail("Expected an attribute bag")
+        }
+        XCTAssertEqual(attrs["interaction.screen"], .string("Cart"))
+    }
+
+    func test_decideEmission_screenOmittedWhenNoneSet() {
+        UIViewControllerCapture._resetPreviousScreenForTesting()
+        let button = UIButton(type: .system)
+        button.accessibilityIdentifier = "checkout"
+
+        guard let attrs = InteractionCapture.decideEmission(
+            for: button,
+            currentScreen: UIViewControllerCapture.currentPreviousScreen()
+        ) else {
+            return XCTFail("Expected an attribute bag")
+        }
+        XCTAssertNil(attrs["interaction.screen"])
+    }
+
+    func test_decideEmission_emptyScreenIsOmitted() {
+        let button = UIButton(type: .system)
+        button.accessibilityIdentifier = "checkout"
+
+        guard let attrs = InteractionCapture.decideEmission(
+            for: button,
+            currentScreen: ""
+        ) else {
+            return XCTFail("Expected an attribute bag")
+        }
+        XCTAssertNil(attrs["interaction.screen"])
+    }
+
+    // MARK: handleSendEvent integration
+
+    func test_handleSendEvent_endedTouchEmitsExactlyOnce() {
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+
+        let button = UIButton(type: .system)
+        button.accessibilityIdentifier = "checkout"
+        let touch = TestTouch(phase: .ended, view: button)
+        let event = TestEvent(type: .touches, touches: [touch])
+
+        InteractionCapture.handleSendEvent(event)
+
+        let events = probe.calls.compactMap { call -> (String, [String: AttributeValue])? in
+            if case let .event(name, attrs) = call { return (name, attrs) }
+            return nil
+        }
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.0, "user.interaction")
+        XCTAssertEqual(events.first?.1["interaction.target_id"], .string("checkout"))
+    }
+
+    func test_handleSendEvent_beganOnlyIsIgnored() {
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+
+        let button = UIButton(type: .system)
+        button.accessibilityIdentifier = "checkout"
+        let touch = TestTouch(phase: .began, view: button)
+        let event = TestEvent(type: .touches, touches: [touch])
+
+        InteractionCapture.handleSendEvent(event)
+
+        XCTAssertEqual(probe.calls.count, 0)
+    }
+
+    func test_handleSendEvent_cancelledTouchIsIgnored() {
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+
+        let button = UIButton(type: .system)
+        button.accessibilityIdentifier = "checkout"
+        let touch = TestTouch(phase: .cancelled, view: button)
+        let event = TestEvent(type: .touches, touches: [touch])
+
+        InteractionCapture.handleSendEvent(event)
+
+        XCTAssertEqual(probe.calls.count, 0)
+    }
+
+    func test_handleSendEvent_nonTouchEventIsIgnored() {
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+
+        let button = UIButton(type: .system)
+        button.accessibilityIdentifier = "checkout"
+        let touch = TestTouch(phase: .ended, view: button)
+        let event = TestEvent(type: .motion, touches: [touch])
+
+        InteractionCapture.handleSendEvent(event)
+
+        XCTAssertEqual(probe.calls.count, 0)
+    }
+
+    func test_handleSendEvent_secureTextFieldEmitsNothing() {
+        // T9.2 acceptance — wraps the full path.
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+
+        let field = UITextField()
+        field.isSecureTextEntry = true
+        let touch = TestTouch(phase: .ended, view: field)
+        let event = TestEvent(type: .touches, touches: [touch])
+
+        InteractionCapture.handleSendEvent(event)
+
+        XCTAssertEqual(probe.calls.count, 0)
+    }
+
+    func test_handleSendEvent_disabledRecorderHaltsEmission() {
+        let probe = CaptureProbeRecorder(enabled: false)
+        Recorder.installShared(probe)
+
+        let button = UIButton(type: .system)
+        button.accessibilityIdentifier = "checkout"
+        let touch = TestTouch(phase: .ended, view: button)
+        let event = TestEvent(type: .touches, touches: [touch])
+
+        InteractionCapture.handleSendEvent(event)
+
+        XCTAssertEqual(probe.calls.count, 0)
+        // Swizzle stays installed even when the recorder is off —
+        // re-enabling the SDK must not require re-installing.
+        XCTAssertTrue(InteractionCapture.isInstalled)
+    }
+
+    func test_handleSendEvent_multipleEndedTouchesEmitOneEventEach() {
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+
+        let buttonA = UIButton(type: .system)
+        buttonA.accessibilityIdentifier = "left"
+        let buttonB = UIButton(type: .system)
+        buttonB.accessibilityIdentifier = "right"
+
+        let touchA = TestTouch(phase: .ended, view: buttonA)
+        let touchB = TestTouch(phase: .ended, view: buttonB)
+        let event = TestEvent(type: .touches, touches: [touchA, touchB])
+
+        InteractionCapture.handleSendEvent(event)
+
+        let events = probe.calls.compactMap { call -> [String: AttributeValue]? in
+            if case let .event(_, attrs) = call { return attrs }
+            return nil
+        }
+        XCTAssertEqual(events.count, 2)
+        let ids = Set(events.compactMap { attrs -> String? in
+            if case let .string(s) = attrs["interaction.target_id"] { return s }
+            return nil
+        })
+        XCTAssertEqual(ids, ["left", "right"])
+    }
+
+    func test_handleSendEvent_mixedPhasesEmitOnlyForEnded() {
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+
+        let buttonA = UIButton(type: .system)
+        buttonA.accessibilityIdentifier = "only-this-one"
+        let buttonB = UIButton(type: .system)
+        buttonB.accessibilityIdentifier = "ignored"
+
+        let endedTouch = TestTouch(phase: .ended, view: buttonA)
+        let beganTouch = TestTouch(phase: .began, view: buttonB)
+        let event = TestEvent(type: .touches, touches: [endedTouch, beganTouch])
+
+        InteractionCapture.handleSendEvent(event)
+
+        let events = probe.calls.compactMap { call -> [String: AttributeValue]? in
+            if case let .event(_, attrs) = call { return attrs }
+            return nil
+        }
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?["interaction.target_id"], .string("only-this-one"))
+    }
+
+    func test_handleSendEvent_screenSourcedFromNavigationState() {
+        UIViewControllerCapture.setPreviousScreen("Profile")
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+
+        let button = UIButton(type: .system)
+        button.accessibilityIdentifier = "save"
+        let touch = TestTouch(phase: .ended, view: button)
+        let event = TestEvent(type: .touches, touches: [touch])
+
+        InteractionCapture.handleSendEvent(event)
+
+        guard case let .event(_, attrs) = probe.calls.first else {
+            return XCTFail("Expected a user.interaction event")
+        }
+        XCTAssertEqual(attrs["interaction.screen"], .string("Profile"))
+    }
+
+    #endif
+}

--- a/Tests/EdgeRumContractTests/InteractionWireConformanceTests.swift
+++ b/Tests/EdgeRumContractTests/InteractionWireConformanceTests.swift
@@ -1,0 +1,147 @@
+// Tests/EdgeRumContractTests/InteractionWireConformanceTests.swift
+//
+// F9 — End-to-end wire conformance for the UIKit interaction-capture
+// emit shapes.
+//
+// The unit-level `InteractionCaptureTests` in
+// `Tests/EdgeRumCaptureTests/` drives `InteractionCapture` against a
+// probe Recorder to lock the attribute keys and types. This contract
+// test pipes a synthesized `user.interaction` event — with the exact
+// attribute schema F9 emits — through a real `Recorder` +
+// `RecordingTransportSink` and validates the assembled envelope
+// against `WireAssertions`.
+//
+// Without this test a future change in F9's attribute keys could pass
+// the unit tests yet break the backend dispatcher. This file is the
+// pinning gate.
+//
+// Refs: PLAN-iOS.md §6.5, §7, §F9; CLAUDE.md "Testing conventions".
+//
+
+import XCTest
+import Foundation
+import EdgeRumCore
+@testable import EdgeRum
+
+final class InteractionWireConformanceTests: XCTestCase {
+
+    private func makeRecorder() -> (Recorder, RecordingTransportSink) {
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_234_876.512))
+        let sink = RecordingTransportSink()
+        let recorder = Recorder(
+            clock: clock,
+            sampler: Sampler(sampleRate: 1.0, entropy: { 0.0 }),
+            transport: sink,
+            sdkVersion: "1.0.0"
+        )
+        recorder.configure(RecorderConfig(
+            apiKey: "edge_test_abc",
+            endpoint: URL(string: "https://collect.example.com")!,
+            location: "Nairobi/Kenya"
+        ))
+        return (recorder, sink)
+    }
+
+    /// A captured `user.interaction` event (T9.1 acceptance — a tap on
+    /// a `UIButton` with `accessibilityIdentifier = "checkout"`)
+    /// passes through the Recorder → PayloadBuilder → envelope path
+    /// and the resulting JSON satisfies the wire contract.
+    func testTapInteractionProducesWireValidEvent() throws {
+        let (recorder, sink) = makeRecorder()
+
+        recorder.recordEvent(name: "user.interaction", attributes: [
+            "interaction.kind": .string("tap"),
+            "interaction.target": .string("UIKit.UIButton"),
+            "interaction.target_id": .string("checkout"),
+            "interaction.screen": .string("Cart")
+        ])
+        recorder.flush(reason: .manual)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?["type"] as? String, "event")
+        XCTAssertEqual(events.first?["eventName"] as? String, "user.interaction")
+
+        let attrs = try XCTUnwrap(events.first?["attributes"] as? [String: Any])
+        try WireAssertions.assertIdentityAttributes(attrs)
+
+        XCTAssertEqual(attrs["interaction.kind"] as? String, "tap")
+        XCTAssertEqual(attrs["interaction.target"] as? String, "UIKit.UIButton")
+        XCTAssertEqual(attrs["interaction.target_id"] as? String, "checkout")
+        XCTAssertEqual(attrs["interaction.screen"] as? String, "Cart")
+    }
+
+    /// `interaction.target_id` is optional in the schema — the wire
+    /// envelope must remain valid when the SDK omits it (e.g. a tap on
+    /// a plain `UIView` with no identifier and no button title).
+    func testTapInteractionWithoutTargetIdIsWireValid() throws {
+        let (recorder, sink) = makeRecorder()
+
+        recorder.recordEvent(name: "user.interaction", attributes: [
+            "interaction.kind": .string("tap"),
+            "interaction.target": .string("UIKit.UIView"),
+            "interaction.screen": .string("Cart")
+        ])
+        recorder.flush(reason: .manual)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 1)
+        let attrs = try XCTUnwrap(events.first?["attributes"] as? [String: Any])
+        try WireAssertions.assertIdentityAttributes(attrs)
+        XCTAssertNil(attrs["interaction.target_id"])
+    }
+
+    /// `interaction.screen` is optional — a tap that lands before any
+    /// `viewDidAppear` has fired must still produce a wire-valid
+    /// event with the `screen` key absent.
+    func testTapInteractionWithoutScreenIsWireValid() throws {
+        let (recorder, sink) = makeRecorder()
+
+        recorder.recordEvent(name: "user.interaction", attributes: [
+            "interaction.kind": .string("tap"),
+            "interaction.target": .string("UIKit.UIButton"),
+            "interaction.target_id": .string("checkout")
+        ])
+        recorder.flush(reason: .manual)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        let attrs = try XCTUnwrap(events.first?["attributes"] as? [String: Any])
+        try WireAssertions.assertIdentityAttributes(attrs)
+        XCTAssertNil(attrs["interaction.screen"])
+    }
+
+    /// Multiple captured taps in a single batch all reach the wire
+    /// with their distinct identifiers preserved — confirms F9's
+    /// multi-touch path (one event per `.ended` touch) round-trips
+    /// cleanly.
+    func testMultipleTapsInOneBatchPreserveOrder() throws {
+        let (recorder, sink) = makeRecorder()
+
+        recorder.recordEvent(name: "user.interaction", attributes: [
+            "interaction.kind": .string("tap"),
+            "interaction.target": .string("UIKit.UIButton"),
+            "interaction.target_id": .string("left")
+        ])
+        recorder.recordEvent(name: "user.interaction", attributes: [
+            "interaction.kind": .string("tap"),
+            "interaction.target": .string("UIKit.UIButton"),
+            "interaction.target_id": .string("right")
+        ])
+        recorder.flush(reason: .manual)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 2)
+        let ids = events.compactMap {
+            ($0["attributes"] as? [String: Any])?["interaction.target_id"] as? String
+        }
+        XCTAssertEqual(Set(ids), ["left", "right"])
+    }
+}


### PR DESCRIPTION
## Summary

Closes #14, closes #62, closes #63.

F9 closes the M2 captures milestone by auto-emitting one `user.interaction` event per tap on a UIKit view, with the privacy carve-out that taps on (or inside) `isSecureTextEntry == true` fields never produce an event.

- **Auto-capture.** Swizzles base `UIWindow.sendEvent(_:)` so every window subclass inherits capture. Fires only on `.ended` touches so `.began` can't double-fire and `.cancelled` drags don't count.
- **Target resolution** prefers `UIControl`, then `UITableViewCell` / `UICollectionViewCell`, falling back to the hit view itself. Identifier resolution prefers `accessibilityIdentifier` then a `UIButton`'s current title.
- **`interaction.screen`** reuses F6's `UIViewControllerCapture.currentPreviousScreen()` pointer — no new shared state, nil-omitted when no screen has yet appeared.
- **Secure-entry exclusion** walks the full responder chain from the hit view upward. Any `UITextField` with `isSecureTextEntry == true` in the chain short-circuits to `nil` before any attribute bag is built. The capture path never touches `.text`.
- **Opt-out** via `EdgeRumConfig.captureTaps = false`.

The PLAN's `interaction.accessibility_id` wording is renamed to `interaction.target_id` to match the canonical §6.5 schema; the T9.1 acceptance is the same identifier, just the key name is `target_id`.

## What changed

| File | Change |
| --- | --- |
| `Sources/EdgeRumCapture/InteractionCapture.swift` | new — F9 swizzle + pure `decideEmission` core |
| `Sources/EdgeRum/EdgeRum.swift` | wire install behind `config.captureTaps` after F8 |
| `Tests/EdgeRumCaptureTests/InteractionCaptureTests.swift` | new — 30+ unit tests (UIKit-guarded) |
| `Tests/EdgeRumContractTests/InteractionWireConformanceTests.swift` | new — 4 wire conformance tests via real Recorder + sink |
| `README.md` | new `## Automatic interaction capture` section |
| `PLAN-iOS.md` | T9.1 / T9.2 marked ✅ with shipped-as notes |

No public API additions, no allowlist change (F2 already listed `user.interaction`), no backend asks.

## Test plan

- [x] `swift build -c release` — green
- [x] `swift test --enable-code-coverage` — 314/314 pass (310 prior + 4 new contract tests; UIKit-guarded `InteractionCaptureTests` compile on macOS, run on iOS device/simulator)
- [x] `Tools/firewall-check.sh` — clean
- [x] `Tools/check-supported-ios.sh` — clean
- [ ] CI: build job (iphoneos + iphonesimulator)
- [ ] CI: test job
- [ ] CI: audit / pod-lint / sample-build
- [ ] Manual on iOS simulator: tap a `UIButton(accessibilityIdentifier: "checkout")` → observe one `user.interaction` with `target_id = "checkout"`. Tap a `UITextField(isSecureTextEntry: true)` → observe zero events.

## Notes

- The PR base is `feature/F1-package-build-infrastructure` (this repo's main PR trunk). Auto-close on merge only fires when the base is the repository's default branch — if that's not the case here, the linked issues #14/#62/#63 can be closed manually at merge time. The `Closes` keywords still create the link UI on each issue.