### PR TITLE
feat(F11): lifecycle + network connectivity capture

### DIFF
--- a/Sources/EdgeRum/EdgeRum.swift
+++ b/Sources/EdgeRum/EdgeRum.swift
@@ -225,6 +225,16 @@ public enum EdgeRum {
             MemorySampler.install(debug: config.debug)
             RunLoopObserverCapture.install(debug: config.debug)
         }
+
+        // F11 — install lifecycle + connectivity capture. Idempotent;
+        // each `install(...)` is a no-op on subsequent calls and on
+        // non-UIKit / non-Network hosts.
+        if config.captureLifecycle {
+            LifecycleCapture.install(debug: config.debug)
+        }
+        if config.captureNetworkChanges {
+            NetworkPathCapture.install(debug: config.debug)
+        }
     }
 
     /// Attach a host-app user profile to subsequent events. Calling

--- a/Sources/EdgeRum/EdgeRumConfig.swift
+++ b/Sources/EdgeRum/EdgeRumConfig.swift
@@ -125,6 +125,19 @@ public struct EdgeRumConfig: Sendable {
     /// detection (≥50 ms). Default `true`.
     public var captureRenderingPerformance: Bool = true
 
+    /// Capture app lifecycle transitions (`foregrounded` / `active` /
+    /// `inactive` / `backgrounded` / `will_terminate`) and emit a
+    /// session-finalize event on backgrounding so the in-memory buffer
+    /// is flushed before the OS suspends or kills the process.
+    /// Default `true`.
+    public var captureLifecycle: Bool = true
+
+    /// Capture network connectivity changes — emits one event per
+    /// transition carrying `network.type`, `network.effectiveType`,
+    /// `network.is_expensive`, `network.is_constrained`, and (iOS 14.2+)
+    /// `network.unsatisfied_reason`. Default `true`.
+    public var captureNetworkChanges: Bool = true
+
     // MARK: Diagnostics
 
     /// When `true`, the SDK logs verbose diagnostics via `os_log` and

--- a/Sources/EdgeRumCapture/LifecycleCapture.swift
+++ b/Sources/EdgeRumCapture/LifecycleCapture.swift
@@ -1,0 +1,243 @@
+// Sources/EdgeRumCapture/LifecycleCapture.swift
+//
+// F11 / T11.1 — UIApplication lifecycle capture.
+//
+// Subscribes to the five UIApplication notifications that map to the
+// `lifecycle.state` vocabulary (PLAN-iOS.md §6.18):
+//
+//   willResignActive       → "inactive"   + emit `session.finalized` (auto-flushes)
+//   didEnterBackground     → "backgrounded"
+//   willEnterForeground    → "foregrounded"
+//   didBecomeActive        → "active"     + drainOfflineQueue()
+//   willTerminate          → "will_terminate" + immediate finalize+flush
+//
+// Each transition emits one `app_lifecycle` event carrying
+// `lifecycle.state` and `lifecycle.previous_state` (the last state
+// this capture observed; `"unknown"` until the first transition).
+//
+// Recorder access: live `Recorder.shared` is fetched per emission;
+// tests swap a probe in via `Recorder.installShared(_:)`.
+//
+// All UIKit code is gated behind `#if canImport(UIKit) && os(iOS)` so
+// `swift test` on the macOS CI host still compiles this file.
+//
+// Refs: PLAN-iOS.md §F11/T11.1, §6.18; CLAUDE.md "eventName values" +
+//       "When in doubt checklist" items 1, 2, 4, 8, 10.
+//
+
+import Foundation
+#if canImport(UIKit) && os(iOS)
+import UIKit
+#endif
+import os.log
+#if canImport(EdgeRumCore)
+import EdgeRumCore
+#endif
+
+/// F11 installer — UIKit lifecycle capture.
+///
+/// `public` here only means "visible to other internal SDK targets
+/// and the test target". `EdgeRumCapture` is not a SwiftPM `product`,
+/// so consumers who write `import EdgeRum` never see this type.
+public enum LifecycleCapture {
+
+    // MARK: Diagnostics
+
+    private static let log = OSLog(subsystem: "com.edge.rum", category: "LifecycleCapture")
+
+    // MARK: Once token
+
+    private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
+        let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
+        p.initialize(to: os_unfair_lock())
+        return p
+    }()
+
+    nonisolated(unsafe) private static var _installed: Bool = false
+
+    /// `true` once `install(...)` has registered the lifecycle
+    /// observers. Read by tests and by the EdgeRum opt-out path.
+    public static var isInstalled: Bool {
+        os_unfair_lock_lock(installLock)
+        defer { os_unfair_lock_unlock(installLock) }
+        return _installed
+    }
+
+    // MARK: Previous-state tracking
+
+    /// Tracked transition target. `"unknown"` until the first
+    /// notification arrives.
+    nonisolated(unsafe) private static var previousState: String = "unknown"
+    private static let previousStateLock: UnsafeMutablePointer<os_unfair_lock> = {
+        let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
+        p.initialize(to: os_unfair_lock())
+        return p
+    }()
+
+    nonisolated(unsafe) private static var lifecycleObservers: [NSObjectProtocol] = []
+
+    // MARK: Public install
+
+    /// Install lifecycle capture. Idempotent + main-thread-safe; on
+    /// non-UIKit hosts (the macOS unit-test runner) this is a no-op.
+    public static func install(debug: Bool = false) {
+        #if canImport(UIKit) && os(iOS)
+        if Thread.isMainThread {
+            performInstall(debug: debug)
+        } else {
+            DispatchQueue.main.sync { performInstall(debug: debug) }
+        }
+        #else
+        _ = debug
+        #endif
+    }
+
+    // MARK: Pure attribute builder (test seam)
+
+    /// Build the `app_lifecycle` attribute bag for a given
+    /// `(newState, previousState)` pair. Pure; tests drive it directly.
+    static func makeAttributes(state: String, previousState: String) -> [String: AttributeValue] {
+        [
+            "lifecycle.state": .string(state),
+            "lifecycle.previous_state": .string(previousState)
+        ]
+    }
+
+    // MARK: Emission
+
+    /// Emit one `app_lifecycle` event with the supplied state. Updates
+    /// the internal previous-state pointer so the next emission carries
+    /// the correct transition source. Exposed `internal` so tests can
+    /// drive emission without posting real notifications.
+    static func emit(state: String) {
+        let recorder = Recorder.shared
+        guard recorder.isEnabled else { return }
+
+        os_unfair_lock_lock(previousStateLock)
+        let prior = previousState
+        previousState = state
+        os_unfair_lock_unlock(previousStateLock)
+
+        recorder.recordEvent(
+            name: "app_lifecycle",
+            attributes: makeAttributes(state: state, previousState: prior)
+        )
+    }
+
+    /// Emit `session.finalized` (which auto-flushes per Recorder
+    /// transport rules). Used on `willResignActive` and `willTerminate`
+    /// so the in-memory buffer is on the wire before the OS suspends
+    /// or kills the process.
+    static func emitSessionFinalized() {
+        let recorder = Recorder.shared
+        guard recorder.isEnabled else { return }
+        recorder.recordEvent(name: "session.finalized", attributes: [:])
+    }
+
+    // MARK: Install machinery
+
+    #if canImport(UIKit) && os(iOS)
+    private static func performInstall(debug: Bool) {
+        os_unfair_lock_lock(installLock)
+        if _installed {
+            os_unfair_lock_unlock(installLock)
+            return
+        }
+
+        let nc = NotificationCenter.default
+
+        let willResign = nc.addObserver(
+            forName: UIApplication.willResignActiveNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            LifecycleCapture.emit(state: "inactive")
+            LifecycleCapture.emitSessionFinalized()
+        }
+        let didEnterBackground = nc.addObserver(
+            forName: UIApplication.didEnterBackgroundNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            LifecycleCapture.emit(state: "backgrounded")
+        }
+        let willEnterForeground = nc.addObserver(
+            forName: UIApplication.willEnterForegroundNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            LifecycleCapture.emit(state: "foregrounded")
+        }
+        let didBecomeActive = nc.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            LifecycleCapture.emit(state: "active")
+            Recorder.shared.drainOfflineQueue()
+        }
+        let willTerminate = nc.addObserver(
+            forName: UIApplication.willTerminateNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            LifecycleCapture.emit(state: "will_terminate")
+            LifecycleCapture.emitSessionFinalized()
+        }
+
+        lifecycleObservers = [
+            willResign,
+            didEnterBackground,
+            willEnterForeground,
+            didBecomeActive,
+            willTerminate
+        ]
+        _installed = true
+        os_unfair_lock_unlock(installLock)
+
+        if debug {
+            os_log(
+                "LifecycleCapture installed",
+                log: log,
+                type: .info
+            )
+        }
+    }
+    #endif
+
+    // MARK: Test-only helpers
+
+    #if DEBUG
+    /// Tear down the registered observers and clear the install flag so
+    /// subsequent tests can drive `install()` from a clean state.
+    public static func _resetInstallFlagForTesting() {
+        os_unfair_lock_lock(installLock)
+        let nc = NotificationCenter.default
+        for token in lifecycleObservers {
+            nc.removeObserver(token)
+        }
+        lifecycleObservers.removeAll()
+        _installed = false
+        os_unfair_lock_unlock(installLock)
+
+        os_unfair_lock_lock(previousStateLock)
+        previousState = "unknown"
+        os_unfair_lock_unlock(previousStateLock)
+    }
+
+    /// Test seam — read the tracked previous state without emitting.
+    public static var _previousStateForTesting: String {
+        os_unfair_lock_lock(previousStateLock)
+        defer { os_unfair_lock_unlock(previousStateLock) }
+        return previousState
+    }
+
+    /// Test seam — reset just the tracked previous state without
+    /// touching install observers.
+    public static func _resetPreviousStateForTesting() {
+        os_unfair_lock_lock(previousStateLock)
+        previousState = "unknown"
+        os_unfair_lock_unlock(previousStateLock)
+    }
+    #endif
+}

--- a/Sources/EdgeRumCapture/NetworkPathCapture.swift
+++ b/Sources/EdgeRumCapture/NetworkPathCapture.swift
@@ -1,0 +1,275 @@
+// Sources/EdgeRumCapture/NetworkPathCapture.swift
+//
+// F11 / T11.2 — NWPathMonitor-driven connectivity capture.
+//
+// Owns one `NetworkPathObserver` (the shared wrapper in
+// `EdgeRumCore/Context/NetworkContext.swift`) and on every transition:
+//
+//   1. Refreshes `Recorder.refreshNetworkContext(_:)` so subsequent
+//      events carry the new `network.type` / `network.effectiveType`.
+//   2. Emits one `network_change` event with the wire keys from
+//      PLAN-iOS.md §6.19:
+//        - network.type
+//        - network.effectiveType
+//        - network.is_expensive
+//        - network.is_constrained
+//        - network.unsatisfied_reason (iOS 14.2+, omitted on 14.0/14.1
+//          and omitted when path is satisfied)
+//
+// Duplicate transitions (same NetworkType + effectiveType + flags +
+// unsatisfied reason as the last emission) are dropped so a chatty
+// monitor doesn't flood the wire.
+//
+// Recorder access: live `Recorder.shared` is fetched per emission;
+// tests swap a probe in via `Recorder.installShared(_:)`.
+//
+// The `Network.framework` types compile on macOS too, so this file is
+// NOT gated behind `#if os(iOS)` — only the actual NWPathMonitor
+// activation runs on iOS via `install(...)`.
+//
+// Refs: PLAN-iOS.md §F11/T11.2, §6.19; CLAUDE.md "eventName values" +
+//       "When in doubt checklist" items 1, 2, 4, 10.
+//
+
+import Foundation
+import Network
+import os.log
+#if canImport(EdgeRumCore)
+import EdgeRumCore
+#endif
+
+/// F11 installer — connectivity-change capture.
+///
+/// `public` here only means "visible to other internal SDK targets and
+/// the test target". `EdgeRumCapture` is not a SwiftPM `product`, so
+/// consumers who write `import EdgeRum` never see this type.
+public enum NetworkPathCapture {
+
+    // MARK: Diagnostics
+
+    private static let log = OSLog(subsystem: "com.edge.rum", category: "NetworkPathCapture")
+
+    // MARK: Once token
+
+    private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
+        let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
+        p.initialize(to: os_unfair_lock())
+        return p
+    }()
+
+    nonisolated(unsafe) private static var _installed: Bool = false
+
+    /// `true` once `install(...)` has armed the path observer.
+    public static var isInstalled: Bool {
+        os_unfair_lock_lock(installLock)
+        defer { os_unfair_lock_unlock(installLock) }
+        return _installed
+    }
+
+    nonisolated(unsafe) private static var sharedObserver: NetworkPathObserver?
+
+    // MARK: Dedupe state
+
+    /// Fingerprint of the last emitted transition. Compared against the
+    /// next transition's fingerprint; identical => skip the emit. Kept
+    /// as a hashable struct so the comparison is one `==`.
+    fileprivate struct Fingerprint: Hashable {
+        let type: NetworkContext.NetworkType
+        let effectiveType: String
+        let isExpensive: Bool
+        let isConstrained: Bool
+        let unsatisfiedReason: String?
+    }
+
+    private static let fingerprintLock: UnsafeMutablePointer<os_unfair_lock> = {
+        let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
+        p.initialize(to: os_unfair_lock())
+        return p
+    }()
+    nonisolated(unsafe) private static var lastFingerprint: Fingerprint?
+
+    // MARK: Public install
+
+    /// Install network-path capture. Idempotent + thread-safe; on
+    /// platforms without `Network.framework` runtime support this is a
+    /// no-op (compile-time guard not needed — Network is part of the
+    /// base SDK on iOS / macOS test hosts).
+    public static func install(debug: Bool = false) {
+        os_unfair_lock_lock(installLock)
+        if _installed {
+            os_unfair_lock_unlock(installLock)
+            return
+        }
+        let observer = NetworkPathObserver()
+        sharedObserver = observer
+        _installed = true
+        os_unfair_lock_unlock(installLock)
+
+        observer.start { context, path in
+            NetworkPathCapture.handle(context: context, path: path)
+        }
+
+        if debug {
+            os_log(
+                "NetworkPathCapture installed",
+                log: log,
+                type: .info
+            )
+        }
+    }
+
+    // MARK: Pure attribute builder (test seam)
+
+    /// Build the `network_change` attribute bag. Pure; tests drive it
+    /// directly to cover every NetworkType + flag combination.
+    ///
+    /// `unsatisfiedReason` is omitted from the bag entirely when `nil`
+    /// — never set to `"unknown"` — so the iOS 14.0/14.1 absence is
+    /// faithfully reflected on the wire.
+    static func makeAttributes(
+        context: NetworkContext,
+        isExpensive: Bool,
+        isConstrained: Bool,
+        unsatisfiedReason: String?
+    ) -> [String: AttributeValue] {
+        var attrs: [String: AttributeValue] = [
+            "network.type": .string(context.type.rawValue),
+            "network.effectiveType": .string(context.effectiveType),
+            "network.is_expensive": .bool(isExpensive),
+            "network.is_constrained": .bool(isConstrained)
+        ]
+        if let reason = unsatisfiedReason {
+            attrs["network.unsatisfied_reason"] = .string(reason)
+        }
+        return attrs
+    }
+
+    /// Map `NWPath.UnsatisfiedReason` (iOS 14.2+) to a wire string.
+    /// `nil` when the path is satisfied. The host-OS gate (`@available`)
+    /// is at the call site; this helper just stringifies a value.
+    @available(iOS 14.2, macOS 11.0, *)
+    static func unsatisfiedReasonString(_ reason: NWPath.UnsatisfiedReason) -> String {
+        // Cases by introduction:
+        //   iOS 14.2 / macOS 11.0 : notAvailable, cellularDenied,
+        //                            wifiDenied, localNetworkDenied
+        //   iOS 16.0 / macOS 14.0 : vpnInactive
+        // The vpnInactive availability check is split out so the
+        // exhaustive `switch` below can compile against the iOS-14.2
+        // SDK base.
+        if #available(iOS 16.0, macOS 14.0, *), reason == .vpnInactive {
+            return "vpn_inactive"
+        }
+        switch reason {
+        case .notAvailable: return "not_available"
+        case .cellularDenied: return "cellular_denied"
+        case .wifiDenied: return "wifi_denied"
+        case .localNetworkDenied: return "local_network_denied"
+        @unknown default: return "unknown"
+        }
+    }
+
+    // MARK: Transition handler
+
+    /// Internal entry point — pull the extras off the raw path, refresh
+    /// the Recorder context, and emit `network_change` if this is a
+    /// genuine transition. Exposed `internal` so tests can drive it
+    /// without a live `NWPathMonitor`.
+    static func handle(context: NetworkContext, path: NWPath) {
+        let isExpensive = path.isExpensive
+        let isConstrained: Bool
+        if #available(iOS 13.0, macOS 10.15, *) {
+            isConstrained = path.isConstrained
+        } else {
+            isConstrained = false
+        }
+        let reason: String?
+        if path.status != .satisfied {
+            if #available(iOS 14.2, macOS 11.0, *) {
+                reason = unsatisfiedReasonString(path.unsatisfiedReason)
+            } else {
+                reason = nil
+            }
+        } else {
+            reason = nil
+        }
+        emit(
+            context: context,
+            isExpensive: isExpensive,
+            isConstrained: isConstrained,
+            unsatisfiedReason: reason
+        )
+    }
+
+    /// Internal test seam — emit a transition built from precomputed
+    /// extras. Refreshes the Recorder's `NetworkContext`, then emits
+    /// `network_change` unless the fingerprint matches the last
+    /// emission.
+    static func emit(
+        context: NetworkContext,
+        isExpensive: Bool,
+        isConstrained: Bool,
+        unsatisfiedReason: String?
+    ) {
+        let recorder = Recorder.shared
+        guard recorder.isEnabled else { return }
+
+        // Always refresh the snapshot so subsequent events ride under
+        // the live network attributes — even when we dedup the change
+        // event itself. (Cheap; the lock inside ContextProvider is the
+        // only cost.)
+        recorder.refreshNetworkContext(context)
+
+        let fp = Fingerprint(
+            type: context.type,
+            effectiveType: context.effectiveType,
+            isExpensive: isExpensive,
+            isConstrained: isConstrained,
+            unsatisfiedReason: unsatisfiedReason
+        )
+
+        os_unfair_lock_lock(fingerprintLock)
+        let prior = lastFingerprint
+        if prior == fp {
+            os_unfair_lock_unlock(fingerprintLock)
+            return
+        }
+        lastFingerprint = fp
+        os_unfair_lock_unlock(fingerprintLock)
+
+        recorder.recordEvent(
+            name: "network_change",
+            attributes: makeAttributes(
+                context: context,
+                isExpensive: isExpensive,
+                isConstrained: isConstrained,
+                unsatisfiedReason: unsatisfiedReason
+            )
+        )
+    }
+
+    // MARK: Test-only helpers
+
+    #if DEBUG
+    /// Tear down the running observer and clear the install flag so
+    /// subsequent tests can drive `install()` from a clean state.
+    public static func _resetInstallFlagForTesting() {
+        os_unfair_lock_lock(installLock)
+        sharedObserver?.stop()
+        sharedObserver = nil
+        _installed = false
+        os_unfair_lock_unlock(installLock)
+
+        os_unfair_lock_lock(fingerprintLock)
+        lastFingerprint = nil
+        os_unfair_lock_unlock(fingerprintLock)
+    }
+
+    /// Test seam — clear just the dedupe fingerprint so a second
+    /// `emit(...)` with the same shape re-emits.
+    public static func _resetDedupeFingerprintForTesting() {
+        os_unfair_lock_lock(fingerprintLock)
+        lastFingerprint = nil
+        os_unfair_lock_unlock(fingerprintLock)
+    }
+    #endif
+}

--- a/Sources/EdgeRumCore/Context/NetworkContext.swift
+++ b/Sources/EdgeRumCore/Context/NetworkContext.swift
@@ -67,26 +67,32 @@ public struct NetworkContext: Sendable, Hashable {
 /// Long-lived `NWPathMonitor` wrapper. Owned by the `ContextProvider`;
 /// invokes its callback on every path transition so the merged
 /// context bag stays current.
+///
+/// The callback receives both the wire-shape `NetworkContext` and the
+/// raw `NWPath` so call-sites that only need the wire snapshot can
+/// ignore the path arg, while F11's `NetworkPathCapture` can read
+/// `isExpensive` / `isConstrained` / `unsatisfiedReason` (iOS 14.2+)
+/// off the same transition without instantiating a second monitor.
 public final class NetworkPathObserver: @unchecked Sendable {
 
     private let monitor: NWPathMonitor
     private let queue: DispatchQueue
     private let lock = NSLock()
-    private var _onChange: ((NetworkContext) -> Void)?
+    private var _onChange: ((NetworkContext, NWPath) -> Void)?
 
     public init(queue: DispatchQueue = DispatchQueue(label: "edge.rum.network", qos: .utility)) {
         self.monitor = NWPathMonitor()
         self.queue = queue
     }
 
-    public func start(onChange: @escaping (NetworkContext) -> Void) {
+    public func start(onChange: @escaping (NetworkContext, NWPath) -> Void) {
         lock.lock(); _onChange = onChange; lock.unlock()
         monitor.pathUpdateHandler = { [weak self] path in
             guard let self else { return }
             self.lock.lock()
             let callback = self._onChange
             self.lock.unlock()
-            callback?(NetworkContext.from(path))
+            callback?(NetworkContext.from(path), path)
         }
         monitor.start(queue: queue)
     }

--- a/Sources/EdgeRumCore/Recorder.swift
+++ b/Sources/EdgeRumCore/Recorder.swift
@@ -425,13 +425,22 @@ public final class Recorder: Recording, @unchecked Sendable {
     }
 
     /// Forward an offline-queue drain request to the installed
-    /// transport. Called from `EdgeRum.enable()` and (later) F11's
+    /// transport. Called from `EdgeRum.enable()` and F11's
     /// `didBecomeActive` lifecycle hook.
     public func drainOfflineQueue() {
         stateLock.lock()
         let currentTransport = transport
         stateLock.unlock()
         currentTransport.drainOfflineQueue()
+    }
+
+    /// Refresh the in-memory `NetworkContext` so subsequent events
+    /// carry the new `network.type` / `network.effectiveType` /
+    /// derived flags. F11's `NetworkPathCapture` calls this from its
+    /// `NWPathMonitor` callback before emitting the `network_change`
+    /// event so the event itself rides under the refreshed context.
+    public func refreshNetworkContext(_ network: NetworkContext) {
+        context.refreshNetwork(network)
     }
 
     /// Drain the buffer and stop. Equivalent to `stop()` plus the

--- a/Sources/EdgeRumCore/Recording.swift
+++ b/Sources/EdgeRumCore/Recording.swift
@@ -58,6 +58,16 @@ public protocol Recording: AnyObject, Sendable {
     func recordError(domain: String, code: Int, message: String?, context: [String: AttributeValue])
 
     func setUser(_ user: RecorderUser)
+
+    /// Update the in-memory `NetworkContext` so subsequent events
+    /// carry the new `network.type` / `network.effectiveType`.
+    /// F11's `NetworkPathCapture` calls this on every NWPath transition.
+    func refreshNetworkContext(_ context: NetworkContext)
+
+    /// Forward an offline-queue drain request to the installed
+    /// transport. Called from `EdgeRum.enable()` and F11's
+    /// `didBecomeActive` lifecycle hook.
+    func drainOfflineQueue()
 }
 
 public extension Recording {
@@ -66,4 +76,14 @@ public extension Recording {
     func configure(_ config: RecorderConfig) {
         _ = config
     }
+
+    /// Default no-op so existing test probes don't have to adopt the
+    /// new requirement. The real `Recorder` overrides this.
+    func refreshNetworkContext(_ context: NetworkContext) {
+        _ = context
+    }
+
+    /// Default no-op so existing test probes don't have to adopt the
+    /// new requirement. The real `Recorder` overrides this.
+    func drainOfflineQueue() { }
 }

--- a/Sources/EdgeRumCore/Transport/HTTPTransportSink.swift
+++ b/Sources/EdgeRumCore/Transport/HTTPTransportSink.swift
@@ -196,7 +196,7 @@ public final class HTTPTransportSink: TransportSink, @unchecked Sendable {
 
     private func startPathObserver() {
         guard let pathObserver else { return }
-        pathObserver.start { [weak self] context in
+        pathObserver.start { [weak self] context, _ in
             guard let self else { return }
             let satisfied = context.type != .none
             self.pathObserverLock.lock()

--- a/Tests/EdgeRumCaptureTests/LifecycleCaptureTests.swift
+++ b/Tests/EdgeRumCaptureTests/LifecycleCaptureTests.swift
@@ -1,0 +1,407 @@
+// Tests/EdgeRumCaptureTests/LifecycleCaptureTests.swift
+//
+// F11 / T11.1 unit tests. Covers:
+//
+//   - makeAttributes: lifecycle.state / lifecycle.previous_state
+//     primitives-only shape for every state pair.
+//   - emit(state:) routes through Recorder.shared.recordEvent with
+//     `app_lifecycle`, carrying the right (state, previous_state).
+//   - emit(state:) updates the internal previous-state pointer so
+//     consecutive emissions chain correctly.
+//   - emitSessionFinalized() routes through Recorder.shared.recordEvent
+//     with `session.finalized`.
+//   - install() idempotent + concurrent-safe (just exercises the
+//     install/uninstall cycle — the actual notification fan-out is
+//     covered by the iOS-only path below).
+//   - Recorder.isEnabled = false halts emission.
+//
+// Notification-driven coverage:
+//   On iOS we post each UIApplication notification by hand and assert
+//   the right calls land on the probe recorder (drainOfflineQueue
+//   for didBecomeActive, session.finalized auto-emit on willResignActive
+//   and willTerminate, etc.).
+//
+// Refs: PLAN-iOS.md §F11/T11.1 acceptance; CLAUDE.md "Testing
+//       conventions".
+//
+
+import XCTest
+import Foundation
+import EdgeRumCore
+@testable import EdgeRumCapture
+#if canImport(UIKit) && os(iOS)
+import UIKit
+#endif
+
+// MARK: - Local probe recorder with drain tracking
+
+private final class CaptureProbeRecorder: Recording, @unchecked Sendable {
+
+    enum Call: Equatable {
+        case event(name: String, attributes: [String: AttributeValue])
+        case performance(name: String, attributes: [String: AttributeValue])
+        case drain
+        case refreshNetwork(NetworkContext)
+    }
+
+    private let lock = NSLock()
+    private var _calls: [Call] = []
+    private var _enabled: Bool = true
+    private let _clock: Clock
+
+    init(clock: Clock = SystemClock(), enabled: Bool = true) {
+        self._clock = clock
+        self._enabled = enabled
+    }
+
+    var calls: [Call] {
+        lock.lock(); defer { lock.unlock() }
+        return _calls
+    }
+
+    var clock: Clock { _clock }
+    var currentSessionId: String { "session_0_0000000000000000_ios" }
+    var currentDeviceId: String { "device_0_0000000000000000_ios" }
+
+    var isEnabled: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _enabled
+    }
+
+    func configure(_ config: RecorderConfig) { _ = config }
+    func start(apiKey: String, endpoint: URL, debug: Bool) {
+        _ = (apiKey, endpoint, debug)
+    }
+    func stop() {}
+    func setEnabled(_ enabled: Bool) {
+        lock.lock(); _enabled = enabled; lock.unlock()
+    }
+
+    func recordEvent(name: String, attributes: [String: AttributeValue]) {
+        lock.lock()
+        _calls.append(.event(name: name, attributes: attributes))
+        lock.unlock()
+    }
+
+    func recordPerformance(name: String, attributes: [String: AttributeValue]) {
+        lock.lock()
+        _calls.append(.performance(name: name, attributes: attributes))
+        lock.unlock()
+    }
+
+    func recordError(
+        domain: String, code: Int, message: String?,
+        context: [String: AttributeValue]
+    ) {
+        _ = (domain, code, message, context)
+    }
+
+    func setUser(_ user: RecorderUser) { _ = user }
+
+    func refreshNetworkContext(_ context: NetworkContext) {
+        lock.lock()
+        _calls.append(.refreshNetwork(context))
+        lock.unlock()
+    }
+
+    func drainOfflineQueue() {
+        lock.lock()
+        _calls.append(.drain)
+        lock.unlock()
+    }
+}
+
+final class LifecycleCaptureTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        LifecycleCapture._resetPreviousStateForTesting()
+    }
+
+    override func tearDown() {
+        LifecycleCapture._resetInstallFlagForTesting()
+        Recorder.resetShared()
+        super.tearDown()
+    }
+
+    // MARK: makeAttributes shape
+
+    func test_makeAttributes_shape() {
+        let attrs = LifecycleCapture.makeAttributes(
+            state: "active",
+            previousState: "inactive"
+        )
+        XCTAssertEqual(attrs["lifecycle.state"], .string("active"))
+        XCTAssertEqual(attrs["lifecycle.previous_state"], .string("inactive"))
+        XCTAssertEqual(attrs.count, 2)
+    }
+
+    func test_makeAttributes_unknownPrevious_onFirstEmission() {
+        let attrs = LifecycleCapture.makeAttributes(
+            state: "foregrounded",
+            previousState: "unknown"
+        )
+        XCTAssertEqual(attrs["lifecycle.previous_state"], .string("unknown"))
+    }
+
+    // MARK: emit routes through Recorder.shared.recordEvent
+
+    func test_emit_routes_app_lifecycle_to_recorder() {
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+
+        LifecycleCapture.emit(state: "backgrounded")
+
+        XCTAssertEqual(probe.calls.count, 1)
+        guard case let .event(name, attrs) = probe.calls[0] else {
+            XCTFail("Expected event call, got \(probe.calls[0])")
+            return
+        }
+        XCTAssertEqual(name, "app_lifecycle")
+        XCTAssertEqual(attrs["lifecycle.state"], .string("backgrounded"))
+        XCTAssertEqual(attrs["lifecycle.previous_state"], .string("unknown"))
+    }
+
+    func test_emit_chainsPreviousState_acrossCalls() {
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+
+        LifecycleCapture.emit(state: "inactive")
+        LifecycleCapture.emit(state: "backgrounded")
+        LifecycleCapture.emit(state: "foregrounded")
+        LifecycleCapture.emit(state: "active")
+
+        XCTAssertEqual(probe.calls.count, 4)
+        // Each event's previous_state matches the prior emission's
+        // new state.
+        guard case let .event(_, a0) = probe.calls[0],
+              case let .event(_, a1) = probe.calls[1],
+              case let .event(_, a2) = probe.calls[2],
+              case let .event(_, a3) = probe.calls[3] else {
+            XCTFail("Expected four event calls")
+            return
+        }
+        XCTAssertEqual(a0["lifecycle.previous_state"], .string("unknown"))
+        XCTAssertEqual(a1["lifecycle.previous_state"], .string("inactive"))
+        XCTAssertEqual(a2["lifecycle.previous_state"], .string("backgrounded"))
+        XCTAssertEqual(a3["lifecycle.previous_state"], .string("foregrounded"))
+    }
+
+    func test_emit_disabledRecorder_short_circuits() {
+        let probe = CaptureProbeRecorder(enabled: false)
+        Recorder.installShared(probe)
+
+        LifecycleCapture.emit(state: "active")
+
+        XCTAssertTrue(probe.calls.isEmpty)
+    }
+
+    // MARK: emitSessionFinalized
+
+    func test_emitSessionFinalized_routesToRecorder() {
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+
+        LifecycleCapture.emitSessionFinalized()
+
+        XCTAssertEqual(probe.calls.count, 1)
+        guard case let .event(name, attrs) = probe.calls[0] else {
+            XCTFail("Expected event call, got \(probe.calls[0])")
+            return
+        }
+        XCTAssertEqual(name, "session.finalized")
+        XCTAssertTrue(attrs.isEmpty, "session.finalized rides on context-only attributes")
+    }
+
+    func test_emitSessionFinalized_disabledRecorder_short_circuits() {
+        let probe = CaptureProbeRecorder(enabled: false)
+        Recorder.installShared(probe)
+
+        LifecycleCapture.emitSessionFinalized()
+
+        XCTAssertTrue(probe.calls.isEmpty)
+    }
+
+    // MARK: install — idempotent
+    //
+    // The install body is gated behind `#if canImport(UIKit) && os(iOS)`
+    // so on the macOS test runner `install(...)` is a no-op and
+    // `isInstalled` stays `false`. The concurrent-safety test only
+    // makes sense on iOS where the install body actually runs.
+
+    #if canImport(UIKit) && os(iOS)
+
+    func test_install_isIdempotent() {
+        XCTAssertFalse(LifecycleCapture.isInstalled)
+        LifecycleCapture.install(debug: false)
+        XCTAssertTrue(LifecycleCapture.isInstalled)
+        LifecycleCapture.install(debug: false)
+        XCTAssertTrue(LifecycleCapture.isInstalled)
+    }
+
+    func test_install_concurrent_callsAreSafe() {
+        let group = DispatchGroup()
+        for _ in 0..<32 {
+            group.enter()
+            DispatchQueue.global().async {
+                LifecycleCapture.install(debug: false)
+                group.leave()
+            }
+        }
+        XCTAssertEqual(group.wait(timeout: .now() + 5.0), .success)
+        XCTAssertTrue(LifecycleCapture.isInstalled)
+    }
+
+    #else
+
+    func test_install_isNoop_onNonUIKitHost() {
+        XCTAssertFalse(LifecycleCapture.isInstalled)
+        LifecycleCapture.install(debug: false)
+        XCTAssertFalse(LifecycleCapture.isInstalled,
+                       "Non-UIKit hosts must remain uninstalled — no UIApplication notifications to observe")
+    }
+
+    #endif
+
+    // MARK: Notification-driven fan-out — iOS only
+
+    #if canImport(UIKit) && os(iOS)
+
+    func test_willResignActive_emits_inactive_and_sessionFinalized() {
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+        LifecycleCapture.install(debug: false)
+
+        let expectation = expectation(description: "main runloop drained")
+        NotificationCenter.default.post(
+            name: UIApplication.willResignActiveNotification,
+            object: nil
+        )
+        DispatchQueue.main.async {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        let calls = probe.calls
+        let eventNames = calls.compactMap { call -> String? in
+            if case let .event(name, _) = call { return name } else { return nil }
+        }
+        XCTAssertTrue(eventNames.contains("app_lifecycle"))
+        XCTAssertTrue(eventNames.contains("session.finalized"))
+
+        guard let lifecycle = calls.first(where: { call in
+            if case let .event(name, _) = call { return name == "app_lifecycle" }
+            return false
+        }), case let .event(_, attrs) = lifecycle else {
+            XCTFail("Expected an app_lifecycle event")
+            return
+        }
+        XCTAssertEqual(attrs["lifecycle.state"], .string("inactive"))
+    }
+
+    func test_didBecomeActive_emits_active_and_drainsOfflineQueue() {
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+        LifecycleCapture.install(debug: false)
+
+        let expectation = expectation(description: "main runloop drained")
+        NotificationCenter.default.post(
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+        DispatchQueue.main.async {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        let calls = probe.calls
+        XCTAssertTrue(calls.contains { call in
+            if case let .event(name, attrs) = call {
+                return name == "app_lifecycle" &&
+                    attrs["lifecycle.state"] == .string("active")
+            }
+            return false
+        })
+        XCTAssertTrue(calls.contains(.drain))
+    }
+
+    func test_didEnterBackground_emits_backgrounded() {
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+        LifecycleCapture.install(debug: false)
+
+        let expectation = expectation(description: "main runloop drained")
+        NotificationCenter.default.post(
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+        DispatchQueue.main.async {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertTrue(probe.calls.contains { call in
+            if case let .event(name, attrs) = call {
+                return name == "app_lifecycle" &&
+                    attrs["lifecycle.state"] == .string("backgrounded")
+            }
+            return false
+        })
+    }
+
+    func test_willEnterForeground_emits_foregrounded() {
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+        LifecycleCapture.install(debug: false)
+
+        let expectation = expectation(description: "main runloop drained")
+        NotificationCenter.default.post(
+            name: UIApplication.willEnterForegroundNotification,
+            object: nil
+        )
+        DispatchQueue.main.async {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        XCTAssertTrue(probe.calls.contains { call in
+            if case let .event(name, attrs) = call {
+                return name == "app_lifecycle" &&
+                    attrs["lifecycle.state"] == .string("foregrounded")
+            }
+            return false
+        })
+    }
+
+    func test_willTerminate_emits_will_terminate_and_sessionFinalized() {
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+        LifecycleCapture.install(debug: false)
+
+        let expectation = expectation(description: "main runloop drained")
+        NotificationCenter.default.post(
+            name: UIApplication.willTerminateNotification,
+            object: nil
+        )
+        DispatchQueue.main.async {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        let names = probe.calls.compactMap { call -> String? in
+            if case let .event(name, _) = call { return name } else { return nil }
+        }
+        XCTAssertTrue(names.contains("app_lifecycle"))
+        XCTAssertTrue(names.contains("session.finalized"))
+
+        XCTAssertTrue(probe.calls.contains { call in
+            if case let .event(name, attrs) = call {
+                return name == "app_lifecycle" &&
+                    attrs["lifecycle.state"] == .string("will_terminate")
+            }
+            return false
+        })
+    }
+
+    #endif
+}

--- a/Tests/EdgeRumCaptureTests/NetworkPathCaptureTests.swift
+++ b/Tests/EdgeRumCaptureTests/NetworkPathCaptureTests.swift
@@ -1,0 +1,360 @@
+// Tests/EdgeRumCaptureTests/NetworkPathCaptureTests.swift
+//
+// F11 / T11.2 unit tests. Covers:
+//
+//   - makeAttributes: every NetworkType (wifi/cellular/wired/none/unknown)
+//     plus the expensive/constrained matrix; primitives-only shape.
+//   - makeAttributes omits `network.unsatisfied_reason` when nil — never
+//     emits a sentinel `"unknown"` string. (iOS 14.0/14.1 parity.)
+//   - unsatisfiedReasonString returns stable wire strings for every
+//     case present at iOS 14.2+.
+//   - emit(...) refreshes the Recorder context bag on every call,
+//     even when the change-event itself is deduped.
+//   - emit(...) deduplicates identical transitions — same
+//     (type/effectiveType/expensive/constrained/reason) fingerprint
+//     produces exactly one event.
+//   - emit(...) re-fires on any single-field change.
+//   - install() is idempotent and concurrent-safe.
+//   - Recorder.isEnabled = false halts both refresh AND emit.
+//
+// Refs: PLAN-iOS.md §F11/T11.2 acceptance; CLAUDE.md "Testing
+//       conventions".
+//
+
+import XCTest
+import Foundation
+import Network
+import EdgeRumCore
+@testable import EdgeRumCapture
+
+// MARK: - Local probe recorder with refresh + drain tracking
+
+private final class CaptureProbeRecorder: Recording, @unchecked Sendable {
+
+    enum Call: Equatable {
+        case event(name: String, attributes: [String: AttributeValue])
+        case performance(name: String, attributes: [String: AttributeValue])
+        case drain
+        case refreshNetwork(NetworkContext)
+    }
+
+    private let lock = NSLock()
+    private var _calls: [Call] = []
+    private var _enabled: Bool = true
+    private let _clock: Clock
+
+    init(clock: Clock = SystemClock(), enabled: Bool = true) {
+        self._clock = clock
+        self._enabled = enabled
+    }
+
+    var calls: [Call] {
+        lock.lock(); defer { lock.unlock() }
+        return _calls
+    }
+
+    var clock: Clock { _clock }
+    var currentSessionId: String { "session_0_0000000000000000_ios" }
+    var currentDeviceId: String { "device_0_0000000000000000_ios" }
+
+    var isEnabled: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return _enabled
+    }
+
+    func configure(_ config: RecorderConfig) { _ = config }
+    func start(apiKey: String, endpoint: URL, debug: Bool) {
+        _ = (apiKey, endpoint, debug)
+    }
+    func stop() {}
+    func setEnabled(_ enabled: Bool) {
+        lock.lock(); _enabled = enabled; lock.unlock()
+    }
+
+    func recordEvent(name: String, attributes: [String: AttributeValue]) {
+        lock.lock()
+        _calls.append(.event(name: name, attributes: attributes))
+        lock.unlock()
+    }
+
+    func recordPerformance(name: String, attributes: [String: AttributeValue]) {
+        lock.lock()
+        _calls.append(.performance(name: name, attributes: attributes))
+        lock.unlock()
+    }
+
+    func recordError(
+        domain: String, code: Int, message: String?,
+        context: [String: AttributeValue]
+    ) {
+        _ = (domain, code, message, context)
+    }
+
+    func setUser(_ user: RecorderUser) { _ = user }
+
+    func refreshNetworkContext(_ context: NetworkContext) {
+        lock.lock()
+        _calls.append(.refreshNetwork(context))
+        lock.unlock()
+    }
+
+    func drainOfflineQueue() {
+        lock.lock()
+        _calls.append(.drain)
+        lock.unlock()
+    }
+}
+
+final class NetworkPathCaptureTests: XCTestCase {
+
+    override func tearDown() {
+        NetworkPathCapture._resetInstallFlagForTesting()
+        Recorder.resetShared()
+        super.tearDown()
+    }
+
+    // MARK: makeAttributes — wire shape
+
+    func test_makeAttributes_wifi_omits_unsatisfied_reason() {
+        let attrs = NetworkPathCapture.makeAttributes(
+            context: NetworkContext(type: .wifi, effectiveType: "wifi"),
+            isExpensive: false,
+            isConstrained: false,
+            unsatisfiedReason: nil
+        )
+        XCTAssertEqual(attrs["network.type"], .string("wifi"))
+        XCTAssertEqual(attrs["network.effectiveType"], .string("wifi"))
+        XCTAssertEqual(attrs["network.is_expensive"], .bool(false))
+        XCTAssertEqual(attrs["network.is_constrained"], .bool(false))
+        XCTAssertNil(attrs["network.unsatisfied_reason"],
+                     "Reason key must be entirely absent — never a sentinel string")
+        XCTAssertEqual(attrs.count, 4)
+    }
+
+    func test_makeAttributes_cellular_expensive() {
+        let attrs = NetworkPathCapture.makeAttributes(
+            context: NetworkContext(type: .cellular, effectiveType: "cellular"),
+            isExpensive: true,
+            isConstrained: false,
+            unsatisfiedReason: nil
+        )
+        XCTAssertEqual(attrs["network.type"], .string("cellular"))
+        XCTAssertEqual(attrs["network.is_expensive"], .bool(true))
+        XCTAssertEqual(attrs["network.is_constrained"], .bool(false))
+    }
+
+    func test_makeAttributes_none_with_unsatisfied_reason() {
+        let attrs = NetworkPathCapture.makeAttributes(
+            context: NetworkContext(type: .none, effectiveType: "unknown"),
+            isExpensive: false,
+            isConstrained: false,
+            unsatisfiedReason: "cellular_denied"
+        )
+        XCTAssertEqual(attrs["network.type"], .string("none"))
+        XCTAssertEqual(attrs["network.unsatisfied_reason"], .string("cellular_denied"))
+        XCTAssertEqual(attrs.count, 5)
+    }
+
+    func test_makeAttributes_wired_constrained() {
+        let attrs = NetworkPathCapture.makeAttributes(
+            context: NetworkContext(type: .wired, effectiveType: "wired"),
+            isExpensive: false,
+            isConstrained: true,
+            unsatisfiedReason: nil
+        )
+        XCTAssertEqual(attrs["network.type"], .string("wired"))
+        XCTAssertEqual(attrs["network.is_constrained"], .bool(true))
+    }
+
+    func test_makeAttributes_unknown_type_path() {
+        let attrs = NetworkPathCapture.makeAttributes(
+            context: NetworkContext(type: .unknown, effectiveType: "unknown"),
+            isExpensive: false,
+            isConstrained: false,
+            unsatisfiedReason: nil
+        )
+        XCTAssertEqual(attrs["network.type"], .string("unknown"))
+    }
+
+    func test_makeAttributes_values_are_primitives_only() {
+        let attrs = NetworkPathCapture.makeAttributes(
+            context: NetworkContext(type: .wifi, effectiveType: "wifi"),
+            isExpensive: false,
+            isConstrained: false,
+            unsatisfiedReason: nil
+        )
+        for (key, value) in attrs {
+            switch value {
+            case .string, .int, .double, .bool:
+                continue
+            }
+            XCTFail("Non-primitive value \(value) at key \(key)")
+        }
+    }
+
+    // MARK: unsatisfiedReasonString mapping (iOS 14.2+)
+
+    func test_unsatisfiedReasonString_mapsKnownCases() {
+        if #available(iOS 14.2, macOS 11.0, *) {
+            XCTAssertEqual(
+                NetworkPathCapture.unsatisfiedReasonString(.notAvailable),
+                "not_available"
+            )
+            XCTAssertEqual(
+                NetworkPathCapture.unsatisfiedReasonString(.cellularDenied),
+                "cellular_denied"
+            )
+            XCTAssertEqual(
+                NetworkPathCapture.unsatisfiedReasonString(.wifiDenied),
+                "wifi_denied"
+            )
+            XCTAssertEqual(
+                NetworkPathCapture.unsatisfiedReasonString(.localNetworkDenied),
+                "local_network_denied"
+            )
+        }
+    }
+
+    // MARK: emit(...) routes to Recorder + refreshes context
+
+    func test_emit_refreshesContext_evenBeforeEvent() {
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+
+        let context = NetworkContext(type: .wifi, effectiveType: "wifi")
+        NetworkPathCapture.emit(
+            context: context,
+            isExpensive: false,
+            isConstrained: false,
+            unsatisfiedReason: nil
+        )
+
+        XCTAssertTrue(probe.calls.contains(.refreshNetwork(context)),
+                      "ContextProvider must see the new path BEFORE the event emits")
+    }
+
+    func test_emit_emitsNetworkChange_withFullAttributeBag() {
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+
+        NetworkPathCapture.emit(
+            context: NetworkContext(type: .cellular, effectiveType: "cellular"),
+            isExpensive: true,
+            isConstrained: false,
+            unsatisfiedReason: nil
+        )
+
+        let events = probe.calls.compactMap { call -> (String, [String: AttributeValue])? in
+            if case let .event(name, attrs) = call { return (name, attrs) } else { return nil }
+        }
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events[0].0, "network_change")
+        XCTAssertEqual(events[0].1["network.type"], .string("cellular"))
+        XCTAssertEqual(events[0].1["network.is_expensive"], .bool(true))
+    }
+
+    // MARK: dedupe
+
+    func test_emit_deduplicatesIdenticalTransitions() {
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+
+        let context = NetworkContext(type: .wifi, effectiveType: "wifi")
+        NetworkPathCapture.emit(
+            context: context, isExpensive: false,
+            isConstrained: false, unsatisfiedReason: nil
+        )
+        NetworkPathCapture.emit(
+            context: context, isExpensive: false,
+            isConstrained: false, unsatisfiedReason: nil
+        )
+        NetworkPathCapture.emit(
+            context: context, isExpensive: false,
+            isConstrained: false, unsatisfiedReason: nil
+        )
+
+        let eventCount = probe.calls.filter { call in
+            if case let .event(name, _) = call { return name == "network_change" }
+            return false
+        }.count
+        XCTAssertEqual(eventCount, 1, "Identical transitions should emit once")
+
+        // Refresh still ran on every call — the context bag must always
+        // reflect the live path.
+        let refreshCount = probe.calls.filter { call in
+            if case .refreshNetwork = call { return true }
+            return false
+        }.count
+        XCTAssertEqual(refreshCount, 3)
+    }
+
+    func test_emit_reFires_when_anyFieldChanges() {
+        let probe = CaptureProbeRecorder()
+        Recorder.installShared(probe)
+
+        // 1. Wi-Fi, not expensive
+        NetworkPathCapture.emit(
+            context: NetworkContext(type: .wifi, effectiveType: "wifi"),
+            isExpensive: false, isConstrained: false, unsatisfiedReason: nil
+        )
+        // 2. Wi-Fi, expensive (change in flag)
+        NetworkPathCapture.emit(
+            context: NetworkContext(type: .wifi, effectiveType: "wifi"),
+            isExpensive: true, isConstrained: false, unsatisfiedReason: nil
+        )
+        // 3. Cellular (change in type)
+        NetworkPathCapture.emit(
+            context: NetworkContext(type: .cellular, effectiveType: "cellular"),
+            isExpensive: true, isConstrained: false, unsatisfiedReason: nil
+        )
+        // 4. None, with reason (change in reason)
+        NetworkPathCapture.emit(
+            context: NetworkContext(type: .none, effectiveType: "unknown"),
+            isExpensive: false, isConstrained: false,
+            unsatisfiedReason: "cellular_denied"
+        )
+
+        let events = probe.calls.compactMap { call -> String? in
+            if case let .event(name, _) = call, name == "network_change" { return name }
+            return nil
+        }
+        XCTAssertEqual(events.count, 4)
+    }
+
+    func test_emit_disabledRecorder_short_circuits() {
+        let probe = CaptureProbeRecorder(enabled: false)
+        Recorder.installShared(probe)
+
+        NetworkPathCapture.emit(
+            context: NetworkContext(type: .wifi, effectiveType: "wifi"),
+            isExpensive: false, isConstrained: false, unsatisfiedReason: nil
+        )
+
+        XCTAssertTrue(probe.calls.isEmpty,
+                      "Disabled recorder must take no calls — context refresh included")
+    }
+
+    // MARK: install — idempotent + concurrent-safe
+
+    func test_install_isIdempotent() {
+        XCTAssertFalse(NetworkPathCapture.isInstalled)
+        NetworkPathCapture.install(debug: false)
+        XCTAssertTrue(NetworkPathCapture.isInstalled)
+        NetworkPathCapture.install(debug: false)
+        XCTAssertTrue(NetworkPathCapture.isInstalled)
+    }
+
+    func test_install_concurrent_callsAreSafe() {
+        let group = DispatchGroup()
+        for _ in 0..<32 {
+            group.enter()
+            DispatchQueue.global().async {
+                NetworkPathCapture.install(debug: false)
+                group.leave()
+            }
+        }
+        let waitResult = group.wait(timeout: .now() + 5.0)
+        XCTAssertEqual(waitResult, .success)
+        XCTAssertTrue(NetworkPathCapture.isInstalled)
+    }
+}

--- a/Tests/EdgeRumContractTests/LifecycleAndNetworkWireConformanceTests.swift
+++ b/Tests/EdgeRumContractTests/LifecycleAndNetworkWireConformanceTests.swift
@@ -1,0 +1,174 @@
+// Tests/EdgeRumContractTests/LifecycleAndNetworkWireConformanceTests.swift
+//
+// F11 — End-to-end wire conformance for the lifecycle (`app_lifecycle`)
+// and connectivity (`network_change`) capture emit shapes.
+//
+// The unit-level `LifecycleCaptureTests` + `NetworkPathCaptureTests` in
+// `Tests/EdgeRumCaptureTests/` drive each capture against a probe
+// Recorder to lock attribute keys and types. This contract test pipes a
+// synthesized event of each kind — with the exact attribute schema F11
+// emits — through a real `Recorder` + `RecordingTransportSink` and
+// validates the assembled envelope against `WireAssertions`.
+//
+// Without this test a future change in F11's attribute keys could pass
+// the unit tests yet break the backend dispatcher. This file is the
+// pinning gate.
+//
+// Refs: PLAN-iOS.md §6.18, §6.19, §7, §F11; CLAUDE.md "Testing
+//       conventions".
+//
+
+import XCTest
+import Foundation
+import EdgeRumCore
+@testable import EdgeRum
+
+final class LifecycleAndNetworkWireConformanceTests: XCTestCase {
+
+    private func makeRecorder() -> (Recorder, RecordingTransportSink) {
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_234_876.512))
+        let sink = RecordingTransportSink()
+        let recorder = Recorder(
+            clock: clock,
+            sampler: Sampler(sampleRate: 1.0, entropy: { 0.0 }),
+            transport: sink,
+            sdkVersion: "1.0.0"
+        )
+        recorder.configure(RecorderConfig(
+            apiKey: "edge_test_abc",
+            endpoint: URL(string: "https://collect.example.com")!,
+            location: "Nairobi/Kenya"
+        ))
+        return (recorder, sink)
+    }
+
+    // MARK: - app_lifecycle
+
+    /// A captured `app_lifecycle` event (T11.1 acceptance — every
+    /// transition emits one event carrying `lifecycle.state` and
+    /// `lifecycle.previous_state`) survives the Recorder → PayloadBuilder
+    /// → envelope path and the assembled JSON satisfies the wire
+    /// contract.
+    func testAppLifecycleEventProducesWireValidEvent() throws {
+        let (recorder, sink) = makeRecorder()
+
+        recorder.recordEvent(name: "app_lifecycle", attributes: [
+            "lifecycle.state": .string("backgrounded"),
+            "lifecycle.previous_state": .string("inactive")
+        ])
+        recorder.flush(reason: .manual)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?["type"] as? String, "event")
+        XCTAssertEqual(events.first?["eventName"] as? String, "app_lifecycle")
+
+        let attrs = try XCTUnwrap(events.first?["attributes"] as? [String: Any])
+        try WireAssertions.assertIdentityAttributes(attrs)
+
+        XCTAssertEqual(attrs["lifecycle.state"] as? String, "backgrounded")
+        XCTAssertEqual(attrs["lifecycle.previous_state"] as? String, "inactive")
+    }
+
+    /// First-emission case — `lifecycle.previous_state == "unknown"`
+    /// must still round-trip cleanly.
+    func testAppLifecycleFirstEmissionWithUnknownPreviousIsWireValid() throws {
+        let (recorder, sink) = makeRecorder()
+
+        recorder.recordEvent(name: "app_lifecycle", attributes: [
+            "lifecycle.state": .string("active"),
+            "lifecycle.previous_state": .string("unknown")
+        ])
+        recorder.flush(reason: .manual)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        let attrs = try XCTUnwrap(events.first?["attributes"] as? [String: Any])
+        try WireAssertions.assertIdentityAttributes(attrs)
+        XCTAssertEqual(attrs["lifecycle.previous_state"] as? String, "unknown")
+    }
+
+    // MARK: - network_change
+
+    /// Wi-Fi → cellular satisfied path — `network_change` carries the
+    /// full F11 attribute bag with primitives only, and identity attrs
+    /// land alongside.
+    func testNetworkChangeCellularPathIsWireValid() throws {
+        let (recorder, sink) = makeRecorder()
+
+        recorder.recordEvent(name: "network_change", attributes: [
+            "network.type": .string("cellular"),
+            "network.effectiveType": .string("cellular"),
+            "network.is_expensive": .bool(true),
+            "network.is_constrained": .bool(false)
+        ])
+        recorder.flush(reason: .manual)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?["eventName"] as? String, "network_change")
+
+        let attrs = try XCTUnwrap(events.first?["attributes"] as? [String: Any])
+        try WireAssertions.assertIdentityAttributes(attrs)
+        XCTAssertEqual(attrs["network.type"] as? String, "cellular")
+        XCTAssertEqual(attrs["network.effectiveType"] as? String, "cellular")
+        XCTAssertEqual(attrs["network.is_expensive"] as? Bool, true)
+        XCTAssertEqual(attrs["network.is_constrained"] as? Bool, false)
+        XCTAssertNil(attrs["network.unsatisfied_reason"],
+                     "Satisfied paths must omit the reason key — never sentinel-string it")
+    }
+
+    /// Unsatisfied path on iOS 14.2+ — `network.unsatisfied_reason`
+    /// rides as a real string attribute and the envelope stays wire-
+    /// valid.
+    func testNetworkChangeWithUnsatisfiedReasonIsWireValid() throws {
+        let (recorder, sink) = makeRecorder()
+
+        recorder.recordEvent(name: "network_change", attributes: [
+            "network.type": .string("none"),
+            "network.effectiveType": .string("unknown"),
+            "network.is_expensive": .bool(false),
+            "network.is_constrained": .bool(false),
+            "network.unsatisfied_reason": .string("cellular_denied")
+        ])
+        recorder.flush(reason: .manual)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        let attrs = try XCTUnwrap(events.first?["attributes"] as? [String: Any])
+        try WireAssertions.assertIdentityAttributes(attrs)
+        XCTAssertEqual(attrs["network.type"] as? String, "none")
+        XCTAssertEqual(attrs["network.unsatisfied_reason"] as? String, "cellular_denied")
+    }
+
+    /// Both event types co-exist in one batch — confirms the F11 events
+    /// don't collide on shared attribute namespaces.
+    func testLifecycleAndNetworkInSameBatch() throws {
+        let (recorder, sink) = makeRecorder()
+
+        recorder.recordEvent(name: "app_lifecycle", attributes: [
+            "lifecycle.state": .string("active"),
+            "lifecycle.previous_state": .string("foregrounded")
+        ])
+        recorder.recordEvent(name: "network_change", attributes: [
+            "network.type": .string("wifi"),
+            "network.effectiveType": .string("wifi"),
+            "network.is_expensive": .bool(false),
+            "network.is_constrained": .bool(false)
+        ])
+        recorder.flush(reason: .manual)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 2)
+        let names = events.compactMap { $0["eventName"] as? String }
+        XCTAssertEqual(Set(names), Set(["app_lifecycle", "network_change"]))
+    }
+}

--- a/Tests/EdgeRumTests/EdgeRumConfigTests.swift
+++ b/Tests/EdgeRumTests/EdgeRumConfigTests.swift
@@ -41,6 +41,8 @@ final class EdgeRumConfigTests: XCTestCase {
         XCTAssertEqual(config.captureHTTP, true)
         XCTAssertEqual(config.captureTaps, true)
         XCTAssertEqual(config.captureRenderingPerformance, true)
+        XCTAssertEqual(config.captureLifecycle, true)
+        XCTAssertEqual(config.captureNetworkChanges, true)
 
         XCTAssertEqual(config.debug, false)
     }


### PR DESCRIPTION
Closes #16

## Summary

Adds the last v1.0 capture pair (M2 milestone) — `app_lifecycle` and `network_change` events — wiring UIApplication lifecycle notifications and `NWPathMonitor` into the existing Recorder.

- **`LifecycleCapture`** subscribes to `willResignActive` / `didEnterBackground` / `willEnterForeground` / `didBecomeActive` / `willTerminate` and emits one `app_lifecycle` per transition (carrying `lifecycle.state` and `lifecycle.previous_state`). On `willResignActive` and `willTerminate` it also emits `session.finalized` (auto-flushes via Recorder transport rules) so the in-memory buffer ships before suspension. On `didBecomeActive` it nudges the offline queue drain.
- **`NetworkPathCapture`** owns a `NetworkPathObserver`; on every NWPath transition it refreshes the Recorder's `NetworkContext` (so subsequent events ride the new attrs) and emits one `network_change` event with `network.type`, `network.effectiveType`, `network.is_expensive`, `network.is_constrained`, and (iOS 14.2+) `network.unsatisfied_reason`. Identical fingerprints are deduped.
- `NetworkPathObserver.start(onChange:)` now delivers `(NetworkContext, NWPath)` so capture sites can read raw NWPath extras without a second monitor. HTTPTransportSink ignores the new second arg.
- `Recorder.refreshNetworkContext(_:)` is the new public seam for the capture target; landed on the `Recording` protocol with a default no-op so existing probe recorders compile unchanged. `drainOfflineQueue()` is similarly added to the protocol with a default no-op.
- `EdgeRumConfig.captureLifecycle` and `EdgeRumConfig.captureNetworkChanges` toggle each capture (default `true`), mirroring F6–F10.

Both `app_lifecycle` and `network_change` are already on `Recorder.allowedEventNames`, so no allowlist change is needed.

## Test plan

- [x] `swift test` — 373 tests pass, 0 failures
- [x] `Tools/firewall-check.sh` — public surface clean of banned terminology
- [x] `LifecycleCaptureTests` covers the pure attribute builder, recorder routing, state-chaining across emissions, disabled-recorder short-circuit, idempotent install, and (iOS-gated) the full notification fan-out for all five UIApplication notifications
- [x] `NetworkPathCaptureTests` covers every `NetworkType` × expensive/constrained matrix in `makeAttributes`, the iOS 14.0/14.1 `unsatisfied_reason` omission, `unsatisfiedReasonString` mapping, fingerprint dedupe (and re-fire on any field change), context-refresh-even-when-deduped behavior, disabled-recorder short-circuit, and concurrent install
- [x] `LifecycleAndNetworkWireConformanceTests` pins the on-the-wire attribute schemas through `Recorder` + `PayloadBuilder` for both event types, including the unsatisfied-reason variant and a mixed batch
- [x] `EdgeRumConfigTests` extended to assert the two new flag defaults
- [ ] Manual sample-app smoke (background → foreground, toggle Network Link Conditioner) — left to reviewer if desired; the unit + contract layers cover the emission paths