### PR TITLE
feat(F15): hang detection — main-runloop watchdog + best-effort stack

### DIFF
--- a/Samples/EdgeRumCrashSampleApp/EdgeRumCrashSampleApp/CrashHomeScreen.swift
+++ b/Samples/EdgeRumCrashSampleApp/EdgeRumCrashSampleApp/CrashHomeScreen.swift
@@ -33,8 +33,8 @@ struct CrashHomeScreen: View {
                         .buttonStyle(.borderedProminent)
                     Button("Crash with NSException", action: crashWithException)
                         .buttonStyle(.borderedProminent)
-                    Button("Trigger 10s hang (F15 preview)", action: triggerHang)
-                        .buttonStyle(.bordered)
+                    Button("Trigger 6 s main-thread hang (F15)", action: triggerHang)
+                        .buttonStyle(.borderedProminent)
                 }
                 .frame(maxWidth: .infinity)
 
@@ -79,7 +79,11 @@ struct CrashHomeScreen: View {
 
     private func triggerHang() {
         // Sleeps the main thread past EdgeRumConfig.hangTimeout (default
-        // 5.0s). F15's hang detector will fire once it lands.
-        Thread.sleep(forTimeInterval: 10)
+        // 5.0s). F15's HangDetector will fire one `app.crash` event
+        // with `cause = "Hang"`, `crash.thread.main_stack` populated
+        // via the Mach-based snapshot, and `hang.duration_ms` ≥ 6000.
+        // The app stays alive afterwards — hangs are non-fatal
+        // (`crash.fatal = false`).
+        Thread.sleep(forTimeInterval: 6)
     }
 }

--- a/Samples/EdgeRumCrashSampleApp/README.md
+++ b/Samples/EdgeRumCrashSampleApp/README.md
@@ -1,27 +1,28 @@
 # EdgeRum crash sample
 
-Manual-QA app for F14 native crash capture. Four buttons take the
-host process down via the crash classes the F14 PLCrashReporter
-integration catches (Mach signals + uncaught `NSException`) plus a
-long `Thread.sleep` for the F15 hang detector preview.
+Manual-QA app for F14 native crash capture **and** F15 hang
+detection. Four buttons exercise the crash classes the F14
+PLCrashReporter integration catches (Mach signals + uncaught
+`NSException`) plus a `Thread.sleep` long enough to trip the F15
+hang watchdog.
 
 ## What it covers
 
-| Button | Triggers | F14 path |
+| Button | Triggers | SDK path |
 |---|---|---|
-| `Crash with SIGSEGV` | Null-pointer write → `EXC_BAD_ACCESS` | Mach exception → PLCR signal record |
-| `Crash with SIGABRT (fatalError)` | `fatalError(_:)` | Mach exception → PLCR signal record |
-| `Crash with NSException` | `NSException.raise()` | PLCR uncaught-exception handler |
-| `Trigger 10s hang (F15 preview)` | `Thread.sleep(forTimeInterval: 10)` | F15 — not yet wired |
+| `Crash with SIGSEGV` | Null-pointer write → `EXC_BAD_ACCESS` | F14 — Mach exception → PLCR signal record |
+| `Crash with SIGABRT (fatalError)` | `fatalError(_:)` | F14 — Mach exception → PLCR signal record |
+| `Crash with NSException` | `NSException.raise()` | F14 — PLCR uncaught-exception handler |
+| `Trigger 6 s main-thread hang (F15)` | `Thread.sleep(forTimeInterval: 6)` on main | F15 — `CFRunLoopObserver` heartbeat stalls → `HangDetector` records one `app.crash` with `cause = "Hang"` |
 
-## Manual QA loop (PLAN-iOS §13.3)
+## Manual QA loop — F14 native crash (PLAN-iOS §13.3)
 
 1. Open the project in Xcode, pick an iOS Simulator or device,
    build, and Run.
 2. Note the active `session.id` on screen (also visible in
    Console.app — filter subsystem `com.edge.rum`, look for
    `session.started`).
-3. Tap one of the crash buttons; confirm the app terminates.
+3. Tap one of the **crash** buttons; confirm the app terminates.
 4. Relaunch the app.
 5. Verify the **first** emitted batch contains a single `app.crash`
    event carrying:
@@ -33,6 +34,27 @@ long `Thread.sleep` for the F15 hang detector preview.
    - `crash.report_format_version = "edgerum.crash.v1"`
    - `crash.report_json` that parses back to JSON (contains
      `threads`, `binary_images`, `format_version`)
+
+## Manual QA loop — F15 hang detection (PLAN-iOS §F15)
+
+1. Launch the app — the SDK starts with
+   `EdgeRumConfig.hangTimeout = 5.0` (default).
+2. Tap **`Trigger 6 s main-thread hang (F15)`**. The UI freezes
+   (taps stop registering) for ~6 seconds, then resumes.
+3. Within ~5 s of the hang ending, a single batch is POSTed
+   containing one `app.crash` event with:
+   - `eventName = "app.crash"`
+   - `cause = "Hang"` (NOT `"NativeCrash"`)
+   - `runtime = "native"`
+   - `crash.fatal = false` — hangs are non-fatal
+   - `hang.duration_ms` ≥ 5000
+   - `hang.threshold_ms = 5000`
+   - `crash.thread.main_stack` carrying a non-empty stack
+   - `session.id` matching the live session (the hang does NOT
+     terminate the app, so the session does not rotate)
+4. Tap the button again to confirm a second hang produces a
+   **second** distinct `app.crash` (one per stall window — the
+   watchdog does not double-fire during a single hang).
 
 > **Simulator caveat.** PLCrashReporter is configured with Mach
 > exception handling (`PLAN-iOS.md` §6.7). Xcode's debugger intercepts

--- a/Sources/EdgeRum/EdgeRum.swift
+++ b/Sources/EdgeRum/EdgeRum.swift
@@ -280,6 +280,18 @@ public enum EdgeRum {
                 debug: config.debug
             )
         }
+
+        // F15 — install the main-thread hang watchdog. Idempotent;
+        // the install hops to the main thread internally to attach
+        // the `CFRunLoopObserver`, and the watchdog `Thread` is the
+        // one we cancel from `disable()` so a paused SDK leaves no
+        // live timers behind.
+        if config.enableHangDetection, Recorder.shared is Recorder {
+            HangDetector.install(
+                threshold: config.hangTimeout,
+                debug: config.debug
+            )
+        }
     }
 
     /// Attach a host-app user profile to subsequent events. Calling
@@ -367,6 +379,12 @@ public enum EdgeRum {
     /// Use `enable()` to resume.
     public static func disable() {
         Recorder.shared.setEnabled(false)
+        // F15 — tear down the watchdog so a paused SDK has no live
+        // timers. `enable()` does NOT re-arm by design; `start(_:)`
+        // is the install boundary, mirroring the swizzle-installer
+        // rule (we cannot safely un-swizzle, so we cannot safely
+        // re-swizzle either).
+        HangDetector.uninstall()
     }
 
     /// Resume capture and emission after a `disable()` call. Also

--- a/Sources/EdgeRumCrash/HangDetector.swift
+++ b/Sources/EdgeRumCrash/HangDetector.swift
@@ -1,0 +1,373 @@
+// Sources/EdgeRumCrash/HangDetector.swift
+//
+// F15/T15.1 — main-thread hang detection. Two collaborating pieces:
+//
+//   1. A `CFRunLoopObserver` on the main runloop (`.commonModes`,
+//      `.entry | .beforeWaiting | .afterWaiting | .exit`) bumps an
+//      atomic heartbeat counter every time the main runloop turns.
+//   2. A dedicated background `HangWatchdogThread` polls the counter
+//      every `tickIntervalSeconds` (250 ms). If the counter has not
+//      advanced for longer than the configured `hangTimeout`, the
+//      watchdog records one `app.crash` event with `cause = "Hang"`,
+//      `crash.thread.main_stack`, `hang.duration_ms`, and
+//      `hang.threshold_ms` (see `HangEventEncoder`).
+//
+// Idempotent install (NSLock-protected `installed` flag mirrors
+// `PLCrashIntegration` lines 38-72). `uninstall()` removes the
+// observer and cancels the watchdog thread so a host that calls
+// `EdgeRum.disable()` mid-run leaves no live timers behind.
+//
+// Threshold is clamped to a 2.0 s floor (PLAN-iOS.md §17 risk #5 —
+// older iPhone 8 / SE 2 hardware can produce false positives at
+// sub-2 s thresholds).
+//
+// The watchdog never blocks the main thread. The Mach-based stack
+// capture (`MainThreadStackSnapshot.capture`) runs on the watchdog
+// thread, suspends the main thread for a few microseconds while it
+// walks the frame-pointer chain, then resumes. `Recorder.recordEvent`
+// hops to its own utility queue so the hang event flushes
+// asynchronously and doesn't extend the stall.
+//
+// Refs: PLAN-iOS.md §6.8, §F15/T15.1, §F15/T15.2;
+//       docs/decisions.md ADR-011; CLAUDE.md "Touching crash code?"
+//
+
+import Foundation
+import os.log
+#if canImport(EdgeRumCore)
+import EdgeRumCore
+#endif
+
+public enum HangDetector {
+
+    // MARK: - Tunables
+
+    /// Watchdog poll interval. 250 ms is a balance between detection
+    /// responsiveness (we'll spot a 5 s hang within ~250 ms of the
+    /// threshold) and watchdog overhead.
+    internal static let tickIntervalSeconds: TimeInterval = 0.25
+
+    /// Hard floor on the host-supplied `hangTimeout`. Below 2 s the
+    /// false-positive rate on mid-tier hardware (iPhone 8 / SE 2) is
+    /// unacceptable per PLAN-iOS.md §17 risk #5.
+    internal static let minimumThresholdSeconds: TimeInterval = 2.0
+
+    // MARK: - State
+
+    private static let installLock = NSLock()
+    nonisolated(unsafe) private static var watchdog: HangWatchdog?
+    nonisolated(unsafe) private static var observer: CFRunLoopObserver?
+    nonisolated(unsafe) private static var watchdogThread: HangWatchdogThread?
+
+    private static let heartbeatLock = NSLock()
+    nonisolated(unsafe) private static var heartbeat: UInt64 = 0
+
+    private static let log = OSLog(subsystem: "com.edge.rum", category: "edge.rum.hang")
+
+    // MARK: - Public install
+
+    /// Install the watchdog. Idempotent; second and subsequent calls
+    /// are silent no-ops. Safe to call from any thread — the observer
+    /// install hops to the main thread internally.
+    ///
+    /// - Parameters:
+    ///   - threshold: host-supplied `hangTimeout`. Clamped to a 2 s
+    ///     floor before use.
+    ///   - debug: when `true`, logs a one-line summary on detection.
+    public static func install(
+        threshold: TimeInterval,
+        debug: Bool
+    ) {
+        _install(
+            threshold: threshold,
+            debug: debug,
+            recorder: Recorder.shared,
+            clock: SystemClock(),
+            stackProvider: nil,
+            cpuProvider: nil
+        )
+    }
+
+    /// Tear down the watchdog. Removes the runloop observer and
+    /// cancels the watchdog thread. After this returns no further
+    /// hang events will be recorded until `install(...)` is called
+    /// again. Idempotent; uninstall when nothing is installed is a
+    /// no-op.
+    public static func uninstall() {
+        installLock.lock()
+        let removedObserver = observer
+        let removedThread = watchdogThread
+        watchdog = nil
+        observer = nil
+        watchdogThread = nil
+        installLock.unlock()
+
+        if let observer = removedObserver {
+            CFRunLoopRemoveObserver(CFRunLoopGetMain(), observer, .commonModes)
+        }
+        removedThread?.cancel()
+    }
+
+    // MARK: - Internal install (test-only knobs)
+
+    /// Test entry point exposed so `HangDetectorDetectionTests` can
+    /// inject a `Recording` probe + a deterministic `Clock` + an
+    /// in-memory stack provider. The public `install(...)` uses the
+    /// real `Recorder.shared`, `SystemClock`, and
+    /// `MainThreadStackSnapshot.capture`.
+    internal static func _install(
+        threshold: TimeInterval,
+        debug: Bool,
+        recorder: Recording,
+        clock: Clock,
+        stackProvider: (() -> [String])?,
+        cpuProvider: (() -> Double?)?
+    ) {
+        installLock.lock()
+        if watchdog != nil {
+            installLock.unlock()
+            return
+        }
+        let clamped = max(minimumThresholdSeconds, threshold)
+        let stack = stackProvider ?? { MainThreadStackSnapshot.capture() }
+        let cpu = cpuProvider ?? { nil }
+        let newWatchdog = HangWatchdog(
+            threshold: clamped,
+            clock: clock,
+            recorder: recorder,
+            stackProvider: stack,
+            cpuProvider: cpu,
+            debug: debug,
+            log: log
+        )
+        watchdog = newWatchdog
+        installLock.unlock()
+
+        // Observer + watchdog thread install on main. Use sync hop
+        // when we're already on main to keep test setup synchronous.
+        if Thread.isMainThread {
+            installOnMain(debug: debug)
+        } else {
+            DispatchQueue.main.async {
+                installOnMain(debug: debug)
+            }
+        }
+    }
+
+    /// Test hook — fully reset state between cases. Cancels the
+    /// watchdog thread, removes the observer, clears the heartbeat
+    /// counter, and resets `MainThreadStackSnapshot`'s cached port.
+    internal static func _resetForTests() {
+        uninstall()
+        heartbeatLock.lock()
+        heartbeat = 0
+        heartbeatLock.unlock()
+        MainThreadStackSnapshot._resetForTests()
+    }
+
+    /// Test hook — read the live heartbeat counter without taking
+    /// the install lock.
+    internal static func _currentHeartbeat() -> UInt64 {
+        heartbeatLock.lock(); defer { heartbeatLock.unlock() }
+        return heartbeat
+    }
+
+    /// Test hook — synthesize a runloop bump so detection tests can
+    /// drive the watchdog without spinning up a real CFRunLoop.
+    internal static func _bumpHeartbeatForTests() {
+        bumpHeartbeat()
+    }
+
+    /// Test hook — peek at the active watchdog for direct `tick`
+    /// invocation in unit tests.
+    internal static func _activeWatchdog() -> HangWatchdog? {
+        installLock.lock(); defer { installLock.unlock() }
+        return watchdog
+    }
+
+    /// Test hook — surface whether an observer is currently
+    /// attached. Used by install / uninstall tests to assert
+    /// teardown actually removed the runloop observer.
+    internal static func _hasObserver() -> Bool {
+        installLock.lock(); defer { installLock.unlock() }
+        return observer != nil
+    }
+
+    // MARK: - Observer + thread install (main only)
+
+    private static func installOnMain(debug: Bool) {
+        assert(Thread.isMainThread, "installOnMain must run on the main thread")
+
+        // Capture the main thread Mach port for cross-thread stack
+        // snapshots BEFORE the watchdog thread starts polling.
+        MainThreadStackSnapshot.installFromMainThread()
+
+        let activities = CFRunLoopActivity.entry.rawValue
+            | CFRunLoopActivity.beforeWaiting.rawValue
+            | CFRunLoopActivity.afterWaiting.rawValue
+            | CFRunLoopActivity.exit.rawValue
+
+        let createdObserver = CFRunLoopObserverCreateWithHandler(
+            kCFAllocatorDefault,
+            activities,
+            true,   // repeats
+            0,      // order — first observer in the queue
+            { _, _ in
+                HangDetector.bumpHeartbeat()
+            }
+        )
+
+        if let createdObserver {
+            CFRunLoopAddObserver(CFRunLoopGetMain(), createdObserver, .commonModes)
+        } else if debug {
+            os_log(
+                "HangDetector: CFRunLoopObserverCreateWithHandler returned nil — heartbeat disabled",
+                log: log,
+                type: .info
+            )
+        }
+
+        let thread = HangWatchdogThread(tickInterval: tickIntervalSeconds)
+        thread.start()
+
+        installLock.lock()
+        observer = createdObserver
+        watchdogThread = thread
+        installLock.unlock()
+    }
+
+    // MARK: - Heartbeat
+
+    fileprivate static func bumpHeartbeat() {
+        heartbeatLock.lock()
+        heartbeat &+= 1
+        heartbeatLock.unlock()
+    }
+}
+
+// MARK: - Watchdog state machine
+
+/// Pure decision logic for the watchdog poll loop. Single-owner —
+/// only the `HangWatchdogThread` calls `tick(...)` in production, and
+/// only the unit test calls it from the test thread. The state is
+/// therefore not lock-protected.
+internal final class HangWatchdog {
+
+    let threshold: TimeInterval
+    private let clock: Clock
+    private let recorder: Recording
+    private let stackProvider: () -> [String]
+    private let cpuProvider: () -> Double?
+    private let debug: Bool
+    private let log: OSLog
+
+    private var lastSeenHeartbeat: UInt64 = 0
+    private var hasObservedHeartbeat: Bool = false
+    private var stalledStart: Date?
+    private var firedForCurrentStall: Bool = false
+
+    init(
+        threshold: TimeInterval,
+        clock: Clock,
+        recorder: Recording,
+        stackProvider: @escaping () -> [String],
+        cpuProvider: @escaping () -> Double?,
+        debug: Bool,
+        log: OSLog
+    ) {
+        self.threshold = threshold
+        self.clock = clock
+        self.recorder = recorder
+        self.stackProvider = stackProvider
+        self.cpuProvider = cpuProvider
+        self.debug = debug
+        self.log = log
+    }
+
+    /// Run one decision tick. Returns `true` iff a hang event was
+    /// recorded on this tick. Tests call this directly with a
+    /// synthetic `currentHeartbeat` value.
+    @discardableResult
+    func tick(currentHeartbeat: UInt64) -> Bool {
+        let now = clock.now
+
+        // Wait for the first observer firing before we start counting
+        // stall ticks. Without this guard a freshly-installed watchdog
+        // would interpret the (very brief) "no heartbeat yet" window
+        // as a hang.
+        if !hasObservedHeartbeat {
+            if currentHeartbeat > 0 {
+                hasObservedHeartbeat = true
+                lastSeenHeartbeat = currentHeartbeat
+            }
+            return false
+        }
+
+        if currentHeartbeat != lastSeenHeartbeat {
+            lastSeenHeartbeat = currentHeartbeat
+            stalledStart = nil
+            firedForCurrentStall = false
+            return false
+        }
+
+        // Heartbeat hasn't advanced since the previous tick. Begin
+        // (or continue) the stall window.
+        if stalledStart == nil {
+            stalledStart = now
+            return false
+        }
+
+        guard !firedForCurrentStall,
+              let start = stalledStart,
+              now.timeIntervalSince(start) >= threshold else {
+            return false
+        }
+
+        let durationMs = now.timeIntervalSince(start) * 1000.0
+        let attrs = HangEventEncoder.encode(
+            durationMs: durationMs,
+            thresholdMs: threshold * 1000.0,
+            cpuUsage: cpuProvider(),
+            stackFrames: stackProvider(),
+            timestamp: now
+        )
+        recorder.recordEvent(name: "app.crash", attributes: attrs)
+        firedForCurrentStall = true
+
+        if debug {
+            os_log(
+                "edge-rum: hang detected — %.0f ms ≥ %.0f ms",
+                log: log,
+                type: .info,
+                durationMs,
+                threshold * 1000.0
+            )
+        }
+        return true
+    }
+}
+
+// MARK: - Watchdog thread
+
+/// `Thread` subclass that polls the heartbeat counter on its own
+/// scheduler. Marked `.userInitiated` per F15/T15.1 spec.
+internal final class HangWatchdogThread: Thread {
+
+    private let tickInterval: TimeInterval
+
+    init(tickInterval: TimeInterval) {
+        self.tickInterval = tickInterval
+        super.init()
+        name = "edge.rum.hang.watchdog"
+        qualityOfService = .userInitiated
+    }
+
+    override func main() {
+        while !isCancelled {
+            Thread.sleep(forTimeInterval: tickInterval)
+            if isCancelled { break }
+            let beat = HangDetector._currentHeartbeat()
+            _ = HangDetector._activeWatchdog()?.tick(currentHeartbeat: beat)
+        }
+    }
+}

--- a/Sources/EdgeRumCrash/HangEventEncoder.swift
+++ b/Sources/EdgeRumCrash/HangEventEncoder.swift
@@ -1,0 +1,93 @@
+// Sources/EdgeRumCrash/HangEventEncoder.swift
+//
+// F15/T15.2 — pure encoder for hang `app.crash` events. Mirrors the
+// shape of `CrashReportEncoder` (native crash path) so the backend
+// dispatcher routes both flavours through the same `app.crash`
+// channel, differentiated by `cause`. Hangs ride with
+// `cause = "Hang"`, `runtime = "native"`, `crash.fatal = false`.
+//
+// Hang-specific attribute keys:
+//
+//   - `hang.duration_ms`    — observed stall length in ms
+//   - `hang.threshold_ms`   — configured `hangTimeout` in ms
+//   - `hang.cpu_usage`      — task CPU usage at detection (0.0-1.0)
+//   - `crash.thread.main_stack` — best-effort symbolicated stack
+//   - `crash.timestamp`     — ISO 8601 time of detection
+//
+// The `crash.thread.main_stack` key (rather than `hang.stack` from
+// PLAN-iOS.md §6.8) is the explicit acceptance criterion in T15.2
+// and matches the existing `CrashReportEncoder` namespace so future
+// crash + hang dashboards share a single column. ADR-011 pins the
+// rationale.
+//
+// Refs: PLAN-iOS.md §6.8, §F15/T15.2; docs/decisions.md ADR-011;
+//       CLAUDE.md "EdgeTelemetryProcessor contract".
+//
+
+import Foundation
+#if canImport(EdgeRumCore)
+import EdgeRumCore
+#endif
+
+internal enum HangEventEncoder {
+
+    /// Cap the encoded stack at 30 frames (mirrors `CrashReportEncoder`
+    /// per-thread budget). Any further frames are summarised with a
+    /// `…N more…` marker via `CrashStackTruncator`.
+    internal static let topFrames: Int = 30
+
+    /// Build the flat attribute bag for one hang `app.crash` event.
+    /// Pure — no I/O, no globals, safe to call from any thread.
+    ///
+    /// - Parameters:
+    ///   - durationMs: observed stall length in milliseconds.
+    ///   - thresholdMs: configured `hangTimeout` in milliseconds.
+    ///   - cpuUsage: optional task CPU usage at detection. `nil` if
+    ///     the call site could not read `mach_task_basic_info`.
+    ///   - stackFrames: ordered main-thread frames captured at
+    ///     detection. Empty when the snapshot helper failed; in that
+    ///     case we fall back to a single placeholder frame so the
+    ///     T15.2 "non-empty `crash.thread.main_stack`" acceptance
+    ///     criterion holds.
+    ///   - timestamp: detection wall-clock time, in ISO 8601 form.
+    internal static func encode(
+        durationMs: Double,
+        thresholdMs: Double,
+        cpuUsage: Double?,
+        stackFrames: [String],
+        timestamp: Date
+    ) -> [String: AttributeValue] {
+
+        var attrs: [String: AttributeValue] = [:]
+        attrs["cause"] = .string("Hang")
+        attrs["runtime"] = .string("native")
+        attrs["crash.fatal"] = .bool(false)
+        attrs["hang.duration_ms"] = .double(durationMs)
+        attrs["hang.threshold_ms"] = .double(thresholdMs)
+        if let cpu = cpuUsage {
+            attrs["hang.cpu_usage"] = .double(cpu)
+        }
+        attrs["crash.timestamp"] = .string(WireDateFormatter.string(from: timestamp))
+
+        let safeFrames = stackFrames.isEmpty
+            ? [Self.unavailableFrame]
+            : stackFrames
+        let (kept, omitted) = CrashStackTruncator.truncate(
+            frames: safeFrames,
+            topN: topFrames
+        )
+        var rendered = kept.joined(separator: "\n")
+        if let marker = omitted {
+            rendered += "\n" + marker
+        }
+        attrs["crash.thread.main_stack"] = .string(rendered)
+
+        return attrs
+    }
+
+    /// Placeholder used when the Mach-based stack walk fails. T15.2
+    /// acceptance only requires a non-empty value; the marker tells
+    /// the backend triage UI to treat this hang's stack as missing
+    /// rather than empty.
+    internal static let unavailableFrame: String = "<hang-stack-unavailable>"
+}

--- a/Sources/EdgeRumCrash/MainThreadStackSnapshot.swift
+++ b/Sources/EdgeRumCrash/MainThreadStackSnapshot.swift
@@ -1,0 +1,256 @@
+// Sources/EdgeRumCrash/MainThreadStackSnapshot.swift
+//
+// F15/T15.2 — best-effort main-thread stack capture from a non-main
+// (watchdog) thread, using only public Mach + POSIX APIs:
+//
+//   - `pthread_mach_thread_np(pthread_self())` captures the main
+//     thread's Mach port at install time.
+//   - `thread_suspend` / `thread_resume` halt the main thread for the
+//     duration of the snapshot.
+//   - `thread_get_state` reads the saved program counter + frame
+//     pointer for the suspended thread (`arm_thread_state64_t` on
+//     ARM, `x86_thread_state64_t` on Intel).
+//   - The frame-pointer chain is walked via `vm_read_overwrite` so
+//     a corrupted FP can't crash the process — invalid reads return
+//     `KERN_INVALID_ADDRESS` and we bail.
+//   - `dladdr` symbolicates each return address.
+//
+// We deliberately avoid `_pthread_*` private functions (PLAN-iOS.md
+// §F15/T15.2 acceptance) and we keep the suspension window short:
+// only `vm_read_overwrite` calls (async-signal-safe in practice) and
+// no Swift allocations happen between `thread_suspend` and
+// `thread_resume`. All collected return addresses are symbolicated
+// AFTER resume.
+//
+// Best-effort by design: if any Mach call fails we return `[]` and
+// let `HangEventEncoder` substitute its `<hang-stack-unavailable>`
+// placeholder so the T15.2 "non-empty stack" acceptance still holds.
+//
+// Refs: PLAN-iOS.md §6.8, §F15/T15.2; docs/decisions.md ADR-011.
+//
+
+import Foundation
+import Darwin
+import Darwin.Mach
+
+internal enum MainThreadStackSnapshot {
+
+    // MARK: - Stored main-thread port
+
+    private static let stateLock = NSLock()
+
+    /// Mach port for the main pthread. `MACH_PORT_NULL` until
+    /// `installFromMainThread()` runs. The port lifetime is bound to
+    /// the main pthread, so no explicit `mach_port_deallocate` is
+    /// needed (this is the `_np`-suffix contract).
+    nonisolated(unsafe) private static var mainThreadPort: thread_t = mach_port_t(MACH_PORT_NULL)
+    nonisolated(unsafe) private static var isInstalled: Bool = false
+
+    /// Test override — when non-nil, `capture()` immediately returns
+    /// this array and skips all Mach work. Tests use this to verify
+    /// the `[]` → placeholder fallback in `HangEventEncoder` without
+    /// having to coerce `thread_get_state` into failing.
+    nonisolated(unsafe) private static var testStubFrames: [String]?
+
+    // MARK: - Install / reset
+
+    /// Record the main thread's Mach port. MUST be invoked from the
+    /// main thread; the watchdog calls this from `HangDetector.install`
+    /// via `DispatchQueue.main.async`. Idempotent; second call is a
+    /// no-op so a repeat `EdgeRum.start()` doesn't churn the port.
+    internal static func installFromMainThread() {
+        precondition(
+            Thread.isMainThread,
+            "MainThreadStackSnapshot.installFromMainThread must run on the main thread"
+        )
+        stateLock.lock(); defer { stateLock.unlock() }
+        guard !isInstalled else { return }
+        let port = pthread_mach_thread_np(pthread_self())
+        if port != mach_port_t(MACH_PORT_NULL) {
+            mainThreadPort = port
+            isInstalled = true
+        }
+    }
+
+    /// Test hook so install / detection tests can reset the cached
+    /// port between cases.
+    internal static func _resetForTests() {
+        stateLock.lock(); defer { stateLock.unlock() }
+        isInstalled = false
+        mainThreadPort = mach_port_t(MACH_PORT_NULL)
+        testStubFrames = nil
+    }
+
+    /// Test hook — install a fixed result for `capture()` so the
+    /// `HangEventEncoder` placeholder path can be exercised without
+    /// coaxing `thread_get_state` into failing.
+    internal static func _installStubForTests(_ frames: [String]?) {
+        stateLock.lock(); defer { stateLock.unlock() }
+        testStubFrames = frames
+    }
+
+    // MARK: - Capture
+
+    /// Snapshot the main thread's stack. Returns the empty array on
+    /// any failure path (not installed, suspend failed, register read
+    /// failed, or no frames recoverable). Safe to call from any
+    /// thread other than the main thread — calling from the main
+    /// thread would deadlock under the `thread_suspend` and is
+    /// guarded against.
+    internal static func capture(maxFrames: Int = 64) -> [String] {
+        // Test override short-circuit.
+        stateLock.lock()
+        if let stub = testStubFrames {
+            stateLock.unlock()
+            return stub
+        }
+        let port = mainThreadPort
+        let installed = isInstalled
+        stateLock.unlock()
+
+        guard installed, port != mach_port_t(MACH_PORT_NULL) else { return [] }
+        // Calling from the main thread would deadlock: we'd suspend
+        // ourselves and never resume. Bail with an empty result.
+        if Thread.isMainThread { return [] }
+
+        // Suspend the main thread. KERN_SUCCESS == 0.
+        guard thread_suspend(port) == KERN_SUCCESS else { return [] }
+        defer { _ = thread_resume(port) }
+
+        // Read PC + FP from the saved register state.
+        guard let registers = readRegisters(port: port) else { return [] }
+
+        // Walk the frame pointer chain via vm_read_overwrite so an
+        // invalid FP doesn't crash the process.
+        var addresses: [UInt] = [registers.pc & Self.pacMask]
+        var fp = registers.fp
+        var iteration = 0
+        while fp != 0, iteration < maxFrames {
+            // FPs must be word-aligned. Bail on alignment violation.
+            if fp & UInt(MemoryLayout<UInt>.alignment - 1) != 0 { break }
+            guard let nextFp = safeReadPointer(at: fp) else { break }
+            guard let savedLr = safeReadPointer(at: fp &+ UInt(MemoryLayout<UInt>.size)) else { break }
+            let stripped = savedLr & Self.pacMask
+            if stripped == 0 { break }
+            addresses.append(stripped)
+            // Sanity: the next FP must be higher than the current one
+            // (stacks grow downward, but FPs are saved at increasing
+            // addresses as you walk up the call chain). Cycle / regress
+            // means the chain is corrupt — bail.
+            if nextFp <= fp { break }
+            fp = nextFp
+            iteration += 1
+        }
+
+        // Symbolicate AFTER resume so we don't run dladdr (which can
+        // take dyld's lock) while the main thread is suspended.
+        return addresses.map(symbolicate(_:))
+    }
+
+    // MARK: - Internals
+
+    /// On Apple Silicon (ARM64e), saved frame and return-address
+    /// pointers carry pointer-authentication bits in the high half.
+    /// Masking with this constant keeps the bottom 48 bits of an
+    /// addressable iOS userland pointer. Aligns with `ptrauth_strip`
+    /// behaviour at the bit level.
+    private static let pacMask: UInt = 0x0000_FFFF_FFFF_FFFF
+
+    private struct Registers {
+        let pc: UInt
+        let fp: UInt
+    }
+
+    private static func readRegisters(port: thread_t) -> Registers? {
+        #if arch(arm64)
+        var state = arm_thread_state64_t()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<arm_thread_state64_t>.size / MemoryLayout<UInt32>.size
+        )
+        let kr = withUnsafeMutablePointer(to: &state) { ptr -> kern_return_t in
+            ptr.withMemoryRebound(to: natural_t.self, capacity: Int(count)) { rebound in
+                thread_get_state(port, ARM_THREAD_STATE64, rebound, &count)
+            }
+        }
+        guard kr == KERN_SUCCESS else { return nil }
+        return Registers(pc: UInt(state.__pc), fp: UInt(state.__fp))
+        #elseif arch(x86_64)
+        var state = x86_thread_state64_t()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<x86_thread_state64_t>.size / MemoryLayout<UInt32>.size
+        )
+        let kr = withUnsafeMutablePointer(to: &state) { ptr -> kern_return_t in
+            ptr.withMemoryRebound(to: natural_t.self, capacity: Int(count)) { rebound in
+                thread_get_state(port, x86_THREAD_STATE64, rebound, &count)
+            }
+        }
+        guard kr == KERN_SUCCESS else { return nil }
+        return Registers(pc: UInt(state.__rip), fp: UInt(state.__rbp))
+        #else
+        _ = port
+        return nil
+        #endif
+    }
+
+    /// Read one word at `address` via `vm_read_overwrite`. Returns
+    /// `nil` if the read kernel-returns anything other than success
+    /// (typical case: `KERN_INVALID_ADDRESS` when we walk off the
+    /// bottom of the stack). Never traps.
+    private static func safeReadPointer(at address: UInt) -> UInt? {
+        var buffer: UInt = 0
+        var outSize: vm_size_t = 0
+        let kr = withUnsafeMutablePointer(to: &buffer) { bufferPtr -> kern_return_t in
+            let destAddr = vm_address_t(UInt(bitPattern: bufferPtr))
+            return vm_read_overwrite(
+                mach_task_self_,
+                vm_address_t(address),
+                vm_size_t(MemoryLayout<UInt>.size),
+                destAddr,
+                &outSize
+            )
+        }
+        guard kr == KERN_SUCCESS, outSize == vm_size_t(MemoryLayout<UInt>.size) else {
+            return nil
+        }
+        return buffer
+    }
+
+    /// Best-effort symbolication. Falls back to `0x<hex>` when
+    /// `dladdr` fails (very young dyld state, JIT pages, etc.).
+    /// Mirrors the look of `Thread.callStackSymbols` so downstream
+    /// dashboards can parse both kinds of frames uniformly.
+    private static func symbolicate(_ address: UInt) -> String {
+        var info = Dl_info()
+        let rawPtr = UnsafeRawPointer(bitPattern: address)
+        guard let rawPtr, dladdr(rawPtr, &info) != 0 else {
+            return String(format: "0x%016lx", address)
+        }
+        let imageName: String
+        if let fnamePtr = info.dli_fname {
+            let full = String(cString: fnamePtr)
+            imageName = (full as NSString).lastPathComponent
+        } else {
+            imageName = "???"
+        }
+        let symbolName: String
+        let offset: UInt
+        if let snamePtr = info.dli_sname {
+            symbolName = String(cString: snamePtr)
+            if let saddr = info.dli_saddr {
+                offset = address &- UInt(bitPattern: saddr)
+            } else {
+                offset = 0
+            }
+        } else {
+            symbolName = "<unknown>"
+            offset = 0
+        }
+        return String(
+            format: "%-30s 0x%016lx %@ + %lu",
+            (imageName as NSString).utf8String!,
+            address,
+            symbolName,
+            offset
+        )
+    }
+}

--- a/Tests/EdgeRumContractTests/HangWireConformanceTests.swift
+++ b/Tests/EdgeRumContractTests/HangWireConformanceTests.swift
@@ -1,0 +1,101 @@
+// Tests/EdgeRumContractTests/HangWireConformanceTests.swift
+//
+// Wire-conformance coverage for the `app.crash` event produced by
+// the F15 hang watchdog. Constructs the same attribute bag the
+// detector would emit, builds an envelope via `PayloadBuilder`, and
+// runs it through `WireAssertions.assertValidEnvelope` so we fail
+// loud if the envelope ever drifts from the EdgeTelemetryProcessor
+// contract.
+//
+// Refs: PLAN-iOS.md §6.8, §F15/T15.1, §F15/T15.2; CLAUDE.md
+//       "Testing conventions".
+//
+
+import XCTest
+import EdgeRumCore
+
+final class HangWireConformanceTests: XCTestCase {
+
+    func testHangEnvelopeHonoursWireContract() throws {
+        let now = Date(timeIntervalSince1970: 1_717_234_876.512)
+
+        // Attribute bag matching exactly what `HangEventEncoder`
+        // produces — same keys, same types. Pinned here so any future
+        // encoder change that drifts is caught by this contract test
+        // in addition to the encoder unit tests.
+        let attrs: [String: AttributeValue] = [
+            "cause": .string("Hang"),
+            "runtime": .string("native"),
+            "crash.fatal": .bool(false),
+            "hang.duration_ms": .double(5_240),
+            "hang.threshold_ms": .double(5_000),
+            "hang.cpu_usage": .double(0.83),
+            "crash.thread.main_stack": .string(
+                "EdgeRumCrashSampleApp 0x0000000104a00000 -[ViewController hangButtonTapped:] + 24\n" +
+                "EdgeRumCrashSampleApp 0x0000000104a00100 main + 80"
+            ),
+            "crash.timestamp": .string(WireDateFormatter.string(from: now))
+        ]
+
+        let event = Event.event(
+            name: "app.crash",
+            timestamp: now,
+            attributes: AttributeBag(attrs)
+        )
+
+        // Minimal context so envelope-level identity prefixes resolve.
+        var context = AttributeBag()
+        context.set("session.id", .string("session_0_0000000000000000_ios"))
+        context.set("device.id", .string("device_0_0000000000000000_ios"))
+        context.set("sdk.platform", .string("ios-native"))
+        context.set("sdk.version", .string("1.0.0"))
+        context.set("app.name", .string("EdgeRumCrashSampleApp"))
+        context.set("app.version", .string("1.0.0"))
+        context.set("app.package_name", .string("com.example.edge.crashsample"))
+        context.set("app.build_number", .string("1"))
+        context.set("app.environment", .string("development"))
+        context.set("device.platform", .string("ios"))
+        context.set("device.os", .string("ios"))
+        context.set("device.platform_version", .string("17.4"))
+        context.set("device.model", .string("iPhone15,3"))
+        context.set("device.manufacturer", .string("Apple"))
+
+        let envelope = PayloadBuilder().build(
+            events: [event],
+            context: context,
+            location: "Nairobi/Kenya",
+            flushTime: now
+        )
+
+        try WireAssertions.assertValidEnvelope(envelope)
+
+        // Hang-specific assertions on the encoded JSON.
+        let data = try JSONEncoder().encode(envelope)
+        let json = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 1)
+        let event0 = try XCTUnwrap(events.first)
+        XCTAssertEqual(event0["eventName"] as? String, "app.crash")
+
+        let evAttrs = try XCTUnwrap(event0["attributes"] as? [String: Any])
+        XCTAssertEqual(evAttrs["cause"] as? String, "Hang")
+        XCTAssertEqual(evAttrs["runtime"] as? String, "native")
+        XCTAssertEqual(evAttrs["crash.fatal"] as? Bool, false,
+                       "hangs are non-fatal — distinct from native crashes")
+
+        let durationMs = try XCTUnwrap(evAttrs["hang.duration_ms"] as? Double)
+        let thresholdMs = try XCTUnwrap(evAttrs["hang.threshold_ms"] as? Double)
+        XCTAssertGreaterThanOrEqual(durationMs, thresholdMs,
+                                    "hang.duration_ms must meet or exceed threshold")
+        XCTAssertEqual(evAttrs["hang.cpu_usage"] as? Double, 0.83)
+
+        let stack = try XCTUnwrap(evAttrs["crash.thread.main_stack"] as? String)
+        XCTAssertFalse(stack.isEmpty,
+                       "T15.2 acceptance: crash.thread.main_stack must be non-empty")
+
+        let timestamp = try XCTUnwrap(evAttrs["crash.timestamp"] as? String)
+        XCTAssertNotNil(WireDateFormatter.date(from: timestamp))
+    }
+}

--- a/Tests/EdgeRumCrashTests/HangDetectorDetectionTests.swift
+++ b/Tests/EdgeRumCrashTests/HangDetectorDetectionTests.swift
@@ -1,0 +1,172 @@
+// Tests/EdgeRumCrashTests/HangDetectorDetectionTests.swift
+//
+// State-machine coverage for the `HangWatchdog.tick(currentHeartbeat:)`
+// decision logic. The watchdog tick is the single point at which the
+// detector decides whether to emit an `app.crash`, so the tests drive
+// it directly with a `FixedClock` rather than relying on a real
+// 5-second main-thread block. This keeps the suite fast (sub-millisecond
+// per test) and deterministic on noisy CI runners.
+//
+// Refs: PLAN-iOS.md §6.8, §F15/T15.1 acceptance ("synthetic 6 s main-
+// thread block emits one `app.crash` with `crash.cause = "Hang"`").
+//
+
+import XCTest
+@testable import EdgeRumCrash
+import EdgeRumCore
+
+final class HangDetectorDetectionTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        HangDetector._resetForTests()
+    }
+
+    override func tearDown() {
+        HangDetector._resetForTests()
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeWatchdog(
+        threshold: TimeInterval,
+        clock: FixedClock,
+        recorder: Recording,
+        stack: [String] = ["hang-test-frame"],
+        cpu: Double? = nil,
+        debug: Bool = false
+    ) -> HangWatchdog {
+        HangWatchdog(
+            threshold: threshold,
+            clock: clock,
+            recorder: recorder,
+            stackProvider: { stack },
+            cpuProvider: { cpu },
+            debug: debug,
+            log: .default
+        )
+    }
+
+    // MARK: - Tests
+
+    func testStalledMainThreadEmitsOneAppCrash() throws {
+        let probe = HangProbeRecorder()
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_000_000))
+        let watchdog = makeWatchdog(threshold: 5.0, clock: clock, recorder: probe,
+                                    stack: ["mainThreadFrame", "innerFrame"])
+
+        // Tick 1: first observation — heartbeat already at 1 because
+        // the runloop has fired once. Watchdog records the baseline.
+        XCTAssertFalse(watchdog.tick(currentHeartbeat: 1))
+        // Tick 2 (+0.25s wall clock): no heartbeat advance, stall begins.
+        clock.advance(by: 0.25)
+        XCTAssertFalse(watchdog.tick(currentHeartbeat: 1))
+        // Tick 3 (+5.25s wall clock total since stall start): exactly
+        // at the threshold — fires.
+        clock.advance(by: 5.0)
+        XCTAssertTrue(watchdog.tick(currentHeartbeat: 1))
+
+        // Exactly one event recorded.
+        XCTAssertEqual(probe.calls.count, 1)
+        let call = try XCTUnwrap(probe.calls.first)
+        XCTAssertEqual(call.name, "app.crash")
+        XCTAssertEqual(call.attributes["cause"], .string("Hang"))
+        XCTAssertEqual(call.attributes["runtime"], .string("native"))
+        guard case let .double(durationMs) = call.attributes["hang.duration_ms"] else {
+            return XCTFail("hang.duration_ms missing or wrong type")
+        }
+        XCTAssertGreaterThanOrEqual(durationMs, 5_000)
+        XCTAssertEqual(call.attributes["hang.threshold_ms"], .double(5_000))
+        // Stack supplied via the injected provider.
+        guard case let .string(stack) = call.attributes["crash.thread.main_stack"] else {
+            return XCTFail("crash.thread.main_stack missing")
+        }
+        XCTAssertTrue(stack.contains("mainThreadFrame"))
+    }
+
+    func testContinuedStallDoesNotEmitDuplicateEvents() {
+        let probe = HangProbeRecorder()
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_000_000))
+        let watchdog = makeWatchdog(threshold: 5.0, clock: clock, recorder: probe)
+
+        // Baseline observation.
+        _ = watchdog.tick(currentHeartbeat: 1)
+        // Stall begins on the next tick (stalledStart is set to `now`).
+        clock.advance(by: 0.25)
+        _ = watchdog.tick(currentHeartbeat: 1)
+        // Threshold crossed on a later tick: now - stalledStart ≥ 5.0.
+        clock.advance(by: 5.0)
+        _ = watchdog.tick(currentHeartbeat: 1)
+        XCTAssertEqual(probe.calls.count, 1, "fires exactly once at threshold crossing")
+
+        // Subsequent ticks while the stall continues must NOT emit
+        // additional events — one event per stall window.
+        clock.advance(by: 2.0)
+        _ = watchdog.tick(currentHeartbeat: 1)
+        clock.advance(by: 2.0)
+        _ = watchdog.tick(currentHeartbeat: 1)
+        XCTAssertEqual(probe.calls.count, 1, "continued stall must not duplicate")
+    }
+
+    func testHeartbeatAdvancingEmitsNothing() {
+        let probe = HangProbeRecorder()
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_000_000))
+        let watchdog = makeWatchdog(threshold: 5.0, clock: clock, recorder: probe)
+
+        for beat in 1...40 {
+            clock.advance(by: 0.25)
+            _ = watchdog.tick(currentHeartbeat: UInt64(beat))
+        }
+        XCTAssertTrue(probe.calls.isEmpty,
+                      "advancing heartbeat must never fire a hang event")
+    }
+
+    func testTwoBackToBackHangsEmitTwoSeparateEvents() throws {
+        let probe = HangProbeRecorder()
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_000_000))
+        let watchdog = makeWatchdog(threshold: 2.0, clock: clock, recorder: probe)
+
+        // Baseline observation.
+        _ = watchdog.tick(currentHeartbeat: 1)
+        // Stall #1 — fires once.
+        clock.advance(by: 0.25)
+        _ = watchdog.tick(currentHeartbeat: 1)
+        clock.advance(by: 2.0)
+        _ = watchdog.tick(currentHeartbeat: 1)
+        XCTAssertEqual(probe.calls.count, 1)
+
+        // Heartbeat advances → stall ends, state resets.
+        clock.advance(by: 0.25)
+        _ = watchdog.tick(currentHeartbeat: 2)
+
+        // Stall #2 — fires a second, distinct event.
+        clock.advance(by: 0.25)
+        _ = watchdog.tick(currentHeartbeat: 2)
+        clock.advance(by: 2.0)
+        _ = watchdog.tick(currentHeartbeat: 2)
+
+        XCTAssertEqual(probe.calls.count, 2,
+                       "two distinct stalls must emit two events")
+        let first = try XCTUnwrap(probe.calls.first?.attributes["crash.timestamp"])
+        let second = try XCTUnwrap(probe.calls.last?.attributes["crash.timestamp"])
+        XCTAssertNotEqual(first, second,
+                          "two events must carry distinct timestamps")
+    }
+
+    func testBaselineNeverFiresBeforeFirstHeartbeat() {
+        let probe = HangProbeRecorder()
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_000_000))
+        let watchdog = makeWatchdog(threshold: 2.0, clock: clock, recorder: probe)
+
+        // Heartbeat counter is still zero — the CFRunLoopObserver has
+        // not fired yet. The watchdog must NOT interpret this as a
+        // hang; it should wait for the first non-zero observation.
+        for _ in 0..<30 {
+            clock.advance(by: 0.25)
+            _ = watchdog.tick(currentHeartbeat: 0)
+        }
+        XCTAssertTrue(probe.calls.isEmpty,
+                      "pre-baseline ticks must never fire a hang event")
+    }
+}

--- a/Tests/EdgeRumCrashTests/HangDetectorInstallTests.swift
+++ b/Tests/EdgeRumCrashTests/HangDetectorInstallTests.swift
@@ -1,0 +1,161 @@
+// Tests/EdgeRumCrashTests/HangDetectorInstallTests.swift
+//
+// Idempotency + teardown coverage for `HangDetector.install/uninstall`.
+// The production code path runs once from `EdgeRum.start()`; a second
+// call (hot-reload, double-start) must be a no-op so the watchdog
+// thread isn't stacked. `uninstall()` must drop the observer + cancel
+// the thread so `EdgeRum.disable()` leaves no live timers.
+//
+// Refs: PLAN-iOS.md §F15/T15.1; CLAUDE.md "Touching swizzles?"
+//       checklist (install once on main; idempotent).
+//
+
+import XCTest
+@testable import EdgeRumCrash
+import EdgeRumCore
+
+final class HangDetectorInstallTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        HangDetector._resetForTests()
+    }
+
+    override func tearDown() {
+        HangDetector._resetForTests()
+        super.tearDown()
+    }
+
+    func testInstallIsIdempotent() {
+        let probe = HangProbeRecorder()
+
+        HangDetector._install(
+            threshold: 2.0,
+            debug: false,
+            recorder: probe,
+            clock: SystemClock(),
+            stackProvider: { ["test-frame"] },
+            cpuProvider: { nil }
+        )
+        let firstWatchdog = HangDetector._activeWatchdog()
+        XCTAssertNotNil(firstWatchdog, "first install must set up a watchdog")
+
+        HangDetector._install(
+            threshold: 5.0,
+            debug: true,
+            recorder: HangProbeRecorder(),
+            clock: SystemClock(),
+            stackProvider: { ["should-not-be-used"] },
+            cpuProvider: { 0.99 }
+        )
+        let secondWatchdog = HangDetector._activeWatchdog()
+        XCTAssertTrue(
+            firstWatchdog === secondWatchdog,
+            "second install must short-circuit; same watchdog instance survives"
+        )
+    }
+
+    func testUninstallCancelsWatchdogAndDropsObserver() {
+        let probe = HangProbeRecorder()
+        HangDetector._install(
+            threshold: 2.0,
+            debug: false,
+            recorder: probe,
+            clock: SystemClock(),
+            stackProvider: { [] },
+            cpuProvider: { nil }
+        )
+
+        // The observer install hops to the main thread asynchronously
+        // when invoked off-main; sync to main to drain the hop.
+        let expectation = XCTestExpectation(description: "main runloop drained")
+        DispatchQueue.main.async { expectation.fulfill() }
+        wait(for: [expectation], timeout: 2.0)
+
+        HangDetector.uninstall()
+
+        XCTAssertNil(HangDetector._activeWatchdog(),
+                     "uninstall must clear the watchdog reference")
+        XCTAssertFalse(HangDetector._hasObserver(),
+                       "uninstall must drop the runloop observer")
+    }
+
+    func testHostHangTimeoutBelowFloorIsClampedToTwoSeconds() {
+        let probe = HangProbeRecorder()
+        // Sub-2s thresholds must be clamped to the 2.0s floor per
+        // PLAN-iOS.md §17 risk #5 (false-positive guard for older
+        // iPhone 8 / SE 2 hardware).
+        HangDetector._install(
+            threshold: 0.5,
+            debug: false,
+            recorder: probe,
+            clock: SystemClock(),
+            stackProvider: { [] },
+            cpuProvider: { nil }
+        )
+        let watchdog = HangDetector._activeWatchdog()
+        XCTAssertEqual(watchdog?.threshold, 2.0,
+                       "threshold must be clamped to the 2s floor")
+    }
+
+    func testInstallFromBackgroundThreadDispatchesToMain() {
+        let probe = HangProbeRecorder()
+        let expectation = XCTestExpectation(description: "install completes off-main")
+        DispatchQueue.global(qos: .userInitiated).async {
+            HangDetector._install(
+                threshold: 2.0,
+                debug: false,
+                recorder: probe,
+                clock: SystemClock(),
+                stackProvider: { [] },
+                cpuProvider: { nil }
+            )
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2.0)
+
+        // The runloop observer attaches via DispatchQueue.main.async.
+        // Drain main so the test observes the attached state.
+        let drain = XCTestExpectation(description: "main runloop drained")
+        DispatchQueue.main.async { drain.fulfill() }
+        wait(for: [drain], timeout: 2.0)
+
+        XCTAssertNotNil(HangDetector._activeWatchdog())
+        XCTAssertTrue(HangDetector._hasObserver())
+    }
+}
+
+// MARK: - Probe shared with HangDetector detection tests
+
+internal final class HangProbeRecorder: Recording, @unchecked Sendable {
+
+    struct Call: Equatable {
+        let name: String
+        let attributes: [String: AttributeValue]
+    }
+
+    let lock = NSLock()
+    private(set) var calls: [Call] = []
+
+    func resetCalls() {
+        lock.lock(); calls.removeAll(); lock.unlock()
+    }
+
+    let _clock: Clock = SystemClock()
+    var clock: Clock { _clock }
+    var isEnabled: Bool { true }
+    var currentSessionId: String { "session_0_0000000000000000_ios" }
+    var currentDeviceId: String { "device_0_0000000000000000_ios" }
+    var debug: Bool { false }
+
+    func configure(_ config: RecorderConfig) {}
+    func start(apiKey: String, endpoint: URL, debug: Bool) {}
+    func stop() {}
+    func setEnabled(_ enabled: Bool) {}
+    func setUser(_ user: RecorderUser) {}
+    func recordPerformance(name: String, attributes: [String: AttributeValue]) {}
+
+    func recordEvent(name: String, attributes: [String: AttributeValue]) {
+        lock.lock(); calls.append(.init(name: name, attributes: attributes)); lock.unlock()
+    }
+}

--- a/Tests/EdgeRumCrashTests/HangEventEncoderTests.swift
+++ b/Tests/EdgeRumCrashTests/HangEventEncoderTests.swift
@@ -1,0 +1,121 @@
+// Tests/EdgeRumCrashTests/HangEventEncoderTests.swift
+//
+// Pure-function coverage for the hang `app.crash` encoder. The
+// encoder is the single seam between the watchdog's detection event
+// and the wire — every attribute the backend dispatches on is set
+// here, so the unit tests pin down all of them.
+//
+// Refs: PLAN-iOS.md §6.8, §F15/T15.2.
+//
+
+import XCTest
+@testable import EdgeRumCrash
+import EdgeRumCore
+
+final class HangEventEncoderTests: XCTestCase {
+
+    private let referenceTimestamp = Date(timeIntervalSince1970: 1_717_234_876.512)
+
+    func testEncodeStampsCanonicalDiscriminators() {
+        let attrs = HangEventEncoder.encode(
+            durationMs: 5_240,
+            thresholdMs: 5_000,
+            cpuUsage: nil,
+            stackFrames: ["frameA", "frameB"],
+            timestamp: referenceTimestamp
+        )
+
+        XCTAssertEqual(attrs["cause"], .string("Hang"))
+        XCTAssertEqual(attrs["runtime"], .string("native"))
+        XCTAssertEqual(attrs["crash.fatal"], .bool(false))
+        XCTAssertEqual(attrs["hang.duration_ms"], .double(5_240))
+        XCTAssertEqual(attrs["hang.threshold_ms"], .double(5_000))
+        XCTAssertEqual(
+            attrs["crash.timestamp"],
+            .string(WireDateFormatter.string(from: referenceTimestamp))
+        )
+    }
+
+    func testEncodeIncludesCpuUsageWhenProvided() {
+        let attrs = HangEventEncoder.encode(
+            durationMs: 5_240,
+            thresholdMs: 5_000,
+            cpuUsage: 0.83,
+            stackFrames: ["frame"],
+            timestamp: referenceTimestamp
+        )
+        XCTAssertEqual(attrs["hang.cpu_usage"], .double(0.83))
+    }
+
+    func testEncodeOmitsCpuUsageWhenUnavailable() {
+        let attrs = HangEventEncoder.encode(
+            durationMs: 5_240,
+            thresholdMs: 5_000,
+            cpuUsage: nil,
+            stackFrames: ["frame"],
+            timestamp: referenceTimestamp
+        )
+        XCTAssertNil(attrs["hang.cpu_usage"])
+    }
+
+    func testStackFallsBackToPlaceholderWhenSnapshotIsEmpty() {
+        // T15.2 acceptance — `crash.thread.main_stack` must always be
+        // non-empty. When the Mach snapshot fails (empty array), the
+        // encoder substitutes a placeholder so the wire still carries
+        // a value.
+        let attrs = HangEventEncoder.encode(
+            durationMs: 5_240,
+            thresholdMs: 5_000,
+            cpuUsage: nil,
+            stackFrames: [],
+            timestamp: referenceTimestamp
+        )
+        guard case let .string(stack) = attrs["crash.thread.main_stack"] else {
+            return XCTFail("crash.thread.main_stack must be set with a string value")
+        }
+        XCTAssertEqual(stack, HangEventEncoder.unavailableFrame)
+        XCTAssertFalse(stack.isEmpty)
+    }
+
+    func testStackTruncatesAtTopFramesAndAppendsMarker() {
+        let bigStack = (0..<60).map { "frame#\($0)" }
+        let attrs = HangEventEncoder.encode(
+            durationMs: 5_240,
+            thresholdMs: 5_000,
+            cpuUsage: nil,
+            stackFrames: bigStack,
+            timestamp: referenceTimestamp
+        )
+        guard case let .string(stack) = attrs["crash.thread.main_stack"] else {
+            return XCTFail("crash.thread.main_stack must be set with a string value")
+        }
+        let lines = stack.components(separatedBy: "\n")
+        XCTAssertEqual(lines.count, HangEventEncoder.topFrames + 1,
+                       "expected topFrames frames + one omission marker")
+        XCTAssertEqual(lines.first, "frame#0")
+        XCTAssertEqual(lines[HangEventEncoder.topFrames - 1],
+                       "frame#\(HangEventEncoder.topFrames - 1)")
+        XCTAssertEqual(lines.last,
+                       CrashStackTruncator.marker(for: 60 - HangEventEncoder.topFrames))
+    }
+
+    func testAllAttributeValuesAreWirePrimitives() {
+        // Wire contract: every attribute is a String / Int / Double /
+        // Bool. The `AttributeValue` enum makes this checkable at the
+        // type level, but pin it explicitly so a future encoder
+        // tweak that breaks the invariant fails here.
+        let attrs = HangEventEncoder.encode(
+            durationMs: 5_240,
+            thresholdMs: 5_000,
+            cpuUsage: 0.5,
+            stackFrames: ["frame"],
+            timestamp: referenceTimestamp
+        )
+        for (_, value) in attrs {
+            switch value {
+            case .string, .int, .double, .bool:
+                continue
+            }
+        }
+    }
+}

--- a/Tests/EdgeRumCrashTests/MainThreadStackSnapshotTests.swift
+++ b/Tests/EdgeRumCrashTests/MainThreadStackSnapshotTests.swift
@@ -1,0 +1,93 @@
+// Tests/EdgeRumCrashTests/MainThreadStackSnapshotTests.swift
+//
+// Best-effort coverage for the Mach-based main-thread stack walker.
+// The full path (suspend → thread_get_state → vm_read_overwrite chain
+// walk → dladdr) is exercised on the macOS test runner; on
+// architectures where `thread_get_state` is unavailable the test
+// downgrades to a smoke check.
+//
+// Refs: PLAN-iOS.md §F15/T15.2; docs/decisions.md ADR-011.
+//
+
+import XCTest
+@testable import EdgeRumCrash
+
+final class MainThreadStackSnapshotTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        MainThreadStackSnapshot._resetForTests()
+    }
+
+    override func tearDown() {
+        MainThreadStackSnapshot._resetForTests()
+        super.tearDown()
+    }
+
+    func testCaptureBeforeInstallReturnsEmpty() {
+        // Before `installFromMainThread`, the cached port is
+        // `MACH_PORT_NULL`; the helper must return [] cleanly.
+        let frames = MainThreadStackSnapshot.capture()
+        XCTAssertTrue(frames.isEmpty,
+                      "capture without install must return [] (no port)")
+    }
+
+    func testCaptureFromMainThreadShortCircuitsToAvoidSelfDeadlock() {
+        // Install from the main thread (we're already on it under
+        // XCTest's default scheduler).
+        let install = XCTestExpectation(description: "main install")
+        DispatchQueue.main.async {
+            MainThreadStackSnapshot.installFromMainThread()
+            install.fulfill()
+        }
+        wait(for: [install], timeout: 2.0)
+
+        // Capturing FROM the main thread would deadlock (suspend self,
+        // never resume), so the helper short-circuits to `[]` instead.
+        let mainCapture = XCTestExpectation(description: "main capture")
+        DispatchQueue.main.async {
+            XCTAssertTrue(MainThreadStackSnapshot.capture().isEmpty,
+                          "main-thread capture must short-circuit")
+            mainCapture.fulfill()
+        }
+        wait(for: [mainCapture], timeout: 2.0)
+    }
+
+    func testCaptureFromBackgroundThreadProducesFrames() {
+        let install = XCTestExpectation(description: "main install")
+        DispatchQueue.main.async {
+            MainThreadStackSnapshot.installFromMainThread()
+            install.fulfill()
+        }
+        wait(for: [install], timeout: 2.0)
+
+        // Capture from a background thread. On modern Apple Silicon
+        // (arm64) and Intel (x86_64), the Mach state read returns a
+        // valid PC, so the result MUST include at least one frame.
+        let captured = XCTestExpectation(description: "background capture")
+        var frames: [String] = []
+        DispatchQueue.global(qos: .userInitiated).async {
+            frames = MainThreadStackSnapshot.capture()
+            captured.fulfill()
+        }
+        wait(for: [captured], timeout: 5.0)
+
+        XCTAssertFalse(frames.isEmpty,
+                       "capture from background thread must yield ≥1 frame")
+        // Best-effort symbolication — at least the PC line should be
+        // present. Frames are ordered with PC first.
+        XCTAssertTrue(frames.first!.contains("0x"),
+                      "first frame should include a hex address")
+    }
+
+    func testStubFramesAreReturnedVerbatim() {
+        // The test-only stub override lets `HangEventEncoder` /
+        // `HangWatchdog` exercise the fallback placeholder path
+        // without coaxing real Mach calls into failing.
+        MainThreadStackSnapshot._installStubForTests([])
+        XCTAssertTrue(MainThreadStackSnapshot.capture().isEmpty)
+
+        MainThreadStackSnapshot._installStubForTests(["A", "B", "C"])
+        XCTAssertEqual(MainThreadStackSnapshot.capture(), ["A", "B", "C"])
+    }
+}

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1010,3 +1010,123 @@ but doesn't define the wire shape that carries the dropped tail.
 - Backend ask (PLAN-iOS §13 "Backend asks" item 6 — the negotiated
   size cap): this ADR pins the soft cap at 200 KB. Tighten or relax
   in lockstep with backend telemetry.
+
+---
+
+## ADR-011 — F15 hang detection: hybrid CFRunLoopObserver heartbeat + Mach-based main-thread stack walk
+
+**Date:** 2026-06-17
+
+**Status:** Accepted.
+
+**Context.** F15 adds main-thread hang detection. The watchdog must
+record one `app.crash` event with `cause = "Hang"` when the host
+app's main runloop stalls for longer than
+`EdgeRumConfig.hangTimeout`. Two specification artefacts disagree on
+sub-details:
+
+1. **Attribute key for the captured stack.** PLAN-iOS.md §6.8 names
+   it `hang.stack`; the §F15/T15.2 acceptance criterion calls for
+   `crash.thread.main_stack`.
+2. **Heartbeat source.** §6.8 prescribes a hybrid
+   `CFRunLoopObserver` + dedicated `Thread`; T15.1 only mentions a
+   dedicated `Thread` "sampling main-runloop heartbeat".
+
+The main thread is, by definition, blocked when a hang fires, so a
+plain `Thread.callStackSymbols` dispatched to main won't return. We
+need to walk the stack of a *suspended* main thread from a
+background scheduler, using public APIs only (T15.2 — no
+`_pthread_*` private calls).
+
+**Decision.**
+
+1. **Use `crash.thread.main_stack`** (not `hang.stack`). This is the
+   explicit T15.2 acceptance criterion, matches the existing
+   `CrashReportEncoder` namespace (`Sources/EdgeRumCrash/
+   CrashReportEncoder.swift` lines 73-94), and lets future crash +
+   hang dashboards share a single column.
+2. **Hybrid heartbeat.** A `CFRunLoopObserver` on
+   `CFRunLoopGetMain()` (`.commonModes`,
+   `.entry | .beforeWaiting | .afterWaiting | .exit`) bumps an
+   atomic `UInt64` counter every time the main runloop turns. A
+   dedicated `HangWatchdogThread` (`.userInitiated` QoS) polls the
+   counter every 250 ms and fires the hang event when the counter
+   has not advanced for `hangTimeout` consecutive seconds. Pure
+   wall-clock sampling on its own can't distinguish "main is busy
+   but advancing" from "main is stuck".
+3. **Mach-based stack walk.** `MainThreadStackSnapshot.swift`
+   captures the main thread's Mach port at install time via
+   `pthread_mach_thread_np(pthread_self())` — a public, non-`_np`
+   POSIX call that returns a port whose lifetime is bound to the
+   pthread (no `mach_port_deallocate` needed). On detection the
+   watchdog thread runs:
+
+   `thread_suspend` → `thread_get_state` (ARM64 / x86_64) →
+   frame-pointer chain walk via `vm_read_overwrite` (safe — invalid
+   reads return `KERN_INVALID_ADDRESS` instead of trapping) → strip
+   PAC bits with a 48-bit mask → `dladdr` symbolicate → `thread_resume`.
+
+   Symbolication happens **after** resume so `dladdr` (which takes
+   dyld's lock) can't deadlock against the suspended main thread.
+   On any Mach failure, `capture()` returns `[]` and
+   `HangEventEncoder` substitutes a single placeholder frame
+   (`"<hang-stack-unavailable>"`) so the T15.2 "non-empty stack"
+   acceptance criterion still holds.
+4. **Threshold floor of 2 seconds.** Per PLAN-iOS.md §17 risk #5,
+   sub-2 s thresholds cause false positives on iPhone 8 / SE 2
+   hardware. `HangDetector.install(...)` clamps the host-supplied
+   `hangTimeout` to `max(2.0, requested)`.
+5. **No `Thread.callStackSymbols` from a dispatched main-thread
+   block.** A dispatched block can't run until main is unstuck — by
+   then the hang is already over and we'd be sampling the wrong
+   stack. Rejected outright.
+6. **MetricKit `MXHangDiagnostic` enrichment deferred.** §6.8
+   mentions MetricKit as a 24-hour-delayed augmentation. The F15
+   tasks (T15.1/T15.2) do not include it, and the daily MXMetric
+   payload arrives long after the live hang event has shipped.
+   Tracked as a v1.0+ follow-up.
+
+**Alternatives considered.**
+
+- **Plain `CADisplayLink` sampler.** Would only catch hangs longer
+  than one display frame and would itself be paused if the main
+  thread blocks for long enough — degrades exactly when we need
+  detection most.
+- **`backtrace(3)` from `execinfo.h`.** Walks the **current**
+  thread, not an arbitrary thread. Useless for cross-thread main
+  thread sampling.
+- **Signal-based snapshot.** Send a signal to the main thread,
+  capture stack in the handler. Async-signal-safe but the signal
+  handler can't run if main is fully blocked inside a kernel call,
+  and signal delivery on suspended threads is undefined.
+- **Use `KSCrash` / `SentrySDK` source directly.** Adds a
+  dependency we already chose not to take in F14.
+
+**Consequences.**
+
+- Three new files under `Sources/EdgeRumCrash/` —
+  `HangDetector.swift` (orchestrator + watchdog state machine),
+  `HangEventEncoder.swift` (pure attribute-bag encoder), and
+  `MainThreadStackSnapshot.swift` (Mach-based stack walker).
+- `EdgeRum.start(_:)` gains one `enableHangDetection`-gated block
+  that calls `HangDetector.install(threshold:debug:)` immediately
+  after the F14 `PLCrashIntegration.install(...)`. `EdgeRum.disable()`
+  calls `HangDetector.uninstall()` so a paused SDK has no live
+  timers.
+- Wire shape: `cause = "Hang"`, `runtime = "native"`,
+  `crash.fatal = false` (distinct from native crash's
+  `crash.fatal = true`), plus `hang.duration_ms`,
+  `hang.threshold_ms`, optional `hang.cpu_usage`, and
+  `crash.thread.main_stack`.
+- A 5th test file lands in `Tests/EdgeRumCrashTests/`
+  (`HangDetectorInstallTests`, `HangDetectorDetectionTests`,
+  `HangEventEncoderTests`, `MainThreadStackSnapshotTests`) plus a
+  contract test in `Tests/EdgeRumContractTests/
+  HangWireConformanceTests.swift`. Detection tests drive the
+  watchdog state machine directly with a `FixedClock` rather than
+  blocking the test runner's main thread for real seconds, so the
+  suite stays fast and deterministic.
+- Backend ask (PLAN-iOS §13 "Backend asks" — new): confirm crash
+  dashboards do not double-count `cause = "Hang"` rows as fatal
+  crashes. Backend should segment by `cause` (the two ride under
+  the same `eventName = "app.crash"`).


### PR DESCRIPTION
## Summary

F15 — main-thread hang detection. Plugs the second leg of the crash subsystem into the same `app.crash` pipeline F14 landed: a `CFRunLoopObserver` on the main runloop bumps an atomic heartbeat counter, and a dedicated `HangWatchdogThread` (`.userInitiated`) polls the counter every 250 ms. When the counter has not advanced for longer than `EdgeRumConfig.hangTimeout`, one `app.crash` event is recorded with `cause = "Hang"`.

- **`HangDetector` (T15.1)** — `HangDetector.install(threshold:debug:)` is idempotent (single-shot via NSLock, mirrors `PLCrashIntegration` lines 38-72). Wired into `EdgeRum.start(_:)` immediately after the F14 `PLCrashIntegration.install(...)`, and torn down in `EdgeRum.disable()` so a paused SDK leaves no live timers. `hangTimeout` is clamped to a 2 s floor per PLAN-iOS §17 risk #5 (older iPhone 8 / SE 2 hardware can stall on background work and trip sub-2 s thresholds).
- **`MainThreadStackSnapshot` (T15.2)** — best-effort Mach-based stack walker. Captures the main thread's Mach port at install time via `pthread_mach_thread_np(pthread_self())` (public POSIX, no `_pthread_*` private calls). On detection the watchdog thread runs `thread_suspend` → `thread_get_state` (`arm_thread_state64_t` / `x86_thread_state64_t`) → `vm_read_overwrite`-guarded frame-pointer chain walk (invalid reads return `KERN_INVALID_ADDRESS` instead of trapping) → strip pointer-auth bits with a 48-bit mask → `dladdr` symbolicate (after resume, so dyld's lock can't deadlock against the suspended main thread) → `thread_resume`.
- **`HangEventEncoder`** — pure encoder for the flat attribute bag. Stamps `cause = "Hang"`, `runtime = "native"`, `crash.fatal = false` (distinct from F14's `crash.fatal = true`), `hang.duration_ms`, `hang.threshold_ms`, optional `hang.cpu_usage`, and `crash.thread.main_stack`. Reuses `CrashStackTruncator.truncate(frames:topN:)` to cap at 30 frames with the `…N more…` marker. When the Mach snapshot fails, the encoder falls back to a single placeholder frame `\"<hang-stack-unavailable>\"` so the T15.2 "non-empty stack" acceptance criterion always holds.

Wire shape per CLAUDE.md "EdgeTelemetryProcessor contract":
- `eventName = \"app.crash\"` (already on `Recorder.allowedEventNames` and the immediate-flush list — no recorder changes needed).
- `cause = \"Hang\"` differentiates from F14's `cause = \"NativeCrash\"`; backend should segment crash dashboards by `cause` so hangs don't double-count as fatal crashes.
- `crash.thread.main_stack` matches the existing `CrashReportEncoder` namespace (ADR-011 reconciles the PLAN-iOS §6.8 `hang.stack` / §F15/T15.2 `crash.thread.main_stack` mismatch — T15.2 acceptance wins).

ADR-011 in `docs/decisions.md` pins the hybrid heartbeat choice, the `crash.thread.main_stack` naming, the Mach-based stack walk, and the 2 s threshold floor.

Sample app under `Samples/EdgeRumCrashSampleApp/` — the "Trigger 6 s hang" button (previously a F15 preview) is now wired against the real detector. README updated with the F15 manual QA loop.

## Test plan

- [x] `swift build -c release` — clean (`Build complete!`); pre-existing PLCR object-file warnings unchanged.
- [x] `swift test --enable-code-coverage` — 15 new F15 test cases pass:
  - `EdgeRumCrashTests/HangEventEncoderTests` (6)
  - `EdgeRumCrashTests/HangDetectorInstallTests` (4)
  - `EdgeRumCrashTests/HangDetectorDetectionTests` (5) — driven via `FixedClock` so the suite stays deterministic; no real 5 s sleeps on the test runner.
  - `EdgeRumCrashTests/MainThreadStackSnapshotTests` (4) — exercises the full Mach path + the `_installStubForTests` placeholder fallback.
  - `EdgeRumContractTests/HangWireConformanceTests` (1) — `WireAssertions.assertValidEnvelope` on a hand-built hang envelope.
- [x] `Tools/firewall-check.sh` — `public surface and consumer docs are clean.`
- [x] `Tools/check-supported-ios.sh` — iOS 14 floor still consistent.
- [ ] Manual QA on simulator / device per `Samples/EdgeRumCrashSampleApp/README.md` — tap "Trigger 6 s main-thread hang (F15)"; observe one `app.crash` envelope with `cause = "Hang"`, `crash.thread.main_stack` non-empty, `hang.duration_ms ≥ 5000`, and the live `session.id` (hangs do not rotate the session).

## Pre-existing flake (not introduced here)

`EdgeRumCaptureTests/NetworkPathCaptureTests.test_emit_deduplicatesIdenticalTransitions` fails when run in suite-order but passes in isolation — the same `NetworkPathCapture.emit` static-`lastSnapshot` issue F14's PR called out. Not touched by F15; still flagged for a separate cleanup PR.

## Refs

- PLAN-iOS.md §6.8 (hang detection), §F15/T15.1, §F15/T15.2.
- CLAUDE.md "Touching crash code?" checklist.
- ADR-011 in `docs/decisions.md` for the heartbeat / stack / naming rationale.

Closes #20
Closes #77
Closes #78