### PR TITLE
feat(F13): error capture — captureError + NSError flattening

### DIFF
--- a/Sources/EdgeRum/EdgeRum.swift
+++ b/Sources/EdgeRum/EdgeRum.swift
@@ -303,21 +303,32 @@ public enum EdgeRum {
     }
 
     /// Report a thrown `Error` as an `app.crash` event with
-    /// `cause = "AppError"`. The error's domain, code, and
-    /// localized description are flattened into wire attributes
-    /// automatically. Supply additional context with `context:`.
+    /// `cause = "AppError"`. The error's type, domain, code,
+    /// `localizedDescription`, and (for `NSError`) the primitive
+    /// entries of `userInfo` are flattened into wire attributes
+    /// automatically. A snapshot of the call-site stack — captured
+    /// here, synchronously, before any queue handoff — is attached
+    /// as `error.stack`. Supply additional caller context with
+    /// `context:`; those keys are prefixed `crash.context.` on the
+    /// wire so they never collide with the standard `error.*`
+    /// payload.
     public static func captureError(
         _ error: Error,
         context: [String: AttributeValue]? = nil
     ) {
         guard requireStarted("captureError") else { return }
-        let nsError = error as NSError
-        Recorder.shared.recordError(
-            domain: nsError.domain,
-            code: nsError.code,
-            message: nsError.localizedDescription,
-            context: context ?? [:]
+        // Call-site stack capture — must happen on the caller's
+        // thread before we hand off to the recorder's queue, else the
+        // frames leak into the queue's own thread.
+        let stack = Thread.callStackSymbols
+        let recorder = Recorder.shared
+        let attrs = AppErrorBuilder.build(
+            error: error,
+            context: context ?? [:],
+            stack: stack,
+            debug: recorder.debug
         )
+        recorder.recordEvent(name: "app.crash", attributes: attrs)
     }
 
     // MARK: Enable / disable

--- a/Sources/EdgeRumCore/AppErrorBuilder.swift
+++ b/Sources/EdgeRumCore/AppErrorBuilder.swift
@@ -1,0 +1,206 @@
+// Sources/EdgeRumCore/AppErrorBuilder.swift
+//
+// Pure helper that flattens an `Error` value into the wire-attribute
+// bag emitted by `EdgeRum.captureError`. Owns:
+//
+//   - `cause = "AppError"`, `runtime = "swift"`
+//   - `error.type` (Swift type name or NSError class)
+//   - `error.kind` discriminator (`"swift"` / `"nserror"`)
+//   - `error.domain`, `error.code`, `error.message`
+//   - `error.userInfo.<key>` flattening for NSError, dropping any
+//     non-primitive values (logged when `debug == true`)
+//   - `error.stack` from a caller-captured `[String]`, truncated
+//     to a UTF-8-safe byte cap
+//   - `crash.context.<key>` prefix on caller-supplied context
+//
+// Stack capture itself MUST happen at the public call site
+// (`EdgeRum.captureError`) — by the time the builder runs the bag is
+// the only thing that matters, so we accept frames as a parameter.
+//
+// Refs: PLAN-iOS.md §6.6, §F13/T13.1, §F13/T13.2; CLAUDE.md
+//       "Recorder + transport implementation notes".
+//
+
+import Foundation
+import os.log
+
+/// Pure flattener — no I/O, no global state, no recorder access.
+public enum AppErrorBuilder {
+
+    /// Soft cap on the joined `error.stack` payload. Mirrors the
+    /// `RunLoopObserverCapture.maxStackBytes` precedent so a deep
+    /// stack can't balloon a batch.
+    public static let maxStackBytes: Int = 4_096
+
+    /// Build the full wire-attribute bag for an `app.crash` event with
+    /// `cause = "AppError"`.
+    ///
+    /// - Parameters:
+    ///   - error: the value reported via `EdgeRum.captureError`.
+    ///   - context: caller-supplied context. Keys are prefixed with
+    ///     `crash.context.` on the wire (PLAN-iOS.md §F13/T13.1).
+    ///   - stack: frames captured at the public call site via
+    ///     `Thread.callStackSymbols`. Truncated UTF-8-safely to
+    ///     `maxStackBytes`.
+    ///   - debug: when `true`, dropped non-primitive `userInfo`
+    ///     entries are logged via `os_log`.
+    public static func build(
+        error: Error,
+        context: [String: AttributeValue],
+        stack: [String],
+        debug: Bool
+    ) -> [String: AttributeValue] {
+        var attrs: [String: AttributeValue] = [:]
+        attrs["cause"] = .string("AppError")
+        attrs["runtime"] = .string("swift")
+        attrs["error.type"] = .string(String(describing: type(of: error)))
+        attrs["error.message"] = .string(messageString(for: error))
+
+        // Every `Error` bridges to `NSError` on Apple platforms with a
+        // synthetic `domain == "<MangledTypeName>"` / `code == 0` —
+        // useful for routing but only meaningful when the host
+        // explicitly threw an `NSError`. `error is NSError` is the
+        // disambiguator the iOS SDK runtime gives us.
+        let ns = error as NSError
+        if isExplicitNSError(error) {
+            attrs["error.kind"] = .string("nserror")
+            attrs["error.domain"] = .string(ns.domain)
+            attrs["error.code"] = .int(ns.code)
+            mergeUserInfo(ns.userInfo, into: &attrs, debug: debug)
+        } else {
+            attrs["error.kind"] = .string("swift")
+            // Bridged Swift errors still carry a domain (the type
+            // name) and a code — useful for backend bucketing without
+            // misrepresenting the source as a Cocoa NSError.
+            attrs["error.domain"] = .string(ns.domain)
+            attrs["error.code"] = .int(ns.code)
+        }
+
+        let stackString = truncateStack(stack, maxBytes: maxStackBytes)
+        if !stackString.isEmpty {
+            attrs["error.stack"] = .string(stackString)
+        }
+
+        for (key, value) in context {
+            attrs["crash.context.\(key)"] = value
+        }
+
+        return attrs
+    }
+
+    // MARK: - Internals (exposed for unit tests)
+
+    /// `String` join of `frames` with `"\n"` separator, clipped to
+    /// `maxBytes` UTF-8 bytes. Drops trailing frames whole rather than
+    /// mid-symbol so the result is always a valid UTF-8 substring.
+    public static func truncateStack(_ frames: [String], maxBytes: Int) -> String {
+        var accum: [String] = []
+        var size = 0
+        for frame in frames {
+            let frameSize = frame.utf8.count + 1 // include the join '\n'
+            if size + frameSize > maxBytes { break }
+            accum.append(frame)
+            size += frameSize
+        }
+        return accum.joined(separator: "\n")
+    }
+
+    /// Distinguish an explicit `NSError` instance from a Swift error
+    /// that the runtime *bridged* to `NSError` automatically. Only the
+    /// former should expose `error.userInfo.*` on the wire.
+    ///
+    /// `type(of: error)` returns the dynamic type of the existential
+    /// value — for a Swift `enum`/`struct` that's the Swift type
+    /// itself (which fails the `is NSError.Type` test), and for a
+    /// host-allocated `NSError(domain:...)` it's `NSError` itself
+    /// (which passes).
+    static func isExplicitNSError(_ error: Error) -> Bool {
+        return type(of: error) is NSError.Type
+    }
+
+    /// `localizedDescription` works for both Swift and NSError, but
+    /// for a bridged Swift error it often returns the generic
+    /// "The operation couldn't be completed." string. Fall back to
+    /// `String(describing:)` so the backend gets the case payload
+    /// (`keyNotFound("foo")` etc.) when available.
+    private static func messageString(for error: Error) -> String {
+        let localized = error.localizedDescription
+        if !localized.isEmpty
+            && !localized.contains("The operation couldn’t be completed")
+            && !localized.contains("The operation couldn't be completed") {
+            return localized
+        }
+        return String(describing: error)
+    }
+
+    /// Flatten `userInfo` into `error.userInfo.<key>` entries, keeping
+    /// only primitives (String / Int / Double / Bool / NSNumber). Any
+    /// nested object, array, or class instance is dropped silently
+    /// from the wire — the firewall in §F13/T13.2 mandates a flat
+    /// primitives-only payload. When `debug == true` the drop is
+    /// logged once per key via `os_log`.
+    static func mergeUserInfo(
+        _ userInfo: [String: Any],
+        into attrs: inout [String: AttributeValue],
+        debug: Bool
+    ) {
+        for (key, raw) in userInfo {
+            guard let primitive = attributeValue(from: raw) else {
+                if debug {
+                    os_log(
+                        "AppErrorBuilder dropped non-primitive userInfo key %{public}@",
+                        log: log,
+                        type: .info,
+                        key
+                    )
+                }
+                continue
+            }
+            attrs["error.userInfo.\(key)"] = primitive
+        }
+    }
+
+    /// Map an arbitrary `Any` to an `AttributeValue` if it is — or
+    /// trivially bridges to — a JSON primitive.
+    static func attributeValue(from raw: Any) -> AttributeValue? {
+        switch raw {
+        case let s as String:
+            return .string(s)
+        case let b as Bool:
+            return .bool(b)
+        case let i as Int:
+            return .int(i)
+        case let i as Int64:
+            return .int(Int(clamping: i))
+        case let d as Double:
+            return .double(d)
+        case let f as Float:
+            return .double(Double(f))
+        case let n as NSNumber:
+            return attributeValue(fromNSNumber: n)
+        default:
+            return nil
+        }
+    }
+
+    private static func attributeValue(fromNSNumber n: NSNumber) -> AttributeValue? {
+        // CFBoolean is the only reliable way to distinguish a real
+        // `Bool` from an `Int` once it has crossed the NSNumber
+        // boundary; ObjCType "c" is also used by Int8 on some
+        // toolchains, so the CFTypeID check is the safe path.
+        if CFGetTypeID(n) == CFBooleanGetTypeID() {
+            return .bool(n.boolValue)
+        }
+        let type = String(cString: n.objCType)
+        switch type {
+        case "c", "C", "s", "S", "i", "I", "l", "L", "q", "Q":
+            return .int(n.intValue)
+        case "f", "d":
+            return .double(n.doubleValue)
+        default:
+            return nil
+        }
+    }
+
+    private static let log = OSLog(subsystem: "com.edge.rum", category: "AppErrorBuilder")
+}

--- a/Sources/EdgeRumCore/RecordedCall.swift
+++ b/Sources/EdgeRumCore/RecordedCall.swift
@@ -22,6 +22,5 @@ public enum RecordedCall: Sendable, Equatable {
     case setEnabled(Bool)
     case event(name: String, attributes: [String: AttributeValue])
     case performance(name: String, attributes: [String: AttributeValue])
-    case error(domain: String, code: Int, message: String?, context: [String: AttributeValue])
     case setUser(RecorderUser)
 }

--- a/Sources/EdgeRumCore/Recorder.swift
+++ b/Sources/EdgeRumCore/Recorder.swift
@@ -223,6 +223,11 @@ public final class Recorder: Recording, @unchecked Sendable {
         return _enabled
     }
 
+    public var debug: Bool {
+        stateLock.lock(); defer { stateLock.unlock() }
+        return _config?.debug ?? false
+    }
+
     public var currentSessionId: String {
         context.currentSession().id
     }
@@ -365,25 +370,6 @@ public final class Recorder: Recording, @unchecked Sendable {
             attributes: AttributeBag(attributes)
         )
         enqueue(metric)
-    }
-
-    public func recordError(
-        domain: String,
-        code: Int,
-        message: String?,
-        context: [String: AttributeValue]
-    ) {
-        var attrs = context
-        attrs["cause"] = .string("AppError")
-        attrs["error.domain"] = .string(domain)
-        attrs["error.code"] = .int(code)
-        if let message {
-            attrs["error.message"] = .string(message)
-        }
-        // Errors bypass the sampler — they always land on the wire.
-        let event = Event.event(name: "app.crash", timestamp: clock.now, attributes: AttributeBag(attrs))
-        enqueue(event)
-        flush(reason: .immediate)
     }
 
     public func setUser(_ user: RecorderUser) {

--- a/Sources/EdgeRumCore/Recording.swift
+++ b/Sources/EdgeRumCore/Recording.swift
@@ -47,6 +47,11 @@ public protocol Recording: AnyObject, Sendable {
     var currentSessionId: String { get }
     var currentDeviceId: String { get }
     var clock: Clock { get }
+    /// `true` when the host passed `EdgeRumConfig.debug = true`. F13's
+    /// `AppErrorBuilder` reads this so dropped `NSError.userInfo` keys
+    /// are logged in debug-only builds. Default no-op `false` so test
+    /// probes that predate F13 don't have to track config state.
+    var debug: Bool { get }
 
     func configure(_ config: RecorderConfig)
     func start(apiKey: String, endpoint: URL, debug: Bool)
@@ -55,7 +60,6 @@ public protocol Recording: AnyObject, Sendable {
 
     func recordEvent(name: String, attributes: [String: AttributeValue])
     func recordPerformance(name: String, attributes: [String: AttributeValue])
-    func recordError(domain: String, code: Int, message: String?, context: [String: AttributeValue])
 
     func setUser(_ user: RecorderUser)
 
@@ -76,6 +80,10 @@ public extension Recording {
     func configure(_ config: RecorderConfig) {
         _ = config
     }
+
+    /// Default — test probes that don't track host config inherit
+    /// `debug == false`. The real `Recorder` overrides this.
+    var debug: Bool { false }
 
     /// Default no-op so existing test probes don't have to adopt the
     /// new requirement. The real `Recorder` overrides this.

--- a/Tests/EdgeRumContractTests/AppErrorWireConformanceTests.swift
+++ b/Tests/EdgeRumContractTests/AppErrorWireConformanceTests.swift
@@ -1,0 +1,204 @@
+// Tests/EdgeRumContractTests/AppErrorWireConformanceTests.swift
+//
+// F13 — End-to-end wire conformance for the application-error
+// (`app.crash` with `cause = "AppError"`) emit shape.
+//
+// The unit-level `AppErrorBuilderTests` lock the attribute keys +
+// types. This contract test pipes a synthesized `app.crash` event
+// built by `AppErrorBuilder` through a real `Recorder` +
+// `RecordingTransportSink` and validates the assembled envelope
+// against `WireAssertions`.
+//
+// Refs: PLAN-iOS.md §6.6, §7, §F13; CLAUDE.md "Testing conventions".
+//
+
+import XCTest
+import Foundation
+import EdgeRumCore
+@testable import EdgeRum
+
+final class AppErrorWireConformanceTests: XCTestCase {
+
+    private func makeRecorder() -> (Recorder, RecordingTransportSink) {
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_234_876.512))
+        let sink = RecordingTransportSink()
+        let recorder = Recorder(
+            clock: clock,
+            sampler: Sampler(sampleRate: 1.0, entropy: { 0.0 }),
+            transport: sink,
+            sdkVersion: "1.0.0"
+        )
+        recorder.configure(RecorderConfig(
+            apiKey: "edge_test_abc",
+            endpoint: URL(string: "https://collect.example.com")!,
+            location: "Nairobi/Kenya"
+        ))
+        return (recorder, sink)
+    }
+
+    // MARK: - NSError → app.crash (T13.2 acceptance)
+
+    func testNSErrorAppCrashEnvelopeIsWireValid() throws {
+        let (recorder, sink) = makeRecorder()
+        let err = NSError(domain: "PaymentDomain", code: 42, userInfo: [
+            NSLocalizedDescriptionKey: "Card declined",
+            "merchant.id": "m_abc",
+            "retry.count": 3
+        ])
+        let attrs = AppErrorBuilder.build(
+            error: err,
+            context: ["payment.method": .string("card")],
+            stack: ["0   EdgeRum   0x0001  +[F13 captureError:_:context:]",
+                    "1   EdgeRum   0x0002  caller_frame"],
+            debug: false
+        )
+        recorder.recordEvent(name: "app.crash", attributes: attrs)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?["type"] as? String, "event")
+        XCTAssertEqual(events.first?["eventName"] as? String, "app.crash")
+
+        let wireAttrs = try XCTUnwrap(events.first?["attributes"] as? [String: Any])
+        try WireAssertions.assertIdentityAttributes(wireAttrs)
+
+        // Fixed payload contract
+        XCTAssertEqual(wireAttrs["cause"] as? String, "AppError")
+        XCTAssertEqual(wireAttrs["runtime"] as? String, "swift")
+        XCTAssertEqual(wireAttrs["error.kind"] as? String, "nserror")
+        XCTAssertEqual(wireAttrs["error.type"] as? String, "NSError")
+        XCTAssertEqual(wireAttrs["error.domain"] as? String, "PaymentDomain")
+        XCTAssertEqual(wireAttrs["error.code"] as? Int, 42)
+        XCTAssertEqual(wireAttrs["error.message"] as? String, "Card declined")
+
+        // T13.2: NSError.userInfo flattens with the `error.userInfo.`
+        // prefix. Primitives survive.
+        XCTAssertEqual(
+            wireAttrs["error.userInfo.\(NSLocalizedDescriptionKey)"] as? String,
+            "Card declined"
+        )
+        XCTAssertEqual(wireAttrs["error.userInfo.merchant.id"] as? String, "m_abc")
+        XCTAssertEqual(wireAttrs["error.userInfo.retry.count"] as? Int, 3)
+
+        // T13.1: caller-context keys arrive prefixed `crash.context.`,
+        // never bare.
+        XCTAssertEqual(wireAttrs["crash.context.payment.method"] as? String, "card")
+        XCTAssertNil(wireAttrs["payment.method"])
+
+        // Stack present
+        XCTAssertNotNil(wireAttrs["error.stack"] as? String)
+    }
+
+    // MARK: - Swift Error → app.crash (T13.1 acceptance)
+
+    func testSwiftErrorAppCrashEnvelopeIsWireValid() throws {
+        let (recorder, sink) = makeRecorder()
+        enum DecodingFailure: Error { case keyNotFound(String) }
+        let attrs = AppErrorBuilder.build(
+            error: DecodingFailure.keyNotFound("invoice_id"),
+            context: ["screen": .string("Receipt")],
+            stack: ["0   EdgeRum   0x0001  test_frame"],
+            debug: false
+        )
+        recorder.recordEvent(name: "app.crash", attributes: attrs)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        let wireAttrs = try XCTUnwrap(events.first?["attributes"] as? [String: Any])
+        try WireAssertions.assertIdentityAttributes(wireAttrs)
+
+        XCTAssertEqual(wireAttrs["cause"] as? String, "AppError")
+        XCTAssertEqual(wireAttrs["runtime"] as? String, "swift")
+        XCTAssertEqual(wireAttrs["error.kind"] as? String, "swift")
+        XCTAssertEqual(wireAttrs["error.type"] as? String, "DecodingFailure")
+        XCTAssertEqual(wireAttrs["crash.context.screen"] as? String, "Receipt")
+        XCTAssertNil(wireAttrs["screen"])
+
+        // Swift errors must NOT carry error.userInfo.* keys.
+        let userInfoKeys = wireAttrs.keys.filter { $0.hasPrefix("error.userInfo.") }
+        XCTAssertTrue(userInfoKeys.isEmpty,
+                      "Swift errors must not surface bridged userInfo")
+    }
+
+    // MARK: - Non-primitive drop (T13.2 acceptance)
+
+    func testNonPrimitiveUserInfoIsDroppedSilently() throws {
+        let (recorder, sink) = makeRecorder()
+        let underlying = NSError(domain: "Underlying", code: 9)
+        let outer = NSError(domain: "Outer", code: 1, userInfo: [
+            "kept": "v",
+            "dropped_dict": ["k": 1] as [String: Int],
+            "dropped_obj": underlying
+        ])
+        let attrs = AppErrorBuilder.build(
+            error: outer,
+            context: [:],
+            stack: ["0   x   y"],
+            debug: false
+        )
+        recorder.recordEvent(name: "app.crash", attributes: attrs)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        let wireAttrs = try XCTUnwrap(events.first?["attributes"] as? [String: Any])
+
+        XCTAssertEqual(wireAttrs["error.userInfo.kept"] as? String, "v")
+        XCTAssertNil(wireAttrs["error.userInfo.dropped_dict"])
+        XCTAssertNil(wireAttrs["error.userInfo.dropped_obj"])
+    }
+
+    // MARK: - Primitives-only sanity (defense-in-depth)
+
+    func testAppCrashAttributesArePrimitives() throws {
+        let (recorder, sink) = makeRecorder()
+        let attrs = AppErrorBuilder.build(
+            error: NSError(domain: "x", code: 0, userInfo: [
+                "s": "string", "i": 7, "d": 1.5, "b": true
+            ]),
+            context: ["c": .string("v")],
+            stack: ["0   y   z"],
+            debug: false
+        )
+        recorder.recordEvent(name: "app.crash", attributes: attrs)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (data, _) = try WireAssertions.assertValidEnvelope(envelope)
+
+        // Belt and braces — wire bytes don't carry forbidden tokens.
+        let raw = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertFalse(raw.contains("\"traceId\""))
+        XCTAssertFalse(raw.contains("\"spanId\""))
+        XCTAssertFalse(raw.contains("\"resourceSpans\""))
+        XCTAssertFalse(raw.lowercased().contains("opentelemetry"))
+    }
+
+    // MARK: - Co-existence with other event types
+
+    func testAppCrashInSameBatchWithOtherEvents() throws {
+        let (recorder, sink) = makeRecorder()
+        // `app.crash` triggers an immediate flush, so emit it last and
+        // assert both events ride the same envelope.
+        recorder.recordEvent(name: "navigation", attributes: [
+            "navigation.kind": .string("uikit"),
+            "navigation.name": .string("Cart")
+        ])
+        let crashAttrs = AppErrorBuilder.build(
+            error: NSError(domain: "x", code: 1),
+            context: [:],
+            stack: ["0   x   y"],
+            debug: false
+        )
+        recorder.recordEvent(name: "app.crash", attributes: crashAttrs)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 2)
+        let names = events.compactMap { $0["eventName"] as? String }
+        XCTAssertEqual(Set(names), Set(["navigation", "app.crash"]))
+    }
+}

--- a/Tests/EdgeRumContractTests/RecorderPipelineTests.swift
+++ b/Tests/EdgeRumContractTests/RecorderPipelineTests.swift
@@ -80,24 +80,45 @@ final class RecorderPipelineContractTests: XCTestCase {
         XCTAssertEqual(attrs["screen.duration_ms"] as? Int, 4300)
     }
 
-    func testErrorEnvelopeIsAppCrashWithFlattenedFields() throws {
+    func testAppCrashEnvelopePassesWireAssertions() throws {
+        // F13: `EdgeRum.captureError` builds the full attribute bag
+        // via `AppErrorBuilder` and emits it through `recordEvent`.
+        // Drive the same path directly so the recorder pipeline is
+        // exercised without going through the public namespace.
         let (recorder, sink, _) = makeRecorder()
-        recorder.recordError(
+        let err = NSError(
             domain: "PaymentDomain",
             code: 42,
-            message: "Card declined",
-            context: ["payment.method": "card"]
+            userInfo: [NSLocalizedDescriptionKey: "Card declined"]
         )
+        let attrs = AppErrorBuilder.build(
+            error: err,
+            context: ["payment.method": .string("card")],
+            stack: ["0  edge_rum_ios  test_frame"],
+            debug: false
+        )
+        recorder.recordEvent(name: "app.crash", attributes: attrs)
         let envelope = try XCTUnwrap(sink.envelopes.first)
         let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
         let events = try XCTUnwrap(json["events"] as? [[String: Any]])
         XCTAssertEqual(events.first?["eventName"] as? String, "app.crash")
-        let attrs = try XCTUnwrap(events.first?["attributes"] as? [String: Any])
-        XCTAssertEqual(attrs["cause"] as? String, "AppError")
-        XCTAssertEqual(attrs["error.domain"] as? String, "PaymentDomain")
-        XCTAssertEqual(attrs["error.code"] as? Int, 42)
-        XCTAssertEqual(attrs["error.message"] as? String, "Card declined")
-        XCTAssertEqual(attrs["payment.method"] as? String, "card")
+        let wireAttrs = try XCTUnwrap(events.first?["attributes"] as? [String: Any])
+        XCTAssertEqual(wireAttrs["cause"] as? String, "AppError")
+        XCTAssertEqual(wireAttrs["runtime"] as? String, "swift")
+        XCTAssertEqual(wireAttrs["error.kind"] as? String, "nserror")
+        XCTAssertEqual(wireAttrs["error.domain"] as? String, "PaymentDomain")
+        XCTAssertEqual(wireAttrs["error.code"] as? Int, 42)
+        XCTAssertEqual(wireAttrs["error.message"] as? String, "Card declined")
+        // T13.2: NSError.userInfo entries flatten with the `error.userInfo.` prefix.
+        XCTAssertEqual(
+            wireAttrs["error.userInfo.\(NSLocalizedDescriptionKey)"] as? String,
+            "Card declined"
+        )
+        // T13.1: caller-supplied context keys arrive prefixed with `crash.context.`,
+        // not bare. Catches regressions to the F2/F3 un-prefixed behaviour.
+        XCTAssertEqual(wireAttrs["crash.context.payment.method"] as? String, "card")
+        XCTAssertNil(wireAttrs["payment.method"])
+        XCTAssertNotNil(wireAttrs["error.stack"])
     }
 
     func testEnvelopeBytesContainNoForbiddenTokens() throws {

--- a/Tests/EdgeRumTests/AppErrorBuilderTests.swift
+++ b/Tests/EdgeRumTests/AppErrorBuilderTests.swift
@@ -1,0 +1,263 @@
+import XCTest
+@testable import EdgeRum
+import EdgeRumCore
+
+/// Unit coverage for the pure F13 attribute builder.
+///
+/// Refs: PLAN-iOS.md §6.6, §F13/T13.1, §F13/T13.2.
+final class AppErrorBuilderTests: XCTestCase {
+
+    // MARK: - error.kind discriminator
+
+    func testSwiftErrorReportsKindSwift() {
+        struct DemoError: Error {}
+        let attrs = AppErrorBuilder.build(
+            error: DemoError(),
+            context: [:],
+            stack: [],
+            debug: false
+        )
+        XCTAssertEqual(attrs["error.kind"], .string("swift"))
+        XCTAssertEqual(attrs["cause"], .string("AppError"))
+        XCTAssertEqual(attrs["runtime"], .string("swift"))
+        XCTAssertNil(attrs.first(where: { $0.key.hasPrefix("error.userInfo.") }),
+                     "Swift errors must not surface error.userInfo.* on the wire")
+    }
+
+    func testNSErrorReportsKindNSError() {
+        let err = NSError(domain: "MyDomain", code: 7)
+        let attrs = AppErrorBuilder.build(
+            error: err,
+            context: [:],
+            stack: [],
+            debug: false
+        )
+        XCTAssertEqual(attrs["error.kind"], .string("nserror"))
+        XCTAssertEqual(attrs["error.domain"], .string("MyDomain"))
+        XCTAssertEqual(attrs["error.code"], .int(7))
+    }
+
+    // MARK: - error.type
+
+    func testErrorTypeIsSwiftTypeName() {
+        enum CheckoutFailure: Error { case cardDeclined }
+        let attrs = AppErrorBuilder.build(
+            error: CheckoutFailure.cardDeclined,
+            context: [:],
+            stack: [],
+            debug: false
+        )
+        XCTAssertEqual(attrs["error.type"], .string("CheckoutFailure"))
+    }
+
+    func testErrorTypeForNSErrorIsClassName() {
+        let err = NSError(domain: "x", code: 0)
+        let attrs = AppErrorBuilder.build(
+            error: err,
+            context: [:],
+            stack: [],
+            debug: false
+        )
+        XCTAssertEqual(attrs["error.type"], .string("NSError"))
+    }
+
+    // MARK: - userInfo flattening (T13.2)
+
+    func testPrimitiveUserInfoIsFlattenedWithPrefix() {
+        let err = NSError(domain: "Domain", code: 1, userInfo: [
+            "stringKey": "hello",
+            "intKey": 42,
+            "doubleKey": 1.5,
+            "boolKey": true
+        ])
+        let attrs = AppErrorBuilder.build(
+            error: err,
+            context: [:],
+            stack: [],
+            debug: false
+        )
+        XCTAssertEqual(attrs["error.userInfo.stringKey"], .string("hello"))
+        XCTAssertEqual(attrs["error.userInfo.intKey"], .int(42))
+        XCTAssertEqual(attrs["error.userInfo.doubleKey"], .double(1.5))
+        XCTAssertEqual(attrs["error.userInfo.boolKey"], .bool(true))
+    }
+
+    func testNonPrimitiveUserInfoValuesAreDroppedSilently() {
+        let nested = NSError(domain: "Underlying", code: 99)
+        let err = NSError(domain: "Outer", code: 1, userInfo: [
+            "kept": "v",
+            "dropped_nested_error": nested,
+            "dropped_array": [1, 2, 3] as [Int],
+            "dropped_dict": ["a": 1] as [String: Int]
+        ])
+        let attrs = AppErrorBuilder.build(
+            error: err,
+            context: [:],
+            stack: [],
+            debug: false
+        )
+        XCTAssertEqual(attrs["error.userInfo.kept"], .string("v"))
+        XCTAssertNil(attrs["error.userInfo.dropped_nested_error"])
+        XCTAssertNil(attrs["error.userInfo.dropped_array"])
+        XCTAssertNil(attrs["error.userInfo.dropped_dict"])
+    }
+
+    func testSwiftErrorDoesNotEmitUserInfoEntries() {
+        struct DemoError: LocalizedError {
+            var errorDescription: String? { "boom" }
+        }
+        let attrs = AppErrorBuilder.build(
+            error: DemoError(),
+            context: [:],
+            stack: [],
+            debug: false
+        )
+        let userInfoKeys = attrs.keys.filter { $0.hasPrefix("error.userInfo.") }
+        XCTAssertTrue(userInfoKeys.isEmpty,
+                      "Swift LocalizedError must not leak bridged userInfo to the wire")
+    }
+
+    // MARK: - context prefixing (T13.1)
+
+    func testCallerContextIsPrefixedCrashContext() {
+        let attrs = AppErrorBuilder.build(
+            error: NSError(domain: "x", code: 0),
+            context: [
+                "screen": .string("Cart"),
+                "user.flow": .string("checkout"),
+                "retry.count": .int(2)
+            ],
+            stack: [],
+            debug: false
+        )
+        XCTAssertEqual(attrs["crash.context.screen"], .string("Cart"))
+        XCTAssertEqual(attrs["crash.context.user.flow"], .string("checkout"))
+        XCTAssertEqual(attrs["crash.context.retry.count"], .int(2))
+        XCTAssertNil(attrs["screen"], "Context keys must never arrive un-prefixed")
+        XCTAssertNil(attrs["user.flow"])
+        XCTAssertNil(attrs["retry.count"])
+    }
+
+    func testContextDoesNotOverwriteErrorAttributes() {
+        // Even if the caller passes a key that collides with one of
+        // the standard error.* attributes, the prefix protects the
+        // wire payload from collisions.
+        let err = NSError(domain: "Real", code: 1)
+        let attrs = AppErrorBuilder.build(
+            error: err,
+            context: [
+                "error.domain": .string("Forged"),
+                "cause": .string("Forged")
+            ],
+            stack: [],
+            debug: false
+        )
+        XCTAssertEqual(attrs["error.domain"], .string("Real"),
+                       "Standard error.domain must reflect the actual error")
+        XCTAssertEqual(attrs["cause"], .string("AppError"))
+        XCTAssertEqual(attrs["crash.context.error.domain"], .string("Forged"))
+        XCTAssertEqual(attrs["crash.context.cause"], .string("Forged"))
+    }
+
+    // MARK: - error.stack
+
+    func testStackJoinsFramesWithNewlines() {
+        let frames = [
+            "0   EdgeRum                  0x0001  frame_a",
+            "1   EdgeRum                  0x0002  frame_b",
+            "2   EdgeRum                  0x0003  frame_c"
+        ]
+        let attrs = AppErrorBuilder.build(
+            error: NSError(domain: "x", code: 0),
+            context: [:],
+            stack: frames,
+            debug: false
+        )
+        if case let .string(joined) = attrs["error.stack"] {
+            XCTAssertEqual(joined.components(separatedBy: "\n").count, 3)
+            XCTAssertTrue(joined.contains("frame_a"))
+            XCTAssertTrue(joined.contains("frame_c"))
+        } else {
+            XCTFail("error.stack must be a .string AttributeValue")
+        }
+    }
+
+    func testEmptyStackOmitsErrorStackAttribute() {
+        let attrs = AppErrorBuilder.build(
+            error: NSError(domain: "x", code: 0),
+            context: [:],
+            stack: [],
+            debug: false
+        )
+        XCTAssertNil(attrs["error.stack"])
+    }
+
+    func testStackTruncationDropsTrailingFramesWhole() {
+        // 100 frames of ~80 bytes each = ~8_100 bytes > 4_096 cap.
+        let frames = (0..<100).map { String(repeating: "F", count: 80) + "_\($0)" }
+        let joined = AppErrorBuilder.truncateStack(frames, maxBytes: 4_096)
+        XCTAssertLessThanOrEqual(joined.utf8.count, 4_096)
+        // Truncation must drop trailing frames whole, not slice
+        // mid-symbol — assert the prefix is intact.
+        XCTAssertTrue(joined.hasPrefix(frames[0]))
+    }
+
+    func testStackTruncationIsUTF8Safe() {
+        // A multi-byte UTF-8 sequence near the byte boundary must not
+        // get sliced. Frames mix ASCII + 4-byte emoji.
+        let emoji = "🛡️🚀"   // 8 bytes of UTF-8
+        let frames = (0..<200).map { "\($0) \(emoji) frame_padding_for_size" }
+        let joined = AppErrorBuilder.truncateStack(frames, maxBytes: 4_096)
+        XCTAssertNotNil(joined.data(using: .utf8),
+                        "truncated string must remain valid UTF-8")
+        XCTAssertLessThanOrEqual(joined.utf8.count, 4_096)
+    }
+
+    // MARK: - Cause / runtime invariants
+
+    func testCauseAndRuntimeAlwaysSet() {
+        let attrs = AppErrorBuilder.build(
+            error: NSError(domain: "x", code: 0),
+            context: [:],
+            stack: [],
+            debug: false
+        )
+        XCTAssertEqual(attrs["cause"], .string("AppError"))
+        XCTAssertEqual(attrs["runtime"], .string("swift"))
+    }
+
+    // MARK: - error.message fallback
+
+    func testSwiftErrorMessageFallsBackToDescribingWhenLocalizedIsGeneric() {
+        struct DemoError: Error {
+            let detail: String
+        }
+        let attrs = AppErrorBuilder.build(
+            error: DemoError(detail: "specific reason"),
+            context: [:],
+            stack: [],
+            debug: false
+        )
+        if case let .string(message) = attrs["error.message"] {
+            XCTAssertTrue(
+                message.contains("DemoError") || message.contains("specific reason"),
+                "Fallback message should describe the Swift error, got \(message)"
+            )
+        } else {
+            XCTFail("error.message must always be set")
+        }
+    }
+
+    func testNSErrorMessageUsesLocalizedDescription() {
+        let err = NSError(domain: "x", code: 0, userInfo: [
+            NSLocalizedDescriptionKey: "Server unreachable"
+        ])
+        let attrs = AppErrorBuilder.build(
+            error: err,
+            context: [:],
+            stack: [],
+            debug: false
+        )
+        XCTAssertEqual(attrs["error.message"], .string("Server unreachable"))
+    }
+}

--- a/Tests/EdgeRumTests/EdgeRumAPITests.swift
+++ b/Tests/EdgeRumTests/EdgeRumAPITests.swift
@@ -171,7 +171,12 @@ final class EdgeRumAPITests: XCTestCase {
 
     // MARK: - captureError
 
-    func testCaptureErrorFlattensNSError() {
+    func testCaptureErrorRoutesAppCrashEventToRecorder() {
+        // F13: the public `captureError` builds an `app.crash` event
+        // (cause = AppError) and hands the full attribute bag to the
+        // Recorder via `recordEvent`. We assert the routing here; the
+        // attribute-shape contract is exercised by
+        // `AppErrorBuilderTests` and the wire conformance test.
         EdgeRum.start(Self.validConfig())
         let err = NSError(
             domain: "PaymentDomain",
@@ -180,17 +185,47 @@ final class EdgeRumAPITests: XCTestCase {
         )
         EdgeRum.captureError(err, context: ["payment.method": "card"])
 
-        let errors = probe.calls.compactMap { call -> (String, Int, String?, [String: AttributeValue])? in
-            if case let .error(domain, code, message, context) = call {
-                return (domain, code, message, context)
+        let crashEvents = probe.calls.compactMap { call -> [String: AttributeValue]? in
+            if case let .event(name, attributes) = call, name == "app.crash" {
+                return attributes
             }
             return nil
         }
-        XCTAssertEqual(errors.count, 1)
-        XCTAssertEqual(errors.first?.0, "PaymentDomain")
-        XCTAssertEqual(errors.first?.1, 42)
-        XCTAssertEqual(errors.first?.2, "Card declined")
-        XCTAssertEqual(errors.first?.3["payment.method"], .string("card"))
+        XCTAssertEqual(crashEvents.count, 1)
+        guard let attrs = crashEvents.first else {
+            return XCTFail("Expected an app.crash routing call")
+        }
+        XCTAssertEqual(attrs["cause"], .string("AppError"))
+        XCTAssertEqual(attrs["runtime"], .string("swift"))
+        XCTAssertEqual(attrs["error.kind"], .string("nserror"))
+        XCTAssertEqual(attrs["error.domain"], .string("PaymentDomain"))
+        XCTAssertEqual(attrs["error.code"], .int(42))
+        XCTAssertEqual(attrs["error.message"], .string("Card declined"))
+        XCTAssertEqual(attrs["crash.context.payment.method"], .string("card"))
+        XCTAssertNil(attrs["payment.method"],
+                     "Caller context must be prefixed `crash.context.`, never bare")
+        // `error.stack` should be captured at the call site.
+        if case let .string(stack) = attrs["error.stack"] {
+            XCTAssertFalse(stack.isEmpty, "error.stack must be captured at the call site")
+            XCTAssertTrue(stack.contains("testCaptureErrorRoutesAppCrashEventToRecorder")
+                          || stack.contains("EdgeRumTests"),
+                          "stack should include a frame from the calling test target")
+        } else {
+            XCTFail("error.stack missing or wrong type")
+        }
+    }
+
+    func testCaptureErrorWithSwiftErrorReportsKindSwift() {
+        struct DemoError: Error { let detail: String }
+        EdgeRum.start(Self.validConfig())
+        EdgeRum.captureError(DemoError(detail: "nope"))
+        let kinds = probe.calls.compactMap { call -> AttributeValue? in
+            if case let .event(name, attributes) = call, name == "app.crash" {
+                return attributes["error.kind"]
+            }
+            return nil
+        }
+        XCTAssertEqual(kinds, [.string("swift")])
     }
 
     // MARK: - enable / disable

--- a/Tests/EdgeRumTests/Helpers/ProbeRecorder.swift
+++ b/Tests/EdgeRumTests/Helpers/ProbeRecorder.swift
@@ -89,17 +89,6 @@ internal final class ProbeRecorder: Recording, @unchecked Sendable {
         lock.unlock()
     }
 
-    internal func recordError(
-        domain: String,
-        code: Int,
-        message: String?,
-        context: [String: AttributeValue]
-    ) {
-        lock.lock()
-        _calls.append(.error(domain: domain, code: code, message: message, context: context))
-        lock.unlock()
-    }
-
     internal func setUser(_ user: RecorderUser) {
         lock.lock()
         _calls.append(.setUser(user))

--- a/Tests/EdgeRumTests/RecorderTests.swift
+++ b/Tests/EdgeRumTests/RecorderTests.swift
@@ -99,18 +99,25 @@ final class RecorderTests: XCTestCase {
 
     // MARK: Immediate-flush triggers
 
-    func testErrorTriggersImmediateFlushAsAppCrash() {
+    func testAppCrashEventTriggersImmediateFlush() {
+        // F13: `EdgeRum.captureError` routes through
+        // `recordEvent(name: "app.crash", ...)`. The Recorder must
+        // treat that event name as an immediate-flush trigger so
+        // crash payloads never wait behind a `flushInterval` timer.
         let (recorder, sink, _) = makeRecorder()
-        recorder.recordError(domain: "PaymentDomain", code: 42, message: "Card declined", context: ["payment.method": "card"])
+        recorder.recordEvent(name: "app.crash", attributes: [
+            "cause": "AppError",
+            "runtime": "swift",
+            "error.kind": "swift",
+            "error.type": "DemoError",
+            "error.message": "boom"
+        ])
         XCTAssertEqual(sink.envelopes.count, 1)
         XCTAssertEqual(sink.sends.first?.reason, .immediate)
         let event = sink.envelopes.first?.events.first
         XCTAssertEqual(event?.name, "app.crash")
         XCTAssertEqual(event?.attributes["cause"], .string("AppError"))
-        XCTAssertEqual(event?.attributes["error.domain"], .string("PaymentDomain"))
-        XCTAssertEqual(event?.attributes["error.code"], .int(42))
-        XCTAssertEqual(event?.attributes["error.message"], .string("Card declined"))
-        XCTAssertEqual(event?.attributes["payment.method"], .string("card"))
+        XCTAssertEqual(event?.attributes["error.kind"], .string("swift"))
     }
 
     func testSessionFinalizedTriggersImmediateFlush() {


### PR DESCRIPTION
## Summary

Implements **F13 — Error capture**. `EdgeRum.captureError(_:context:)` now
builds a full `app.crash` payload (PLAN-iOS.md §6.6) via a new pure
`AppErrorBuilder` helper in `EdgeRumCore`.

Wire attributes (in addition to the standard identity bag):

| Key | Type | Notes |
|-----|------|-------|
| `cause` | `String` | always `"AppError"` |
| `runtime` | `String` | always `"swift"` (distinguishes from native crashes) |
| `error.type` | `String` | Swift type name or NSError class (`String(describing: type(of: error))`) |
| `error.kind` | `String` | `"swift"` for Swift errors, `"nserror"` for host-allocated NSError |
| `error.domain` | `String` | `(error as NSError).domain` |
| `error.code` | `Int` | `(error as NSError).code` |
| `error.message` | `String` | `localizedDescription`, falling back to `String(describing:)` when generic |
| `error.userInfo.<k>` | primitive | NSError only — primitives kept, non-primitives dropped silently (debug-logged) |
| `error.stack` | `String` | `Thread.callStackSymbols` captured at the public call site, joined with `\n`, UTF-8-safely truncated to 4 KiB |
| `crash.context.<k>` | primitive | caller-supplied context keys, **prefixed** so they can never collide with the `error.*` set |

`Thread.callStackSymbols` is captured **synchronously** in
`EdgeRum.captureError` before any handoff to the Recorder's serial
queue — otherwise the frames would be the queue's, not the caller's.

## Implementation highlights

- **`Sources/EdgeRumCore/AppErrorBuilder.swift`** — pure flattener
  with no I/O, no global state. Owns the userInfo primitive filter
  (NSNumber + CFBoolean disambiguation, ObjC-type-encoding switch),
  the `error.kind` discriminator (`type(of: error) is NSError.Type`),
  the call-site stack truncation, and the `crash.context.` prefix.
- **`Recording` protocol** — `recordError(domain:code:message:context:)`
  is removed; the existing `recordEvent(name: "app.crash", attributes:)`
  path already gives us forced-emit (sampler allowlist) + immediate
  flush. New `var debug: Bool { get }` with a protocol-extension
  default of `false` so test probes pre-dating F13 keep compiling.
- **`Recorder`** — exposes `public var debug: Bool` reading
  `_config?.debug` under `stateLock`; old `recordError` method
  deleted in favour of the `recordEvent` route.
- **`EdgeRum.captureError`** — rewritten to capture the stack at the
  call site, delegate flattening to `AppErrorBuilder`, and emit via
  `Recorder.shared.recordEvent`.
- **`RecordedCall.error`** case removed (no longer produced); the
  `ProbeRecorder` stub is dead and gone.

## Tests

- `Tests/EdgeRumTests/AppErrorBuilderTests.swift` — **14 unit cases**:
  - Swift / NSError discriminator
  - `error.type` derivation for both
  - userInfo flattening for primitives (`String`/`Int`/`Double`/`Bool`)
  - non-primitive userInfo drop (nested NSError, `[Int]`, `[String: Int]`)
  - Swift errors carry no `error.userInfo.*`
  - caller context prefixing + collision protection
  - stack join, truncation, UTF-8 safety with multi-byte glyphs
  - `cause` / `runtime` invariants
  - `error.message` fallback for generic LocalizedError descriptions
- `Tests/EdgeRumContractTests/AppErrorWireConformanceTests.swift` — **5 wire-conformance cases**:
  - NSError envelope passes `WireAssertions.assertValidEnvelope` +
    `assertIdentityAttributes`; full attribute set verified
  - Swift error envelope passes the same gates with `error.kind = "swift"`
  - Non-primitive userInfo dropped at the wire boundary
  - Primitives-only sanity check (no `traceId`/`spanId`/`opentelemetry`
    tokens in the raw bytes)
  - `app.crash` co-exists with `navigation` in the same batch
- Existing tests updated for the new attribute shape and prefixed
  context (`RecorderTests`, `RecorderPipelineTests`, `EdgeRumAPITests`).

Full suite: **433 tests, 0 F13-related failures**. One pre-existing
flake in `NetworkPathCaptureTests.test_emit_deduplicatesIdenticalTransitions`
passes when run in isolation — caused by shared static state across
the full test run, unrelated to this PR.

## Verification

- [x] `swift build -c release` — clean
- [x] `swift test --filter AppError` — 19/19 new cases pass
- [x] `swift test --filter RecorderTests` — 16/16 pass (updated)
- [x] `swift test --filter EdgeRumAPITests` — pass (updated)
- [x] `Tools/firewall-check.sh` — public surface clean
- [x] Belt-and-braces grep for banned terms (`opentelemetry`, `otel`,
      `span`, `tracer`, `telemetry`) on F13 files — clean
- [ ] Manual smoke in `Samples/EdgeRumSampleApp` — call
      `EdgeRum.captureError(NSError(domain: "Demo", code: 42, userInfo: ["k": "v", "underlying": NSError(...)]))`
      and `EdgeRum.captureError(DemoError())` and inspect the wire payload.

## Linked issues

Closes #18
Closes #71
Closes #72