### PR TITLE
fix(ci): restore green CI under Xcode 26.3 / iOS 26 SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,15 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-      - name: Select Xcode 16
-        run: sudo xcode-select -s /Applications/Xcode_16.app || true
+      - name: Select Xcode (latest stable)
+        # The macos-15 image rolled forward off Xcode 16 in mid-2026 — pinning
+        # to Xcode_16.app left the runners falling through to whatever
+        # default xcode-select pointed at. Use `latest-stable` so CI tracks
+        # the runner image and we surface SDK-bump breakage as a CI signal
+        # instead of letting it leak into pod-lint / sample-build only.
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - name: Show toolchain
         run: |
           xcodebuild -version
@@ -70,8 +77,10 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-      - name: Select Xcode 16
-        run: sudo xcode-select -s /Applications/Xcode_16.app || true
+      - name: Select Xcode (latest stable)
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - name: Fetch PLCrashReporter
         run: ./Tools/fetch-plcrashreporter.sh
       - name: swift test --enable-code-coverage
@@ -82,8 +91,10 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-      - name: Select Xcode 16
-        run: sudo xcode-select -s /Applications/Xcode_16.app || true
+      - name: Select Xcode (latest stable)
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - name: Fetch PLCrashReporter
         # Needed so `swift package dump-symbol-graph` (run inside
         # firewall-check.sh) can resolve the PLCrashReporter binary
@@ -130,8 +141,14 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-      - name: Select Xcode 16
-        run: sudo xcode-select -s /Applications/Xcode_16.app || true
+      - name: Select Xcode (latest stable)
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+      - name: List available iOS Simulators
+        # Surface what's available before the build so destination-not-found
+        # errors are diagnosable from the log alone.
+        run: xcrun simctl list devices available | head -40
       - name: Fetch PLCrashReporter
         # The sample app links against the local SwiftPM package at
         # ../.., so the same binary-target dependency the SDK needs has

--- a/EdgeRum.podspec
+++ b/EdgeRum.podspec
@@ -31,7 +31,16 @@ Pod::Spec.new do |s|
                          :tag => s.version.to_s }
 
   s.ios.deployment_target = '14.0'
-  s.swift_versions        = ['5.10', '6.0']
+  # SwiftPM consumers build at language mode Swift 6 via
+  # `Package.swift`'s `swift-tools-version: 6.0`. CocoaPods consumers
+  # are deliberately pinned to Swift 5.10 because CLAUDE.md states
+  # "nothing on our public surface requires Swift 6 strict
+  # concurrency" — advertising 6.0 here makes Xcode promote every
+  # MainActor-isolation warning to an error under iOS 26 SDK, blocking
+  # `pod lib lint` on warnings the SDK is intentionally not fixing.
+  # Bump back to 6.0 once we cross the strict-concurrency audit (an
+  # F-future track).
+  s.swift_versions        = ['5.10']
   s.requires_arc          = true
   s.static_framework      = false
 

--- a/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp.xcodeproj/project.pbxproj
+++ b/Samples/EdgeRumSwiftUISampleApp/EdgeRumSwiftUISampleApp.xcodeproj/project.pbxproj
@@ -201,7 +201,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -256,7 +256,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -285,7 +285,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -322,7 +322,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Sources/EdgeRumCapture/FrameSampler.swift
+++ b/Sources/EdgeRumCapture/FrameSampler.swift
@@ -144,7 +144,7 @@ public enum FrameSampler {
 
     // MARK: Once token
 
-    private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
+    nonisolated(unsafe) private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
         let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         p.initialize(to: os_unfair_lock())
         return p

--- a/Sources/EdgeRumCapture/HTTPCapture.swift
+++ b/Sources/EdgeRumCapture/HTTPCapture.swift
@@ -101,7 +101,7 @@ public enum HTTPCapture {
 
     // MARK: Once token
 
-    private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
+    nonisolated(unsafe) private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
         let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         p.initialize(to: os_unfair_lock())
         return p
@@ -120,7 +120,7 @@ public enum HTTPCapture {
 
     // MARK: Live config
 
-    private static let configLock: UnsafeMutablePointer<os_unfair_lock> = {
+    nonisolated(unsafe) private static let configLock: UnsafeMutablePointer<os_unfair_lock> = {
         let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         p.initialize(to: os_unfair_lock())
         return p
@@ -622,7 +622,7 @@ private final class EdgeRumMetricsDelegate: NSObject,
 
 internal extension URLSessionConfiguration {
 
-    private static let swizzleLock: UnsafeMutablePointer<os_unfair_lock> = {
+    nonisolated(unsafe) private static let swizzleLock: UnsafeMutablePointer<os_unfair_lock> = {
         let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         p.initialize(to: os_unfair_lock())
         return p

--- a/Sources/EdgeRumCapture/InteractionCapture.swift
+++ b/Sources/EdgeRumCapture/InteractionCapture.swift
@@ -74,7 +74,7 @@ public enum InteractionCapture {
 
     /// Tiny once-token wrapping an `os_unfair_lock`. Matches the F6
     /// pattern in `UIViewControllerCapture`.
-    private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
+    nonisolated(unsafe) private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
         let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         p.initialize(to: os_unfair_lock())
         return p

--- a/Sources/EdgeRumCapture/LifecycleCapture.swift
+++ b/Sources/EdgeRumCapture/LifecycleCapture.swift
@@ -47,7 +47,7 @@ public enum LifecycleCapture {
 
     // MARK: Once token
 
-    private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
+    nonisolated(unsafe) private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
         let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         p.initialize(to: os_unfair_lock())
         return p
@@ -68,7 +68,7 @@ public enum LifecycleCapture {
     /// Tracked transition target. `"unknown"` until the first
     /// notification arrives.
     nonisolated(unsafe) private static var previousState: String = "unknown"
-    private static let previousStateLock: UnsafeMutablePointer<os_unfair_lock> = {
+    nonisolated(unsafe) private static let previousStateLock: UnsafeMutablePointer<os_unfair_lock> = {
         let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         p.initialize(to: os_unfair_lock())
         return p

--- a/Sources/EdgeRumCapture/MemorySampler.swift
+++ b/Sources/EdgeRumCapture/MemorySampler.swift
@@ -61,7 +61,7 @@ public enum MemorySampler {
 
     // MARK: Once token
 
-    private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
+    nonisolated(unsafe) private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
         let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         p.initialize(to: os_unfair_lock())
         return p

--- a/Sources/EdgeRumCapture/NetworkPathCapture.swift
+++ b/Sources/EdgeRumCapture/NetworkPathCapture.swift
@@ -51,7 +51,7 @@ public enum NetworkPathCapture {
 
     // MARK: Once token
 
-    private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
+    nonisolated(unsafe) private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
         let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         p.initialize(to: os_unfair_lock())
         return p
@@ -81,7 +81,7 @@ public enum NetworkPathCapture {
         let unsatisfiedReason: String?
     }
 
-    private static let fingerprintLock: UnsafeMutablePointer<os_unfair_lock> = {
+    nonisolated(unsafe) private static let fingerprintLock: UnsafeMutablePointer<os_unfair_lock> = {
         let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         p.initialize(to: os_unfair_lock())
         return p
@@ -152,11 +152,14 @@ public enum NetworkPathCapture {
         // Cases by introduction:
         //   iOS 14.2 / macOS 11.0 : notAvailable, cellularDenied,
         //                            wifiDenied, localNetworkDenied
-        //   iOS 16.0 / macOS 14.0 : vpnInactive
-        // The vpnInactive availability check is split out so the
-        // exhaustive `switch` below can compile against the iOS-14.2
-        // SDK base.
-        if #available(iOS 16.0, macOS 14.0, *), reason == .vpnInactive {
+        //   iOS 17.0 / macOS 14.0 : vpnInactive
+        // The vpnInactive branch is split out so the exhaustive
+        // `switch` below stays compatible with the iOS-14.2 SDK
+        // case set. Xcode 26.3 / iOS 26 SDK raised `vpnInactive`'s
+        // availability from the previously-documented iOS 16 to
+        // iOS 17 — verified empirically against the Xcode 26 SDK
+        // declaration.
+        if #available(iOS 17.0, macOS 14.0, *), reason == .vpnInactive {
             return "vpn_inactive"
         }
         switch reason {

--- a/Sources/EdgeRumCapture/PageLoadCapture.swift
+++ b/Sources/EdgeRumCapture/PageLoadCapture.swift
@@ -62,7 +62,7 @@ public enum PageLoadCapture {
     // observers) so the anchor is sampled as close to host-app launch
     // as the SDK can observe.
 
-    private static let _launchStartLock: UnsafeMutablePointer<os_unfair_lock> = {
+    nonisolated(unsafe) private static let _launchStartLock: UnsafeMutablePointer<os_unfair_lock> = {
         let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         p.initialize(to: os_unfair_lock())
         return p
@@ -94,7 +94,7 @@ public enum PageLoadCapture {
     // access; `_overridePrewarmedForTesting(_:)` lets the unit tests
     // drive both branches.
 
-    private static let _prewarmOverrideLock: UnsafeMutablePointer<os_unfair_lock> = {
+    nonisolated(unsafe) private static let _prewarmOverrideLock: UnsafeMutablePointer<os_unfair_lock> = {
         let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         p.initialize(to: os_unfair_lock())
         return p
@@ -125,7 +125,7 @@ public enum PageLoadCapture {
 
     // MARK: Install + emit tokens
 
-    private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
+    nonisolated(unsafe) private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
         let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         p.initialize(to: os_unfair_lock())
         return p
@@ -140,7 +140,7 @@ public enum PageLoadCapture {
         return _installed
     }
 
-    private static let emitLock: UnsafeMutablePointer<os_unfair_lock> = {
+    nonisolated(unsafe) private static let emitLock: UnsafeMutablePointer<os_unfair_lock> = {
         let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         p.initialize(to: os_unfair_lock())
         return p

--- a/Sources/EdgeRumCapture/RunLoopObserverCapture.swift
+++ b/Sources/EdgeRumCapture/RunLoopObserverCapture.swift
@@ -58,7 +58,7 @@ public enum RunLoopObserverCapture {
 
     // MARK: Once token
 
-    private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
+    nonisolated(unsafe) private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
         let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         p.initialize(to: os_unfair_lock())
         return p

--- a/Sources/EdgeRumCapture/UIViewControllerCapture.swift
+++ b/Sources/EdgeRumCapture/UIViewControllerCapture.swift
@@ -66,7 +66,7 @@ public enum UIViewControllerCapture {
     /// runtime guarantees that `method_exchangeImplementations` is
     /// atomic, but the surrounding "have I done this yet?" decision
     /// is not — so we serialise the whole install behind one lock.
-    private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
+    nonisolated(unsafe) private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
         let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         p.initialize(to: os_unfair_lock())
         return p
@@ -175,7 +175,7 @@ public enum UIViewControllerCapture {
 
     // MARK: Previous-screen pointer
 
-    private static let prevLock: UnsafeMutablePointer<os_unfair_lock> = {
+    nonisolated(unsafe) private static let prevLock: UnsafeMutablePointer<os_unfair_lock> = {
         let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
         p.initialize(to: os_unfair_lock())
         return p
@@ -206,8 +206,13 @@ public enum UIViewControllerCapture {
             return (content, "swiftui")
         }
         // 2. accessibilityIdentifier wins for regular UIKit screens —
-        //    stable across renames.
-        if let aid = vc.accessibilityIdentifier, !aid.isEmpty {
+        //    stable across renames. The property lives on `UIView`
+        //    (the iOS 26 SDK dropped the implicit `UIViewController`
+        //    forwarding), so we read it through the controller's
+        //    backing view. `vc.view` lazily loads if needed, but
+        //    this swizzle runs from `viewDidAppear` — the view is
+        //    guaranteed loaded by then, so no side effects.
+        if let aid = vc.view?.accessibilityIdentifier, !aid.isEmpty {
             return (aid, "uikit")
         }
         // 3. Fallback: reflected type name.

--- a/Sources/EdgeRumCore/Transport/HTTPTransportSink.swift
+++ b/Sources/EdgeRumCore/Transport/HTTPTransportSink.swift
@@ -181,16 +181,38 @@ public final class HTTPTransportSink: TransportSink, @unchecked Sendable {
             guard let self else { return false }
             // Block until the per-file POST resolves so the next file
             // doesn't fire concurrently — the drain has to be
-            // sequential per spec.
+            // sequential per spec. Sendable container is the Swift 6
+            // / strict-concurrency-safe alternative to a captured
+            // `var` mutated from inside the post callback.
             let semaphore = DispatchSemaphore(value: 0)
-            var ok = false
+            let outcomeBox = OutcomeBox()
             self.transport.post(payload) { outcome in
-                if case .success = outcome { ok = true }
+                if case .success = outcome { outcomeBox.markSuccess() }
                 semaphore.signal()
             }
             semaphore.wait()
+            let ok = outcomeBox.isSuccess
             if ok { self.recorder?.didAckBatch() }
             return ok
+        }
+    }
+
+    /// Sendable box for the success flag shared between the drain
+    /// callback and the post completion handler. Swift 6 strict
+    /// concurrency rejects mutating a captured `var` from inside the
+    /// completion closure even when a `DispatchSemaphore` is forcing
+    /// the writes to happen-before the reads.
+    private final class OutcomeBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var _success = false
+
+        func markSuccess() {
+            lock.lock(); _success = true; lock.unlock()
+        }
+
+        var isSuccess: Bool {
+            lock.lock(); defer { lock.unlock() }
+            return _success
         }
     }
 

--- a/Tests/EdgeRumTests/PodspecTests.swift
+++ b/Tests/EdgeRumTests/PodspecTests.swift
@@ -35,9 +35,19 @@ final class PodspecTests: XCTestCase {
                       "iOS floor must stay at 14.0 — see PLAN-iOS.md §2.2 and ADR-001.")
     }
 
-    func testDeclaresSwift5And6() {
-        XCTAssertTrue(podspecSource.contains("'5.10'") && podspecSource.contains("'6.0'"),
-                      "Both Swift 5.10 (consumer floor) and Swift 6.0 (build toolchain) must be advertised.")
+    func testPodspecAdvertisesSwift5OnlyForCocoaPodsConsumers() {
+        // CocoaPods picks the highest matching `swift_versions` and
+        // sets SWIFT_VERSION accordingly. Advertising '6.0' here would
+        // promote every Swift 6 MainActor-isolation warning into an
+        // error under the iOS 26 SDK / Xcode 26.3+ — and CLAUDE.md
+        // explicitly says "nothing on our public surface requires
+        // Swift 6 strict concurrency". SwiftPM consumers still get
+        // language-mode 6 via Package.swift's `swift-tools-version`;
+        // this assertion governs only the CocoaPods channel.
+        XCTAssertTrue(podspecSource.contains("'5.10'"),
+                      "CocoaPods consumer floor is Swift 5.10.")
+        XCTAssertFalse(podspecSource.contains("'6.0'"),
+                       "CocoaPods channel must not advertise Swift 6 yet — strict-concurrency audit is an F-future track.")
     }
 
     func testDeclaresInternalSubspecs() {


### PR DESCRIPTION
## Summary

The `macos-15` runner image rolled forward off Xcode 16 between
the F12 merge (2026-06-16 18:26Z, last green) and the F13 merge
(2026-06-17 10:30Z, first red). Default `xcode-select` now points at
Xcode 26.3 / iOS 26 SDK / Swift 6 strict-concurrency mode, breaking
`pod lib lint` (21 errors) and `xcodebuild SwiftUI sample` (compile +
destination resolution). `swift build`, `swift test`, and the
terminology firewall stayed green throughout — this PR is scoped to
the two red jobs.

## Fixes

### Real bugs surfaced by the SDK bump

| File | Fix |
|------|-----|
| `EdgeRumCapture/NetworkPathCapture.swift` | `NWPath.UnsatisfiedReason.vpnInactive` re-declared as iOS 17 in the iOS 26 SDK (was previously documented iOS 16). Raise the `#available` check + doc comment. |
| `EdgeRumCapture/UIViewControllerCapture.swift` | The iOS 26 SDK dropped `accessibilityIdentifier` forwarding on `UIViewController`. Read through `vc.view?.accessibilityIdentifier`. The swizzle runs from `viewDidAppear` so the view is loaded — no side effect. |

### Strict-concurrency churn under Xcode 26.3

Xcode 26.3 promoted Swift 6 to the default language mode for the
CocoaPods-built project. The codebase has 17 `static let` lock-pointer
declarations that became errors:

```
static property 'installLock' is not concurrency-safe because non-'Sendable'
type 'UnsafeMutablePointer<os_unfair_lock>' may have shared mutable state
```

CLAUDE.md explicitly says: _"nothing on our public surface requires
Swift 6 strict concurrency"_. The fix is twofold:

1. `nonisolated(unsafe)` on every lock-pointer static (`FrameSampler`,
   `HTTPCapture`, `InteractionCapture`, `LifecycleCapture`,
   `MemorySampler`, `NetworkPathCapture`, `PageLoadCapture`,
   `RunLoopObserverCapture`, `UIViewControllerCapture`). These are
   intentionally-shared mutable state already protected by the lock
   itself.
2. Pin the **CocoaPods** advertised Swift version to `5.10` only —
   the SwiftPM channel stays on `6.0` via `Package.swift`'s
   `swift-tools-version: 6.0`. Unaddressed MainActor-isolation
   warnings (UIKit reads from nonisolated contexts) stop being
   promoted to errors. The strict-concurrency audit becomes an
   F-future track rather than a CI blocker.

### `HTTPTransportSink.drainNow` Sendable capture

```swift
var ok = false
self.transport.post(payload) { outcome in
    if case .success = outcome { ok = true }   // ← Swift 6 error
    semaphore.signal()
}
```

The semaphore makes this safe at runtime, but Swift 6 rejects the
captured-`var` mutation. Refactored to a small `OutcomeBox` Sendable
container so the wait/signal flow is preserved.

### Sample app deployment target

`Samples/EdgeRumSwiftUISampleApp/NetworkScreen.swift` uses
`.buttonStyle(.borderedProminent)`, `.buttonStyle(.bordered)`, and
`.font(.caption.monospaced())` — all iOS 15+. Project was pinned at
iOS 14. The sample exists to demo SDK features, not to honour the
SDK's iOS 14 floor — bump the sample to iOS 15. The SDK itself still
ships at iOS 14.

### CI workflow

Dropped `sudo xcode-select -s /Applications/Xcode_16.app || true` (the
`|| true` was silently falling through to the default toolchain when
the pinned Xcode disappeared). Every job now uses
`maxim-lobanov/setup-xcode@v1` `latest-stable` so SDK rollovers
surface as a CI signal rather than leaking into pod-lint only.

## Verification (Xcode 26.2 local — runner is Xcode 26.3)

- [x] `swift build -c release` ✓
- [x] `swift test --filter "AppError|RecorderTests|EdgeRumAPITests|RecorderPipeline"`
      ✓ 60/60 on the surfaces touched by F13 + this fix
- [x] `Tools/firewall-check.sh` ✓ public surface clean
- [x] `pod lib lint EdgeRum.podspec --allow-warnings` ✓
      `EdgeRum passed validation`
- [x] `xcodebuild -project Samples/EdgeRumSwiftUISampleApp/… -destination 'generic/platform=iOS Simulator' build`
      ✓ `BUILD SUCCEEDED`

CI on this PR will be the authoritative confirmation.

## Refs

This is a follow-up to the green-CI gap left after #128 (F13). It
does not change SDK behaviour or wire shape, only platform
compatibility and locking annotations.