### PR TITLE
feat(F16): context bag enrichment — thermal, a11y, NWPath extras, storage, locale

### DIFF
--- a/Sources/EdgeRum/EdgeRum.swift
+++ b/Sources/EdgeRum/EdgeRum.swift
@@ -210,6 +210,17 @@ public enum EdgeRum {
             debug: config.debug
         )
 
+        // F16 — install the context-enrichment observers (thermal,
+        // accessibility, NWPath extras, storage, locale) so the
+        // ContextProvider stays current without the Recorder having to
+        // re-snapshot on every event. Idempotent.
+        if let realRecorder = Recorder.shared as? Recorder {
+            ContextObservers.install(
+                provider: realRecorder.currentContextProvider,
+                debug: config.debug
+            )
+        }
+
         // F6 — install UIKit screen capture once. Idempotent and
         // main-thread-safe; on non-UIKit hosts (the macOS unit-test
         // runner) `install(...)` is a no-op so this call site stays

--- a/Sources/EdgeRumCore/Context/AccessibilityContext.swift
+++ b/Sources/EdgeRumCore/Context/AccessibilityContext.swift
@@ -1,0 +1,135 @@
+// Sources/EdgeRumCore/Context/AccessibilityContext.swift
+//
+// F16/T16.2 — accessibility settings carried on every event so the
+// backend can correlate UX issues with users running large dynamic
+// type, VoiceOver, etc.
+//
+// Wire keys (docs/data-flow.md §3.2):
+//   device.dynamic_type        — content size category
+//                                ("XS" / "S" / "M" / "L" / "XL" / "XXL"
+//                                 / "XXXL" / "AX1" / "AX2" / "AX3"
+//                                 / "AX4" / "AX5")
+//   device.reduce_motion       — Bool
+//   device.bold_text           — Bool
+//   device.voiceover           — Bool
+//   device.increase_contrast   — Bool (sourced from
+//                                `UIAccessibility.isDarkerSystemColorsEnabled`,
+//                                which is the iOS "Increase Contrast"
+//                                toggle in Settings → Accessibility)
+//
+// Observers in `ContextObservers` subscribe to:
+//   - voiceOverStatusDidChangeNotification
+//   - reduceMotionStatusDidChangeNotification
+//   - boldTextStatusDidChangeNotification
+//   - darkerSystemColorsStatusDidChangeNotification
+//   - UIContentSizeCategory.didChangeNotification
+//
+// Refs: PLAN-iOS.md §16.4 / F16 / T16.2.
+//
+
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+public struct AccessibilityContext: Sendable, Hashable {
+
+    public var dynamicType: String?
+    public var reduceMotion: Bool?
+    public var boldText: Bool?
+    public var voiceOver: Bool?
+    public var increaseContrast: Bool?
+
+    public init(
+        dynamicType: String? = nil,
+        reduceMotion: Bool? = nil,
+        boldText: Bool? = nil,
+        voiceOver: Bool? = nil,
+        increaseContrast: Bool? = nil
+    ) {
+        self.dynamicType = dynamicType
+        self.reduceMotion = reduceMotion
+        self.boldText = boldText
+        self.voiceOver = voiceOver
+        self.increaseContrast = increaseContrast
+    }
+
+    /// Snapshot the live `UIAccessibility` flags. UIKit's accessibility
+    /// properties are documented as safe to read from any thread, but
+    /// `UIApplication.shared.preferredContentSizeCategory` must be
+    /// touched from the main thread, so we hop if needed (pattern from
+    /// `DeviceContext.readScreenMetrics`).
+    public static func snapshot() -> AccessibilityContext {
+        #if canImport(UIKit)
+        let (dynamic, reduce, bold, voice, contrast) = readUIAccessibility()
+        return AccessibilityContext(
+            dynamicType: dynamic,
+            reduceMotion: reduce,
+            boldText: bold,
+            voiceOver: voice,
+            increaseContrast: contrast
+        )
+        #else
+        return AccessibilityContext()
+        #endif
+    }
+
+    public func write(into bag: inout AttributeBag) {
+        bag.setIfPresent("device.dynamic_type", dynamicType.map { .string($0) })
+        bag.setIfPresent("device.reduce_motion", reduceMotion.map { .bool($0) })
+        bag.setIfPresent("device.bold_text", boldText.map { .bool($0) })
+        bag.setIfPresent("device.voiceover", voiceOver.map { .bool($0) })
+        bag.setIfPresent("device.increase_contrast", increaseContrast.map { .bool($0) })
+    }
+
+    #if canImport(UIKit)
+    /// Map `UIContentSizeCategory` to the wire string per
+    /// `docs/data-flow.md` §3.2 ("XS"…"AX5"). Exposed internal so
+    /// `AccessibilityContextTests` can drive every category without
+    /// changing the simulator's preferred text size.
+    internal static func dynamicTypeString(_ category: UIContentSizeCategory) -> String {
+        switch category {
+        case .extraSmall:                        return "XS"
+        case .small:                             return "S"
+        case .medium:                            return "M"
+        case .large:                             return "L"
+        case .extraLarge:                        return "XL"
+        case .extraExtraLarge:                   return "XXL"
+        case .extraExtraExtraLarge:              return "XXXL"
+        case .accessibilityMedium:               return "AX1"
+        case .accessibilityLarge:                return "AX2"
+        case .accessibilityExtraLarge:           return "AX3"
+        case .accessibilityExtraExtraLarge:      return "AX4"
+        case .accessibilityExtraExtraExtraLarge: return "AX5"
+        default:                                 return "L"
+        }
+    }
+    #endif
+}
+
+#if canImport(UIKit)
+
+/// Read the five UIAccessibility flags. Forces a main-thread hop when
+/// called off-main because `UIApplication.shared` access is main-actor
+/// constrained on Swift 6.
+private func readUIAccessibility()
+    -> (String?, Bool?, Bool?, Bool?, Bool?) {
+    if Thread.isMainThread {
+        return readUIAccessibilityOnMain()
+    }
+    var result: (String?, Bool?, Bool?, Bool?, Bool?) = (nil, nil, nil, nil, nil)
+    DispatchQueue.main.sync { result = readUIAccessibilityOnMain() }
+    return result
+}
+
+private func readUIAccessibilityOnMain()
+    -> (String?, Bool?, Bool?, Bool?, Bool?) {
+    let category = UIApplication.shared.preferredContentSizeCategory
+    let dynamic = AccessibilityContext.dynamicTypeString(category)
+    let reduce = UIAccessibility.isReduceMotionEnabled
+    let bold = UIAccessibility.isBoldTextEnabled
+    let voice = UIAccessibility.isVoiceOverRunning
+    let contrast = UIAccessibility.isDarkerSystemColorsEnabled
+    return (dynamic, reduce, bold, voice, contrast)
+}
+#endif

--- a/Sources/EdgeRumCore/Context/ContextObservers.swift
+++ b/Sources/EdgeRumCore/Context/ContextObservers.swift
@@ -1,0 +1,289 @@
+// Sources/EdgeRumCore/Context/ContextObservers.swift
+//
+// F16 — Idempotent installer for the notification observers and the
+// periodic storage refresh timer that keep `PowerContext`,
+// `AccessibilityContext`, and `StorageContext` (and the locale/timezone
+// fields on `DeviceContext`) up to date.
+//
+// Lives in `EdgeRumCore` rather than `EdgeRumCapture` because these
+// observers don't swizzle anything and don't emit events; they only
+// refresh in-memory snapshots on the supplied `ContextProvider`. See
+// `docs/decisions.md` ADR-F16.
+//
+// Install machinery mirrors `LifecycleCapture` lines 137-226:
+//   - one os_unfair_lock-guarded `_installed` flag
+//   - notification observers stored in a static array of tokens
+//   - DEBUG-only reset for tests
+//
+// Subscriptions (F16):
+//   T16.1 PowerContext:
+//     - ProcessInfo.thermalStateDidChangeNotification
+//     - NSProcessInfoPowerStateDidChange
+//   T16.2 AccessibilityContext:
+//     - UIAccessibility.voiceOverStatusDidChangeNotification
+//     - UIAccessibility.reduceMotionStatusDidChangeNotification
+//     - UIAccessibility.boldTextStatusDidChangeNotification
+//     - UIAccessibility.darkerSystemColorsStatusDidChangeNotification
+//     - UIContentSizeCategory.didChangeNotification
+//   T16.4 StorageContext:
+//     - 5-minute `DispatchSource.makeTimerSource` on a utility queue
+//     - suspend on willResignActive, resume on didBecomeActive
+//   T16.5 DeviceContext locale/timezone refresh:
+//     - NSLocale.currentLocaleDidChangeNotification
+//
+// Refs: PLAN-iOS.md §16.4 / F16; CLAUDE.md "When in doubt checklist"
+//       item 1 (no public-surface change), item 8 (single install
+//       guarded by Once token).
+//
+
+import Foundation
+import os.log
+#if canImport(UIKit)
+import UIKit
+#endif
+
+public enum ContextObservers {
+
+    // MARK: - Diagnostics
+
+    private static let log = OSLog(subsystem: "com.edge.rum", category: "ContextObservers")
+
+    // MARK: - Once token
+
+    nonisolated(unsafe) private static let installLock: UnsafeMutablePointer<os_unfair_lock> = {
+        let p = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
+        p.initialize(to: os_unfair_lock())
+        return p
+    }()
+
+    nonisolated(unsafe) private static var _installed: Bool = false
+
+    /// `true` once `install(provider:debug:)` has registered the
+    /// observers and armed the storage timer.
+    public static var isInstalled: Bool {
+        os_unfair_lock_lock(installLock)
+        defer { os_unfair_lock_unlock(installLock) }
+        return _installed
+    }
+
+    // MARK: - State
+
+    nonisolated(unsafe) private static var observers: [NSObjectProtocol] = []
+    nonisolated(unsafe) private static var storageTimer: DispatchSourceTimer?
+    nonisolated(unsafe) private static var storageTimerSuspended: Bool = false
+
+    /// Storage refresh interval. 5 minutes per PLAN-iOS.md §16.4 / T16.4
+    /// ("Refresh at session start + every 5 min").
+    internal static let storageRefreshInterval: DispatchTimeInterval = .seconds(300)
+
+    // MARK: - Public install
+
+    /// Install all F16 observers and arm the storage refresh timer.
+    /// Idempotent — second and subsequent calls are no-ops. Safe to
+    /// call from any thread; UIKit reads inside the notification
+    /// callbacks hop to main as needed.
+    public static func install(
+        provider: ContextProvider,
+        debug: Bool = false
+    ) {
+        os_unfair_lock_lock(installLock)
+        if _installed {
+            os_unfair_lock_unlock(installLock)
+            return
+        }
+        _installed = true
+        os_unfair_lock_unlock(installLock)
+
+        // Seed every context once so the very first event after
+        // install carries fresh F16 attributes.
+        provider.refreshPower(PowerContext.snapshot())
+        provider.refreshAccessibility(AccessibilityContext.snapshot())
+        provider.refreshStorage(StorageContext.snapshot())
+
+        let nc = NotificationCenter.default
+        var tokens: [NSObjectProtocol] = []
+
+        // T16.1 — thermal + low power mode
+        tokens.append(nc.addObserver(
+            forName: ProcessInfo.thermalStateDidChangeNotification,
+            object: nil,
+            queue: nil
+        ) { [weak provider] _ in
+            provider?.refreshPower(PowerContext.snapshot())
+        })
+        // `NSProcessInfoPowerStateDidChange` is iOS 9.0+ but
+        // macOS 12.0+. The package floor is macOS 11 (test host only),
+        // so guard on macOS while leaving iOS unconditional.
+        #if os(iOS)
+        tokens.append(nc.addObserver(
+            forName: Notification.Name.NSProcessInfoPowerStateDidChange,
+            object: nil,
+            queue: nil
+        ) { [weak provider] _ in
+            provider?.refreshPower(PowerContext.snapshot())
+        })
+        #else
+        if #available(macOS 12.0, *) {
+            tokens.append(nc.addObserver(
+                forName: Notification.Name.NSProcessInfoPowerStateDidChange,
+                object: nil,
+                queue: nil
+            ) { [weak provider] _ in
+                provider?.refreshPower(PowerContext.snapshot())
+            })
+        }
+        #endif
+
+        // T16.5 — locale & timezone (re-snapshot DeviceContext)
+        tokens.append(nc.addObserver(
+            forName: NSLocale.currentLocaleDidChangeNotification,
+            object: nil,
+            queue: nil
+        ) { [weak provider] _ in
+            provider?.refreshDevice(DeviceContext.snapshot())
+        })
+
+        #if canImport(UIKit) && os(iOS)
+        // T16.2 — accessibility flags
+        let a11yRefresh: (Notification) -> Void = { [weak provider] _ in
+            provider?.refreshAccessibility(AccessibilityContext.snapshot())
+        }
+        tokens.append(nc.addObserver(
+            forName: UIAccessibility.voiceOverStatusDidChangeNotification,
+            object: nil, queue: .main, using: a11yRefresh
+        ))
+        tokens.append(nc.addObserver(
+            forName: UIAccessibility.reduceMotionStatusDidChangeNotification,
+            object: nil, queue: .main, using: a11yRefresh
+        ))
+        tokens.append(nc.addObserver(
+            forName: UIAccessibility.boldTextStatusDidChangeNotification,
+            object: nil, queue: .main, using: a11yRefresh
+        ))
+        tokens.append(nc.addObserver(
+            forName: UIAccessibility.darkerSystemColorsStatusDidChangeNotification,
+            object: nil, queue: .main, using: a11yRefresh
+        ))
+        tokens.append(nc.addObserver(
+            forName: UIContentSizeCategory.didChangeNotification,
+            object: nil, queue: .main, using: a11yRefresh
+        ))
+
+        // T16.4 — pause/resume storage timer on lifecycle transitions
+        // so we don't run statfs while the app is backgrounded.
+        tokens.append(nc.addObserver(
+            forName: UIApplication.willResignActiveNotification,
+            object: nil, queue: .main
+        ) { _ in
+            suspendStorageTimer()
+        })
+        tokens.append(nc.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil, queue: .main
+        ) { [weak provider] _ in
+            // Refresh once on foreground in case disk grew/shrank
+            // while we were backgrounded.
+            provider?.refreshStorage(StorageContext.snapshot())
+            resumeStorageTimer()
+        })
+        #endif
+
+        os_unfair_lock_lock(installLock)
+        observers = tokens
+        os_unfair_lock_unlock(installLock)
+
+        // Arm the 5-minute storage refresh timer (utility queue,
+        // mirrors `MemorySampler.swift:240`). Starts in the running
+        // state; lifecycle hooks suspend/resume it.
+        armStorageTimer(provider: provider)
+
+        if debug {
+            os_log("ContextObservers installed (F16)", log: log, type: .info)
+        }
+    }
+
+    // MARK: - Storage timer
+
+    private static func armStorageTimer(provider: ContextProvider) {
+        let queue = DispatchQueue(label: "com.edge.rum.context.storage", qos: .utility)
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(
+            deadline: .now() + storageRefreshInterval,
+            repeating: storageRefreshInterval,
+            leeway: .seconds(5)
+        )
+        timer.setEventHandler { [weak provider] in
+            provider?.refreshStorage(StorageContext.snapshot())
+        }
+        os_unfair_lock_lock(installLock)
+        storageTimer = timer
+        storageTimerSuspended = false
+        os_unfair_lock_unlock(installLock)
+        timer.resume()
+    }
+
+    private static func suspendStorageTimer() {
+        os_unfair_lock_lock(installLock)
+        let timer = storageTimer
+        let wasSuspended = storageTimerSuspended
+        if let _ = timer, !wasSuspended {
+            storageTimerSuspended = true
+        }
+        os_unfair_lock_unlock(installLock)
+        if let timer = timer, !wasSuspended {
+            timer.suspend()
+        }
+    }
+
+    private static func resumeStorageTimer() {
+        os_unfair_lock_lock(installLock)
+        let timer = storageTimer
+        let wasSuspended = storageTimerSuspended
+        if let _ = timer, wasSuspended {
+            storageTimerSuspended = false
+        }
+        os_unfair_lock_unlock(installLock)
+        if let timer = timer, wasSuspended {
+            timer.resume()
+        }
+    }
+
+    // MARK: - Test-only helpers
+
+    #if DEBUG
+    /// Tear down the registered observers + storage timer and clear
+    /// the install flag so subsequent tests can drive `install(...)`
+    /// from a clean state.
+    public static func _resetInstallFlagForTesting() {
+        os_unfair_lock_lock(installLock)
+        let removedObservers = observers
+        let removedTimer = storageTimer
+        let wasSuspended = storageTimerSuspended
+        observers.removeAll()
+        storageTimer = nil
+        storageTimerSuspended = false
+        _installed = false
+        os_unfair_lock_unlock(installLock)
+
+        let nc = NotificationCenter.default
+        for token in removedObservers {
+            nc.removeObserver(token)
+        }
+        if let timer = removedTimer {
+            // `DispatchSourceTimer` must be resumed before
+            // cancel/release; otherwise a suspended source crashes on
+            // dealloc with EXC_BAD_INSTRUCTION.
+            if wasSuspended {
+                timer.resume()
+            }
+            timer.cancel()
+        }
+    }
+
+    /// Force a one-shot storage refresh so tests can assert the timer
+    /// path without waiting 5 minutes.
+    public static func _refreshStorageNowForTesting(provider: ContextProvider) {
+        provider.refreshStorage(StorageContext.snapshot())
+    }
+    #endif
+}

--- a/Sources/EdgeRumCore/Context/ContextProvider.swift
+++ b/Sources/EdgeRumCore/Context/ContextProvider.swift
@@ -1,19 +1,24 @@
 // Sources/EdgeRumCore/Context/ContextProvider.swift
 //
-// Holds the six identity-attribute snapshots (app, device, network,
-// session, user, sdk) and combines them into a single `AttributeBag`
-// at every `Recorder.recordEvent`.
+// Holds the identity-attribute snapshots and combines them into a
+// single `AttributeBag` at every `Recorder.recordEvent`. The original
+// six groups — app, device, network, session, user, sdk — are joined
+// by three F16 enrichment groups: power, accessibility, storage.
 //
 // Refresh hooks let the surrounding code update individual contexts
 // without recomputing the whole snapshot:
-//   - `refreshNetwork(_:)`     — NWPath transition
-//   - `setUser(_:)`            — EdgeRum.identify()
-//   - `refreshSession(_:)`     — SessionManager rotation
-//   - `refreshDevice(_:)`      — battery / system change
+//   - `refreshNetwork(_:)`        — NWPath transition
+//   - `setUser(_:)`               — EdgeRum.identify()
+//   - `refreshSession(_:)`        — SessionManager rotation
+//   - `refreshDevice(_:)`         — battery / system change / locale change
+//   - `refreshPower(_:)`          — thermal / low power mode change (F16/T16.1)
+//   - `refreshAccessibility(_:)`  — VoiceOver / dynamic type / etc. (F16/T16.2)
+//   - `refreshStorage(_:)`        — periodic refresh + lifecycle    (F16/T16.4)
 //
-// Refs: PLAN-iOS.md §7.5, §F3/T3.3, CLAUDE.md "Recorder + transport
-//       implementation notes" step 1 ("snapshots app/device/network/
-//       session/user attributes into an in-memory AttributeBag").
+// Refs: PLAN-iOS.md §7.5, §F3/T3.3, §16.4 / F16; CLAUDE.md "Recorder
+//       + transport implementation notes" step 1 ("snapshots app/
+//       device/network/session/user attributes into an in-memory
+//       AttributeBag").
 //
 
 import Foundation
@@ -28,6 +33,9 @@ public final class ContextProvider: @unchecked Sendable {
     private var session: SessionContextSnapshot
     private var user: UserContextSnapshot
     private var sdk: SdkContext
+    private var power: PowerContext
+    private var accessibility: AccessibilityContext
+    private var storage: StorageContext
 
     public init(
         app: AppContext,
@@ -36,7 +44,10 @@ public final class ContextProvider: @unchecked Sendable {
         network: NetworkContext,
         session: SessionContextSnapshot,
         user: UserContextSnapshot,
-        sdk: SdkContext
+        sdk: SdkContext,
+        power: PowerContext = PowerContext(),
+        accessibility: AccessibilityContext = AccessibilityContext(),
+        storage: StorageContext = StorageContext()
     ) {
         self.app = app
         self.device = device
@@ -45,19 +56,26 @@ public final class ContextProvider: @unchecked Sendable {
         self.session = session
         self.user = user
         self.sdk = sdk
+        self.power = power
+        self.accessibility = accessibility
+        self.storage = storage
     }
 
     // MARK: Snapshot
 
     /// Build the merged attribute bag in the order app → device →
-    /// network → session → user → sdk. Within the same call no key
-    /// collides (each context writes a disjoint key namespace).
+    /// power → accessibility → storage → network → session → user →
+    /// sdk. Within the same call no key collides (each context writes
+    /// a disjoint key namespace).
     public func snapshot() -> AttributeBag {
         lock.lock(); defer { lock.unlock() }
         var bag = AttributeBag()
         app.write(into: &bag)
         device.write(into: &bag)
         deviceIdentity.write(into: &bag)
+        power.write(into: &bag)
+        accessibility.write(into: &bag)
+        storage.write(into: &bag)
         network.write(into: &bag)
         session.write(into: &bag)
         user.write(into: &bag)
@@ -97,6 +115,18 @@ public final class ContextProvider: @unchecked Sendable {
         lock.lock(); self.user = user; lock.unlock()
     }
 
+    public func refreshPower(_ power: PowerContext) {
+        lock.lock(); self.power = power; lock.unlock()
+    }
+
+    public func refreshAccessibility(_ accessibility: AccessibilityContext) {
+        lock.lock(); self.accessibility = accessibility; lock.unlock()
+    }
+
+    public func refreshStorage(_ storage: StorageContext) {
+        lock.lock(); self.storage = storage; lock.unlock()
+    }
+
     // MARK: Read
 
     public func currentSession() -> SessionContextSnapshot {
@@ -117,5 +147,20 @@ public final class ContextProvider: @unchecked Sendable {
     public func currentNetwork() -> NetworkContext {
         lock.lock(); defer { lock.unlock() }
         return network
+    }
+
+    public func currentPower() -> PowerContext {
+        lock.lock(); defer { lock.unlock() }
+        return power
+    }
+
+    public func currentAccessibility() -> AccessibilityContext {
+        lock.lock(); defer { lock.unlock() }
+        return accessibility
+    }
+
+    public func currentStorage() -> StorageContext {
+        lock.lock(); defer { lock.unlock() }
+        return storage
     }
 }

--- a/Sources/EdgeRumCore/Context/DeviceContext.swift
+++ b/Sources/EdgeRumCore/Context/DeviceContext.swift
@@ -13,21 +13,24 @@
 // attribute still carries something meaningful.
 //
 // Wire keys (CLAUDE.md):
-//   device.platform           = "ios"
-//   device.manufacturer       = "Apple"
-//   device.os                 = "ios"
-//   device.platform_version   — UIDevice.current.systemVersion
-//   device.model              — utsname identifier
-//   device.isVirtual          — simulator detect
-//   device.screenWidth/Height — UIScreen.main.nativeBounds (points × scale)
-//   device.pixelRatio         — UIScreen.main.scale
-//   device.batteryLevel       — UIDevice.batteryLevel (when monitoring)
-//   device.batteryCharging    — UIDevice.batteryState ∈ {.charging,.full}
+//   device.platform             = "ios"
+//   device.manufacturer         = "Apple"
+//   device.os                   = "ios"
+//   device.platform_version     — UIDevice.current.systemVersion
+//   device.model                — utsname identifier
+//   device.isVirtual            — simulator detect
+//   device.screenWidth/Height   — UIScreen.main.nativeBounds (points × scale)
+//   device.pixelRatio           — UIScreen.main.scale
+//   device.batteryLevel         — UIDevice.batteryLevel (when monitoring)
+//   device.batteryCharging      — UIDevice.batteryState ∈ {.charging,.full}
+//   device.locale               — Locale.current.identifier            (F16/T16.5)
+//   device.timezone             — TimeZone.current.identifier          (F16/T16.5)
+//   device.timezone_offset_min  — TimeZone.current.secondsFromGMT()/60 (F16/T16.5)
 //
 // Note: `device.id` is owned by `IdentityProvider` (F4) and merged
 // in alongside; this struct holds only the immutable / cheap reads.
 //
-// Refs: PLAN-iOS.md §7.5, §F3/T3.3.
+// Refs: PLAN-iOS.md §7.5, §F3/T3.3, §16.4 / F16; docs/data-flow.md §3.2.
 //
 
 import Foundation
@@ -48,6 +51,9 @@ public struct DeviceContext: Sendable, Hashable {
     public var pixelRatio: Double?
     public var batteryLevel: Double?
     public var batteryCharging: Bool?
+    public var locale: String?
+    public var timezone: String?
+    public var timezoneOffsetMin: Int?
 
     public init(
         platform: String = "ios",
@@ -60,7 +66,10 @@ public struct DeviceContext: Sendable, Hashable {
         screenHeight: Int? = nil,
         pixelRatio: Double? = nil,
         batteryLevel: Double? = nil,
-        batteryCharging: Bool? = nil
+        batteryCharging: Bool? = nil,
+        locale: String? = nil,
+        timezone: String? = nil,
+        timezoneOffsetMin: Int? = nil
     ) {
         self.platform = platform
         self.manufacturer = manufacturer
@@ -73,6 +82,9 @@ public struct DeviceContext: Sendable, Hashable {
         self.pixelRatio = pixelRatio
         self.batteryLevel = batteryLevel
         self.batteryCharging = batteryCharging
+        self.locale = locale
+        self.timezone = timezone
+        self.timezoneOffsetMin = timezoneOffsetMin
     }
 
     public static func snapshot() -> DeviceContext {
@@ -117,6 +129,8 @@ public struct DeviceContext: Sendable, Hashable {
             batteryCharging = nil
         }
 
+        let (localeId, tzId, tzOffset) = readLocaleAndTimezone()
+
         return DeviceContext(
             platformVersion: platformVersion,
             model: model,
@@ -125,12 +139,18 @@ public struct DeviceContext: Sendable, Hashable {
             screenHeight: h,
             pixelRatio: scale,
             batteryLevel: batteryLevel,
-            batteryCharging: batteryCharging
+            batteryCharging: batteryCharging,
+            locale: localeId,
+            timezone: tzId,
+            timezoneOffsetMin: tzOffset
         )
         #else
-        // Non-UIKit hosts (rare; test environments) — return only the
-        // constant identity keys. Tests can override fields directly.
-        return DeviceContext()
+        let (localeId, tzId, tzOffset) = readLocaleAndTimezone()
+        return DeviceContext(
+            locale: localeId,
+            timezone: tzId,
+            timezoneOffsetMin: tzOffset
+        )
         #endif
     }
 
@@ -146,7 +166,25 @@ public struct DeviceContext: Sendable, Hashable {
         bag.setIfPresent("device.pixelRatio", pixelRatio.map { .double($0) })
         bag.setIfPresent("device.batteryLevel", batteryLevel.map { .double($0) })
         bag.setIfPresent("device.batteryCharging", batteryCharging.map { .bool($0) })
+        bag.setIfPresent("device.locale", locale.map { .string($0) })
+        bag.setIfPresent("device.timezone", timezone.map { .string($0) })
+        bag.setIfPresent("device.timezone_offset_min", timezoneOffsetMin.map { .int($0) })
     }
+}
+
+/// Read `Locale.current.identifier`, `TimeZone.current.identifier`, and
+/// the GMT offset (minutes) for the F16/T16.5 wire keys. Returns
+/// `(nil, nil, nil)` only when the underlying values are empty, which
+/// is essentially impossible on a real device but defends the tests.
+internal func readLocaleAndTimezone() -> (String?, String?, Int?) {
+    let localeId = Locale.current.identifier
+    let tzId = TimeZone.current.identifier
+    let offsetMinutes = TimeZone.current.secondsFromGMT() / 60
+    return (
+        localeId.isEmpty ? nil : localeId,
+        tzId.isEmpty ? nil : tzId,
+        offsetMinutes
+    )
 }
 
 #if canImport(UIKit)

--- a/Sources/EdgeRumCore/Context/NetworkContext.swift
+++ b/Sources/EdgeRumCore/Context/NetworkContext.swift
@@ -4,10 +4,13 @@
 // `ContextProvider` is updated whenever the path transitions; the
 // stored snapshot is what `Recorder.recordEvent` merges in.
 //
-// Wire keys (CLAUDE.md):
+// Wire keys (CLAUDE.md / docs/data-flow.md §3.3):
 //   network.type             — "wifi" / "cellular" / "wired" / "none" / "unknown"
 //   network.effectiveType    — best-effort radio access tech on iOS
 //                              ("2g" / "3g" / "4g" / "5g" / "wifi" / "unknown")
+//   network.expensive        — NWPath.isExpensive                    (F16/T16.3)
+//   network.constrained      — NWPath.isConstrained                  (F16/T16.3)
+//   network.interface        — Active NWInterface name (e.g. "en0")  (F16/T16.3)
 //
 // `effectiveType` is "best-effort on iOS" per CLAUDE.md "Required
 // identity attributes". For Wi-Fi paths we report `"wifi"`. For
@@ -16,7 +19,7 @@
 // for cellular paths and leaves a TODO comment for the CT-based
 // refinement to land in F8.
 //
-// Refs: PLAN-iOS.md §7.5, §F3/T3.3.
+// Refs: PLAN-iOS.md §7.5, §F3/T3.3, §16.4 / F16; docs/data-flow.md §3.3.
 //
 
 import Foundation
@@ -34,33 +37,98 @@ public struct NetworkContext: Sendable, Hashable {
 
     public var type: NetworkType
     public var effectiveType: String
+    public var isExpensive: Bool
+    public var isConstrained: Bool
+    public var interface: String?
 
-    public init(type: NetworkType = .unknown, effectiveType: String = "unknown") {
+    public init(
+        type: NetworkType = .unknown,
+        effectiveType: String = "unknown",
+        isExpensive: Bool = false,
+        isConstrained: Bool = false,
+        interface: String? = nil
+    ) {
         self.type = type
         self.effectiveType = effectiveType
+        self.isExpensive = isExpensive
+        self.isConstrained = isConstrained
+        self.interface = interface
     }
 
     public func write(into bag: inout AttributeBag) {
         bag.set("network.type", .string(type.rawValue))
         bag.set("network.effectiveType", .string(effectiveType))
+        bag.set("network.expensive", .bool(isExpensive))
+        bag.set("network.constrained", .bool(isConstrained))
+        bag.setIfPresent("network.interface", interface.map { .string($0) })
     }
 
     /// Map a `Network.framework` `NWPath` to our wire representation.
     public static func from(_ path: NWPath) -> NetworkContext {
+        let isExpensive = path.isExpensive
+        let isConstrained: Bool
+        if #available(iOS 13.0, macOS 10.15, *) {
+            isConstrained = path.isConstrained
+        } else {
+            isConstrained = false
+        }
+        let interface = primaryInterfaceName(path)
+
         guard path.status == .satisfied else {
-            return NetworkContext(type: .none, effectiveType: "unknown")
+            return NetworkContext(
+                type: .none,
+                effectiveType: "unknown",
+                isExpensive: isExpensive,
+                isConstrained: isConstrained,
+                interface: interface
+            )
         }
         if path.usesInterfaceType(.wifi) {
-            return NetworkContext(type: .wifi, effectiveType: "wifi")
+            return NetworkContext(
+                type: .wifi,
+                effectiveType: "wifi",
+                isExpensive: isExpensive,
+                isConstrained: isConstrained,
+                interface: interface
+            )
         }
         if path.usesInterfaceType(.cellular) {
             // F8 refines effectiveType from `CTTelephonyNetworkInfo`.
-            return NetworkContext(type: .cellular, effectiveType: "cellular")
+            return NetworkContext(
+                type: .cellular,
+                effectiveType: "cellular",
+                isExpensive: isExpensive,
+                isConstrained: isConstrained,
+                interface: interface
+            )
         }
         if path.usesInterfaceType(.wiredEthernet) {
-            return NetworkContext(type: .wired, effectiveType: "wired")
+            return NetworkContext(
+                type: .wired,
+                effectiveType: "wired",
+                isExpensive: isExpensive,
+                isConstrained: isConstrained,
+                interface: interface
+            )
         }
-        return NetworkContext(type: .unknown, effectiveType: "unknown")
+        return NetworkContext(
+            type: .unknown,
+            effectiveType: "unknown",
+            isExpensive: isExpensive,
+            isConstrained: isConstrained,
+            interface: interface
+        )
+    }
+
+    /// First available interface name (e.g. `"en0"`, `"pdp_ip0"`),
+    /// `nil` when the path reports no available interfaces. F16/T16.3.
+    private static func primaryInterfaceName(_ path: NWPath) -> String? {
+        // `availableInterfaces` is an `[NWInterface]` ordered by the
+        // system's preferred priority. We surface the first one so
+        // event consumers know which physical interface served the
+        // traffic at emission time.
+        guard let first = path.availableInterfaces.first else { return nil }
+        return first.name
     }
 }
 

--- a/Sources/EdgeRumCore/Context/PowerContext.swift
+++ b/Sources/EdgeRumCore/Context/PowerContext.swift
@@ -1,0 +1,72 @@
+// Sources/EdgeRumCore/Context/PowerContext.swift
+//
+// F16/T16.1 — `device.thermal_state` + `device.low_power_mode`.
+//
+// Reads `ProcessInfo.processInfo.thermalState` and
+// `ProcessInfo.processInfo.isLowPowerModeEnabled`. The two underlying
+// values change via `thermalStateDidChangeNotification` and
+// `NSProcessInfoPowerStateDidChange`; observers in `ContextObservers`
+// call `ContextProvider.refreshPower(.snapshot())` on each change so
+// the next emitted event carries the fresh values.
+//
+// Wire keys (docs/data-flow.md §3.2):
+//   device.thermal_state    — "nominal" / "fair" / "serious" / "critical"
+//   device.low_power_mode   — Bool
+//
+// Refs: PLAN-iOS.md §16.4 / F16 / T16.1.
+//
+
+import Foundation
+
+public struct PowerContext: Sendable, Hashable {
+
+    public var thermalState: String?
+    public var lowPowerMode: Bool?
+
+    public init(thermalState: String? = nil, lowPowerMode: Bool? = nil) {
+        self.thermalState = thermalState
+        self.lowPowerMode = lowPowerMode
+    }
+
+    /// Snapshot the live `ProcessInfo` values. Cheap and thread-safe;
+    /// `ProcessInfo.processInfo` is the shared singleton.
+    ///
+    /// `isLowPowerModeEnabled` is iOS 9.0+ but macOS 12.0+ — the
+    /// package targets macOS 11 (test host only), so the macOS branch
+    /// is gated and reports `nil` when unavailable.
+    public static func snapshot() -> PowerContext {
+        let info = ProcessInfo.processInfo
+        let lowPower: Bool?
+        #if os(iOS)
+        lowPower = info.isLowPowerModeEnabled
+        #else
+        if #available(macOS 12.0, *) {
+            lowPower = info.isLowPowerModeEnabled
+        } else {
+            lowPower = nil
+        }
+        #endif
+        return PowerContext(
+            thermalState: Self.thermalStateString(info.thermalState),
+            lowPowerMode: lowPower
+        )
+    }
+
+    public func write(into bag: inout AttributeBag) {
+        bag.setIfPresent("device.thermal_state", thermalState.map { .string($0) })
+        bag.setIfPresent("device.low_power_mode", lowPowerMode.map { .bool($0) })
+    }
+
+    /// Map `ProcessInfo.ThermalState` to the wire string. Exposed
+    /// internal so `PowerContextTests` can drive every case without a
+    /// real device or simulator under heat stress.
+    internal static func thermalStateString(_ state: ProcessInfo.ThermalState) -> String {
+        switch state {
+        case .nominal: return "nominal"
+        case .fair: return "fair"
+        case .serious: return "serious"
+        case .critical: return "critical"
+        @unknown default: return "nominal"
+        }
+    }
+}

--- a/Sources/EdgeRumCore/Context/StorageContext.swift
+++ b/Sources/EdgeRumCore/Context/StorageContext.swift
@@ -1,0 +1,110 @@
+// Sources/EdgeRumCore/Context/StorageContext.swift
+//
+// F16/T16.4 — disk capacity + background-refresh status carried on
+// every event so the backend can correlate "out of disk" / "refresh
+// denied" with crash & hang patterns.
+//
+// Wire keys (docs/data-flow.md §3.1 / §3.2):
+//   device.disk_free_mb     — `FileManager.attributesOfFileSystem(forPath:)`
+//                              `.systemFreeSize` ÷ 1 048 576
+//   device.disk_total_mb    — same dict's `.systemSize` ÷ 1 048 576
+//   app.background_refresh  — `UIApplication.backgroundRefreshStatus`
+//                              ("available" / "denied" / "restricted"
+//                               / "unknown")
+//
+// Refresh strategy: `ContextObservers` arms a 5-minute
+// `DispatchSource.makeTimerSource` (mirrors `MemorySampler`'s
+// utility-queue timer) that calls `provider.refreshStorage(.snapshot())`.
+// The timer is suspended on `willResignActive` and resumed on
+// `didBecomeActive` so we don't run statfs in the background.
+//
+// Refs: PLAN-iOS.md §16.4 / F16 / T16.4.
+//
+
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+public struct StorageContext: Sendable, Hashable {
+
+    public var diskFreeMb: Int?
+    public var diskTotalMb: Int?
+    public var backgroundRefresh: String?
+
+    public init(
+        diskFreeMb: Int? = nil,
+        diskTotalMb: Int? = nil,
+        backgroundRefresh: String? = nil
+    ) {
+        self.diskFreeMb = diskFreeMb
+        self.diskTotalMb = diskTotalMb
+        self.backgroundRefresh = backgroundRefresh
+    }
+
+    public static func snapshot() -> StorageContext {
+        let (free, total) = readDiskMB()
+        let refresh = readBackgroundRefresh()
+        return StorageContext(
+            diskFreeMb: free,
+            diskTotalMb: total,
+            backgroundRefresh: refresh
+        )
+    }
+
+    public func write(into bag: inout AttributeBag) {
+        bag.setIfPresent("device.disk_free_mb", diskFreeMb.map { .int($0) })
+        bag.setIfPresent("device.disk_total_mb", diskTotalMb.map { .int($0) })
+        bag.setIfPresent("app.background_refresh", backgroundRefresh.map { .string($0) })
+    }
+
+    /// Read free + total bytes from the home-directory volume and
+    /// convert to whole megabytes. Returns `(nil, nil)` if the
+    /// `FileManager` query throws — we never surface a partial value.
+    internal static func readDiskMB() -> (Int?, Int?) {
+        let path = NSHomeDirectory()
+        guard let attrs = try? FileManager.default.attributesOfFileSystem(forPath: path) else {
+            return (nil, nil)
+        }
+        let free = (attrs[.systemFreeSize] as? NSNumber)?.int64Value
+        let total = (attrs[.systemSize] as? NSNumber)?.int64Value
+        let mb: (Int64) -> Int = { bytes in
+            Int(bytes / 1_048_576)
+        }
+        return (free.map(mb), total.map(mb))
+    }
+
+    /// Map `UIBackgroundRefreshStatus` to the wire string. Returns
+    /// `nil` on non-UIKit hosts (tests / macOS CI).
+    internal static func readBackgroundRefresh() -> String? {
+        #if canImport(UIKit)
+        if Thread.isMainThread {
+            return backgroundRefreshStringOnMain()
+        }
+        var result: String?
+        DispatchQueue.main.sync { result = backgroundRefreshStringOnMain() }
+        return result
+        #else
+        return nil
+        #endif
+    }
+
+    #if canImport(UIKit)
+    /// Pure mapping `UIBackgroundRefreshStatus → wire string`.
+    /// Exposed internal so `StorageContextTests` can drive every case.
+    internal static func backgroundRefreshString(_ status: UIBackgroundRefreshStatus) -> String {
+        switch status {
+        case .available: return "available"
+        case .denied: return "denied"
+        case .restricted: return "restricted"
+        @unknown default: return "unknown"
+        }
+    }
+    #endif
+}
+
+#if canImport(UIKit)
+private func backgroundRefreshStringOnMain() -> String {
+    return StorageContext.backgroundRefreshString(UIApplication.shared.backgroundRefreshStatus)
+}
+#endif

--- a/Sources/EdgeRumCore/Recorder.swift
+++ b/Sources/EdgeRumCore/Recorder.swift
@@ -236,6 +236,16 @@ public final class Recorder: Recording, @unchecked Sendable {
         context.currentDeviceIdentity().id
     }
 
+    /// Expose the held `ContextProvider` so the F16 `ContextObservers`
+    /// installer (and tests) can refresh individual context groups
+    /// without going through the Recorder API. Intentionally typed as
+    /// the concrete `ContextProvider` because that's the only
+    /// implementation; if alternative providers ever land this will
+    /// move behind a protocol.
+    public var currentContextProvider: ContextProvider {
+        context
+    }
+
     public func configure(_ config: RecorderConfig) {
         stateLock.lock()
         self._config = config

--- a/Tests/EdgeRumCaptureTests/NetworkPathCaptureTests.swift
+++ b/Tests/EdgeRumCaptureTests/NetworkPathCaptureTests.swift
@@ -107,6 +107,18 @@ private final class CaptureProbeRecorder: Recording, @unchecked Sendable {
 
 final class NetworkPathCaptureTests: XCTestCase {
 
+    override func setUp() {
+        // Reset BEFORE each test too — `EdgeRumAPITests` (runs
+        // alphabetically earlier) calls `EdgeRum.start(_:)` which
+        // installs `NetworkPathCapture`'s live `NWPathMonitor`; on
+        // CI macOS hosts the monitor fires its pathUpdateHandler
+        // immediately and seeds `lastFingerprint`. Without this reset
+        // the first dedupe-test emit would be silently absorbed.
+        super.setUp()
+        NetworkPathCapture._resetInstallFlagForTesting()
+        Recorder.resetShared()
+    }
+
     override func tearDown() {
         NetworkPathCapture._resetInstallFlagForTesting()
         Recorder.resetShared()

--- a/Tests/EdgeRumContractTests/F16ContextEnrichmentConformanceTests.swift
+++ b/Tests/EdgeRumContractTests/F16ContextEnrichmentConformanceTests.swift
@@ -1,0 +1,185 @@
+import XCTest
+import EdgeRumCore
+
+/// F16 — wire conformance for the context-bag enrichment.
+///
+/// Drives a `Recorder` seeded with non-default F16 contexts (Power,
+/// Accessibility, Storage, plus NetworkContext extras and the
+/// DeviceContext locale/timezone fields), emits one `navigation`
+/// event, and asserts:
+///
+///   - The envelope still passes every `WireAssertions.assertValidEnvelope`
+///     check (primitives only, no forbidden tokens, ISO 8601 stamps).
+///   - Every one of the 16 new wire keys is present with the expected
+///     type and value.
+///   - The existing identity attributes (session.id, device.id,
+///     sdk.platform) survive the new write order.
+///
+/// Refs: PLAN-iOS.md §16.4 / F16; docs/data-flow.md §3.
+final class F16ContextEnrichmentConformanceTests: XCTestCase {
+
+    private func makeRecorderWithF16Contexts() -> (Recorder, RecordingTransportSink) {
+        let clock = FixedClock(Date(timeIntervalSince1970: 1_717_234_876.512))
+        let sink = RecordingTransportSink()
+
+        let provider = ContextProvider(
+            app: AppContext(
+                name: "Shop",
+                packageName: "com.example.shop",
+                version: "2.1.0",
+                buildNumber: "412",
+                environment: "production"
+            ),
+            device: DeviceContext(
+                platformVersion: "17.4.1",
+                model: "iPhone15,3",
+                isVirtual: false,
+                screenWidth: 1290,
+                screenHeight: 2796,
+                pixelRatio: 3.0,
+                locale: "en_KE",
+                timezone: "Africa/Nairobi",
+                timezoneOffsetMin: 180
+            ),
+            deviceIdentity: DeviceIdentitySnapshot(id: "device_1_aaaaaaaaaaaaaaaa_ios"),
+            network: NetworkContext(
+                type: .cellular,
+                effectiveType: "4g",
+                isExpensive: true,
+                isConstrained: true,
+                interface: "pdp_ip0"
+            ),
+            session: SessionContextSnapshot(
+                id: "session_1_bbbbbbbbbbbbbbbb_ios",
+                startTime: Date(timeIntervalSince1970: 1),
+                sequence: 7
+            ),
+            user: UserContextSnapshot(id: "user_1_cccccccccccccccc"),
+            sdk: SdkContext(version: "1.0.0"),
+            power: PowerContext(thermalState: "serious", lowPowerMode: true),
+            accessibility: AccessibilityContext(
+                dynamicType: "AX2",
+                reduceMotion: true,
+                boldText: false,
+                voiceOver: true,
+                increaseContrast: false
+            ),
+            storage: StorageContext(
+                diskFreeMb: 9_876,
+                diskTotalMb: 131_072,
+                backgroundRefresh: "available"
+            )
+        )
+
+        let recorder = Recorder(
+            clock: clock,
+            sampler: Sampler(sampleRate: 1.0, entropy: { 0.0 }),
+            transport: sink,
+            contextProvider: provider,
+            sdkVersion: "1.0.0"
+        )
+        recorder.configure(RecorderConfig(
+            apiKey: "edge_test_abc",
+            endpoint: URL(string: "https://collect.example.com")!
+        ))
+        return (recorder, sink)
+    }
+
+    func testEnvelopeCarriesAllSixteenF16Attributes() throws {
+        let (recorder, sink) = makeRecorderWithF16Contexts()
+        // configure() called above re-snapshots the live AppContext +
+        // DeviceContext from Info.plist / UIDevice, which clobbers our
+        // fixture's locale fields. Re-apply the F16 contexts after
+        // configure so the asserted values survive.
+        let provider = recorder.currentContextProvider
+        provider.refreshDevice(DeviceContext(
+            platformVersion: "17.4.1",
+            model: "iPhone15,3",
+            isVirtual: false,
+            screenWidth: 1290,
+            screenHeight: 2796,
+            pixelRatio: 3.0,
+            locale: "en_KE",
+            timezone: "Africa/Nairobi",
+            timezoneOffsetMin: 180
+        ))
+
+        recorder.recordEvent(name: "navigation", attributes: [
+            "navigation.kind": "uikit",
+            "navigation.name": "Cart"
+        ])
+        recorder.flush(reason: .manual)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        let attrs = try XCTUnwrap(events.first?["attributes"] as? [String: Any])
+        try WireAssertions.assertIdentityAttributes(attrs)
+
+        // T16.1 PowerContext
+        XCTAssertEqual(attrs["device.thermal_state"] as? String, "serious")
+        XCTAssertEqual(attrs["device.low_power_mode"] as? Bool, true)
+
+        // T16.2 AccessibilityContext
+        XCTAssertEqual(attrs["device.dynamic_type"] as? String, "AX2")
+        XCTAssertEqual(attrs["device.reduce_motion"] as? Bool, true)
+        XCTAssertEqual(attrs["device.bold_text"] as? Bool, false)
+        XCTAssertEqual(attrs["device.voiceover"] as? Bool, true)
+        XCTAssertEqual(attrs["device.increase_contrast"] as? Bool, false)
+
+        // T16.3 NetworkContext extras
+        XCTAssertEqual(attrs["network.expensive"] as? Bool, true)
+        XCTAssertEqual(attrs["network.constrained"] as? Bool, true)
+        XCTAssertEqual(attrs["network.interface"] as? String, "pdp_ip0")
+
+        // T16.4 StorageContext
+        XCTAssertEqual(attrs["device.disk_free_mb"] as? Int, 9_876)
+        XCTAssertEqual(attrs["device.disk_total_mb"] as? Int, 131_072)
+        XCTAssertEqual(attrs["app.background_refresh"] as? String, "available")
+
+        // T16.5 DeviceContext locale / timezone
+        XCTAssertEqual(attrs["device.locale"] as? String, "en_KE")
+        XCTAssertEqual(attrs["device.timezone"] as? String, "Africa/Nairobi")
+        XCTAssertEqual(attrs["device.timezone_offset_min"] as? Int, 180)
+    }
+
+    /// All F16 attributes must be primitives — the generic
+    /// `assertValidEnvelope` already enforces this, but we add a
+    /// targeted sanity check on the specific key set so any future
+    /// regression toward nested/array values surfaces here with a
+    /// clear name.
+    func testF16AttributesAreAllPrimitives() throws {
+        let (recorder, sink) = makeRecorderWithF16Contexts()
+        recorder.recordEvent(name: "navigation", attributes: [:])
+        recorder.flush(reason: .manual)
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        let attrs = try XCTUnwrap(events.first?["attributes"] as? [String: Any])
+
+        let f16Keys: [String] = [
+            "device.thermal_state",
+            "device.low_power_mode",
+            "device.dynamic_type",
+            "device.reduce_motion",
+            "device.bold_text",
+            "device.voiceover",
+            "device.increase_contrast",
+            "network.expensive",
+            "network.constrained",
+            "network.interface",
+            "device.disk_free_mb",
+            "device.disk_total_mb",
+            "app.background_refresh",
+            "device.locale",
+            "device.timezone",
+            "device.timezone_offset_min"
+        ]
+        for key in f16Keys {
+            let value = try XCTUnwrap(attrs[key], "F16 key \(key) must be present on every event")
+            XCTAssertFalse(value is [Any], "\(key) must not be an array")
+            XCTAssertFalse(value is [String: Any], "\(key) must not be a nested object")
+        }
+    }
+}

--- a/Tests/EdgeRumTests/AccessibilityContextTests.swift
+++ b/Tests/EdgeRumTests/AccessibilityContextTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+@testable import EdgeRum
+@testable import EdgeRumCore
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Unit tests for `AccessibilityContext` — F16/T16.2's UIAccessibility
+/// snapshot.
+///
+/// Refs: PLAN-iOS.md §16.4 / F16 / T16.2; docs/data-flow.md §3.2.
+final class AccessibilityContextTests: XCTestCase {
+
+    // MARK: write(into:)
+
+    func testWriteEmitsAllFiveKeysWhenPresent() {
+        let ctx = AccessibilityContext(
+            dynamicType: "L",
+            reduceMotion: false,
+            boldText: true,
+            voiceOver: false,
+            increaseContrast: true
+        )
+        var bag = AttributeBag()
+        ctx.write(into: &bag)
+        XCTAssertEqual(bag["device.dynamic_type"], .string("L"))
+        XCTAssertEqual(bag["device.reduce_motion"], .bool(false))
+        XCTAssertEqual(bag["device.bold_text"], .bool(true))
+        XCTAssertEqual(bag["device.voiceover"], .bool(false))
+        XCTAssertEqual(bag["device.increase_contrast"], .bool(true))
+        XCTAssertEqual(bag.count, 5)
+    }
+
+    func testWriteOmitsAllKeysWhenNil() {
+        let ctx = AccessibilityContext()
+        var bag = AttributeBag()
+        ctx.write(into: &bag)
+        XCTAssertTrue(bag.isEmpty)
+    }
+
+    func testWriteEmitsOnlyDynamicTypeWhenOthersNil() {
+        let ctx = AccessibilityContext(dynamicType: "XXXL")
+        var bag = AttributeBag()
+        ctx.write(into: &bag)
+        XCTAssertEqual(bag["device.dynamic_type"], .string("XXXL"))
+        XCTAssertNil(bag["device.reduce_motion"])
+        XCTAssertEqual(bag.count, 1)
+    }
+
+    // MARK: dynamicTypeString mapping
+
+    #if canImport(UIKit)
+    func testDynamicTypeMappingStandardCategories() {
+        XCTAssertEqual(AccessibilityContext.dynamicTypeString(.extraSmall), "XS")
+        XCTAssertEqual(AccessibilityContext.dynamicTypeString(.small), "S")
+        XCTAssertEqual(AccessibilityContext.dynamicTypeString(.medium), "M")
+        XCTAssertEqual(AccessibilityContext.dynamicTypeString(.large), "L")
+        XCTAssertEqual(AccessibilityContext.dynamicTypeString(.extraLarge), "XL")
+        XCTAssertEqual(AccessibilityContext.dynamicTypeString(.extraExtraLarge), "XXL")
+        XCTAssertEqual(AccessibilityContext.dynamicTypeString(.extraExtraExtraLarge), "XXXL")
+    }
+
+    func testDynamicTypeMappingAccessibilityCategories() {
+        XCTAssertEqual(AccessibilityContext.dynamicTypeString(.accessibilityMedium), "AX1")
+        XCTAssertEqual(AccessibilityContext.dynamicTypeString(.accessibilityLarge), "AX2")
+        XCTAssertEqual(AccessibilityContext.dynamicTypeString(.accessibilityExtraLarge), "AX3")
+        XCTAssertEqual(AccessibilityContext.dynamicTypeString(.accessibilityExtraExtraLarge), "AX4")
+        XCTAssertEqual(AccessibilityContext.dynamicTypeString(.accessibilityExtraExtraExtraLarge), "AX5")
+    }
+
+    func testDynamicTypeMappingUnknownCategoryFallsBackToL() {
+        let unknown = UIContentSizeCategory(rawValue: "UIContentSizeCategorySomethingTotallyMade")
+        XCTAssertEqual(AccessibilityContext.dynamicTypeString(unknown), "L")
+    }
+    #endif
+
+    // MARK: snapshot()
+
+    #if canImport(UIKit)
+    func testSnapshotProducesAllFiveFieldsOnUIKitHost() {
+        let ctx = AccessibilityContext.snapshot()
+        XCTAssertNotNil(ctx.dynamicType, "dynamicType must be populated on UIKit hosts")
+        XCTAssertNotNil(ctx.reduceMotion)
+        XCTAssertNotNil(ctx.boldText)
+        XCTAssertNotNil(ctx.voiceOver)
+        XCTAssertNotNil(ctx.increaseContrast)
+    }
+    #endif
+
+    func testSnapshotDoesNotCrashOffMainThread() {
+        let exp = expectation(description: "off-main snapshot")
+        DispatchQueue.global(qos: .utility).async {
+            _ = AccessibilityContext.snapshot()
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 2.0)
+    }
+}

--- a/Tests/EdgeRumTests/ContextObserversTests.swift
+++ b/Tests/EdgeRumTests/ContextObserversTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import EdgeRum
+@testable import EdgeRumCore
+
+/// Unit tests for the F16 `ContextObservers` installer.
+///
+/// `ContextObservers.install(provider:debug:)` must be:
+///   - idempotent (second call is a no-op)
+///   - seed every F16 context on install so the first event after
+///     install carries the new attributes
+///   - teardown-clean for tests (no live timers / observers after
+///     `_resetInstallFlagForTesting`)
+///
+/// We cannot easily fire system notifications from a unit test, but
+/// we can drive the install path and verify the seeded snapshots
+/// land in the provider's bag.
+///
+/// Refs: PLAN-iOS.md §16.4 / F16.
+final class ContextObserversTests: XCTestCase {
+
+    private func makeProvider() -> ContextProvider {
+        ContextProvider(
+            app: AppContext(),
+            device: DeviceContext(),
+            deviceIdentity: DeviceIdentitySnapshot(id: "device_1_aa_ios"),
+            network: NetworkContext(),
+            session: SessionContextSnapshot(id: "s", startTime: Date(timeIntervalSince1970: 0), sequence: 0),
+            user: UserContextSnapshot(id: "u"),
+            sdk: SdkContext(version: "1.0.0")
+        )
+    }
+
+    override func setUp() {
+        super.setUp()
+        #if DEBUG
+        ContextObservers._resetInstallFlagForTesting()
+        #endif
+    }
+
+    override func tearDown() {
+        #if DEBUG
+        ContextObservers._resetInstallFlagForTesting()
+        #endif
+        super.tearDown()
+    }
+
+    func testInstallIsIdempotent() {
+        let p = makeProvider()
+        XCTAssertFalse(ContextObservers.isInstalled)
+        ContextObservers.install(provider: p)
+        XCTAssertTrue(ContextObservers.isInstalled)
+        // Second call must be a no-op (would otherwise crash the
+        // dispatch source by resuming an already-running timer).
+        ContextObservers.install(provider: p)
+        XCTAssertTrue(ContextObservers.isInstalled)
+    }
+
+    func testInstallSeedsPowerAccessibilityAndStorage() {
+        let p = makeProvider()
+        // Pre-install: nothing populated.
+        let preBag = p.snapshot()
+        XCTAssertNil(preBag["device.thermal_state"])
+        XCTAssertNil(preBag["device.disk_total_mb"])
+
+        ContextObservers.install(provider: p)
+
+        let bag = p.snapshot()
+        // Power should always seed thermal state on iOS/macOS.
+        XCTAssertNotNil(bag["device.thermal_state"])
+        // Storage seeded — at least total disk should resolve on the
+        // test host.
+        XCTAssertNotNil(bag["device.disk_total_mb"])
+    }
+
+    #if DEBUG
+    func testResetClearsInstallFlag() {
+        let p = makeProvider()
+        ContextObservers.install(provider: p)
+        XCTAssertTrue(ContextObservers.isInstalled)
+        ContextObservers._resetInstallFlagForTesting()
+        XCTAssertFalse(ContextObservers.isInstalled)
+        // Re-installable after reset.
+        ContextObservers.install(provider: p)
+        XCTAssertTrue(ContextObservers.isInstalled)
+    }
+    #endif
+
+    func testStorageRefreshIntervalIsFiveMinutes() {
+        // The PLAN-iOS.md §16.4 / T16.4 acceptance pins this at 5 min.
+        // Reading the constant directly catches accidental drift.
+        XCTAssertEqual(ContextObservers.storageRefreshInterval, .seconds(300))
+    }
+}

--- a/Tests/EdgeRumTests/ContextProviderTests.swift
+++ b/Tests/EdgeRumTests/ContextProviderTests.swift
@@ -107,6 +107,100 @@ final class ContextProviderTests: XCTestCase {
         XCTAssertEqual(bag["session.sequence"], .int(42))
     }
 
+    // MARK: F16 enrichment groups
+
+    func testSnapshotIncludesPowerAccessibilityAndStorageWhenPresent() {
+        let p = ContextProvider(
+            app: AppContext(name: "Shop", packageName: "com.example.shop", version: "2.1.0", buildNumber: "412", environment: "production"),
+            device: DeviceContext(),
+            deviceIdentity: DeviceIdentitySnapshot(id: "device_1_aaaaaaaaaaaaaaaa_ios"),
+            network: NetworkContext(),
+            session: SessionContextSnapshot(id: "s", startTime: Date(timeIntervalSince1970: 0), sequence: 0),
+            user: UserContextSnapshot(id: "u"),
+            sdk: SdkContext(version: "1.0.0"),
+            power: PowerContext(thermalState: "fair", lowPowerMode: true),
+            accessibility: AccessibilityContext(
+                dynamicType: "AX1",
+                reduceMotion: true,
+                boldText: false,
+                voiceOver: true,
+                increaseContrast: false
+            ),
+            storage: StorageContext(
+                diskFreeMb: 1_024,
+                diskTotalMb: 65_536,
+                backgroundRefresh: "available"
+            )
+        )
+        let bag = p.snapshot()
+        // power.*
+        XCTAssertEqual(bag["device.thermal_state"], .string("fair"))
+        XCTAssertEqual(bag["device.low_power_mode"], .bool(true))
+        // accessibility.*
+        XCTAssertEqual(bag["device.dynamic_type"], .string("AX1"))
+        XCTAssertEqual(bag["device.reduce_motion"], .bool(true))
+        XCTAssertEqual(bag["device.bold_text"], .bool(false))
+        XCTAssertEqual(bag["device.voiceover"], .bool(true))
+        XCTAssertEqual(bag["device.increase_contrast"], .bool(false))
+        // storage.*
+        XCTAssertEqual(bag["device.disk_free_mb"], .int(1_024))
+        XCTAssertEqual(bag["device.disk_total_mb"], .int(65_536))
+        XCTAssertEqual(bag["app.background_refresh"], .string("available"))
+    }
+
+    func testRefreshPowerReplacesPowerKeys() {
+        let p = makeProvider()
+        XCTAssertNil(p.snapshot()["device.thermal_state"])
+        p.refreshPower(PowerContext(thermalState: "critical", lowPowerMode: true))
+        let bag = p.snapshot()
+        XCTAssertEqual(bag["device.thermal_state"], .string("critical"))
+        XCTAssertEqual(bag["device.low_power_mode"], .bool(true))
+    }
+
+    func testRefreshAccessibilityReplacesAccessibilityKeys() {
+        let p = makeProvider()
+        p.refreshAccessibility(AccessibilityContext(
+            dynamicType: "XXL",
+            reduceMotion: false,
+            boldText: true,
+            voiceOver: false,
+            increaseContrast: true
+        ))
+        let bag = p.snapshot()
+        XCTAssertEqual(bag["device.dynamic_type"], .string("XXL"))
+        XCTAssertEqual(bag["device.bold_text"], .bool(true))
+        XCTAssertEqual(bag["device.increase_contrast"], .bool(true))
+    }
+
+    func testRefreshStorageReplacesStorageKeys() {
+        let p = makeProvider()
+        p.refreshStorage(StorageContext(
+            diskFreeMb: 4_096,
+            diskTotalMb: 131_072,
+            backgroundRefresh: "denied"
+        ))
+        let bag = p.snapshot()
+        XCTAssertEqual(bag["device.disk_free_mb"], .int(4_096))
+        XCTAssertEqual(bag["device.disk_total_mb"], .int(131_072))
+        XCTAssertEqual(bag["app.background_refresh"], .string("denied"))
+    }
+
+    func testRefreshNetworkPreservesExtras() {
+        let p = makeProvider()
+        p.refreshNetwork(NetworkContext(
+            type: .cellular,
+            effectiveType: "cellular",
+            isExpensive: true,
+            isConstrained: true,
+            interface: "pdp_ip0"
+        ))
+        let bag = p.snapshot()
+        XCTAssertEqual(bag["network.type"], .string("cellular"))
+        XCTAssertEqual(bag["network.expensive"], .bool(true))
+        XCTAssertEqual(bag["network.constrained"], .bool(true))
+        XCTAssertEqual(bag["network.interface"], .string("pdp_ip0"))
+    }
+
     // MARK: Bundle.main / UIDevice parity (issue #38 acceptance)
 
     func testAppContextSnapshotReadsBundleMain() {

--- a/Tests/EdgeRumTests/DeviceContextLocaleTests.swift
+++ b/Tests/EdgeRumTests/DeviceContextLocaleTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import EdgeRum
+import EdgeRumCore
+
+/// Unit tests for the F16/T16.5 locale + timezone fields added to
+/// `DeviceContext`. Kept in a separate file from the broader
+/// `ContextProviderTests` so the v1.0 device assertions there don't
+/// pick up dependencies on the v1.0+ keys.
+///
+/// Refs: PLAN-iOS.md §16.4 / F16 / T16.5; docs/data-flow.md §3.2.
+final class DeviceContextLocaleTests: XCTestCase {
+
+    // MARK: write(into:)
+
+    func testWriteEmitsLocaleTimezoneAndOffset() {
+        let ctx = DeviceContext(
+            locale: "en_KE",
+            timezone: "Africa/Nairobi",
+            timezoneOffsetMin: 180
+        )
+        var bag = AttributeBag()
+        ctx.write(into: &bag)
+        XCTAssertEqual(bag["device.locale"], .string("en_KE"))
+        XCTAssertEqual(bag["device.timezone"], .string("Africa/Nairobi"))
+        XCTAssertEqual(bag["device.timezone_offset_min"], .int(180))
+    }
+
+    func testWriteOmitsLocaleKeysWhenNil() {
+        let ctx = DeviceContext()
+        var bag = AttributeBag()
+        ctx.write(into: &bag)
+        XCTAssertNil(bag["device.locale"])
+        XCTAssertNil(bag["device.timezone"])
+        XCTAssertNil(bag["device.timezone_offset_min"])
+    }
+
+    // MARK: snapshot()
+
+    func testSnapshotPopulatesLocaleAndTimezoneFromHost() {
+        let ctx = DeviceContext.snapshot()
+        XCTAssertEqual(ctx.locale, Locale.current.identifier)
+        XCTAssertEqual(ctx.timezone, TimeZone.current.identifier)
+        XCTAssertEqual(
+            ctx.timezoneOffsetMin,
+            TimeZone.current.secondsFromGMT() / 60
+        )
+    }
+
+    /// Offset must be in the canonical −720…+840 minute range so the
+    /// backend can store it as a small int.
+    func testSnapshotTimezoneOffsetIsInValidMinuteRange() {
+        let ctx = DeviceContext.snapshot()
+        let offset = try? XCTUnwrap(ctx.timezoneOffsetMin)
+        if let offset = offset {
+            XCTAssertGreaterThanOrEqual(offset, -720)
+            XCTAssertLessThanOrEqual(offset, 840)
+        }
+    }
+}

--- a/Tests/EdgeRumTests/NetworkContextExtrasTests.swift
+++ b/Tests/EdgeRumTests/NetworkContextExtrasTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import EdgeRum
+import EdgeRumCore
+import Network
+
+/// Unit tests for `NetworkContext` extras — F16/T16.3's `expensive`,
+/// `constrained`, and `interface` wire keys.
+///
+/// Refs: PLAN-iOS.md §16.4 / F16 / T16.3; docs/data-flow.md §3.3.
+final class NetworkContextExtrasTests: XCTestCase {
+
+    // MARK: write(into:)
+
+    func testWriteEmitsAllFiveKeysWhenExtrasPresent() {
+        let ctx = NetworkContext(
+            type: .wifi,
+            effectiveType: "wifi",
+            isExpensive: true,
+            isConstrained: false,
+            interface: "en0"
+        )
+        var bag = AttributeBag()
+        ctx.write(into: &bag)
+        XCTAssertEqual(bag["network.type"], .string("wifi"))
+        XCTAssertEqual(bag["network.effectiveType"], .string("wifi"))
+        XCTAssertEqual(bag["network.expensive"], .bool(true))
+        XCTAssertEqual(bag["network.constrained"], .bool(false))
+        XCTAssertEqual(bag["network.interface"], .string("en0"))
+        XCTAssertEqual(bag.count, 5)
+    }
+
+    func testWriteOmitsInterfaceWhenNil() {
+        let ctx = NetworkContext(
+            type: .none,
+            effectiveType: "unknown",
+            isExpensive: false,
+            isConstrained: false,
+            interface: nil
+        )
+        var bag = AttributeBag()
+        ctx.write(into: &bag)
+        XCTAssertEqual(bag["network.type"], .string("none"))
+        XCTAssertEqual(bag["network.expensive"], .bool(false))
+        XCTAssertEqual(bag["network.constrained"], .bool(false))
+        XCTAssertNil(bag["network.interface"])
+    }
+
+    func testWriteAlwaysEmitsExpensiveAndConstrainedAsBool() {
+        // Default-init NetworkContext should still emit booleans for
+        // `expensive` and `constrained` (defaulting to false) so the
+        // wire shape stays stable.
+        let ctx = NetworkContext()
+        var bag = AttributeBag()
+        ctx.write(into: &bag)
+        XCTAssertEqual(bag["network.expensive"], .bool(false))
+        XCTAssertEqual(bag["network.constrained"], .bool(false))
+    }
+
+    // MARK: from(_:) — exercise the live NWPathMonitor's currentPath
+
+    /// `NWPathMonitor.currentPath` always returns a valid path even
+    /// before `.start(queue:)` is called, so we can drive
+    /// `NetworkContext.from(_:)` against a real path without
+    /// activating the monitor. We can't assert specific flag values
+    /// (CI hosts vary) but we can assert types + shape, which is what
+    /// the wire contract cares about.
+    func testFromCurrentPathProducesWellTypedExtras() {
+        let monitor = NWPathMonitor()
+        defer { monitor.cancel() }
+        let ctx = NetworkContext.from(monitor.currentPath)
+        // type is always one of the enum cases — covered by NetworkType
+        XCTAssertNotNil(NetworkContext.NetworkType(rawValue: ctx.type.rawValue))
+        // expensive + constrained must be plain Bool — no nil here
+        // because the struct stores `Bool`, not `Bool?`.
+        XCTAssertTrue(ctx.isExpensive == true || ctx.isExpensive == false)
+        XCTAssertTrue(ctx.isConstrained == true || ctx.isConstrained == false)
+        // interface is optional but, when present, must be a
+        // non-empty string (NWInterface.name is a non-optional String).
+        if let iface = ctx.interface {
+            XCTAssertFalse(iface.isEmpty)
+        }
+    }
+}

--- a/Tests/EdgeRumTests/PowerContextTests.swift
+++ b/Tests/EdgeRumTests/PowerContextTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import EdgeRum
+@testable import EdgeRumCore
+
+/// Unit tests for `PowerContext` — F16/T16.1's thermal state +
+/// low-power-mode capture.
+///
+/// Refs: PLAN-iOS.md §16.4 / F16 / T16.1; docs/data-flow.md §3.2.
+final class PowerContextTests: XCTestCase {
+
+    // MARK: write(into:)
+
+    func testWriteEmitsBothKeysWhenPresent() {
+        let ctx = PowerContext(thermalState: "fair", lowPowerMode: true)
+        var bag = AttributeBag()
+        ctx.write(into: &bag)
+        XCTAssertEqual(bag["device.thermal_state"], .string("fair"))
+        XCTAssertEqual(bag["device.low_power_mode"], .bool(true))
+        XCTAssertEqual(bag.count, 2)
+    }
+
+    func testWriteOmitsBothKeysWhenNil() {
+        let ctx = PowerContext()
+        var bag = AttributeBag()
+        ctx.write(into: &bag)
+        XCTAssertNil(bag["device.thermal_state"])
+        XCTAssertNil(bag["device.low_power_mode"])
+        XCTAssertEqual(bag.count, 0)
+    }
+
+    func testWriteEmitsOnlyThermalWhenLowPowerNil() {
+        let ctx = PowerContext(thermalState: "critical", lowPowerMode: nil)
+        var bag = AttributeBag()
+        ctx.write(into: &bag)
+        XCTAssertEqual(bag["device.thermal_state"], .string("critical"))
+        XCTAssertNil(bag["device.low_power_mode"])
+    }
+
+    // MARK: thermalStateString mapping
+
+    func testThermalStateMappingNominal() {
+        XCTAssertEqual(PowerContext.thermalStateString(.nominal), "nominal")
+    }
+
+    func testThermalStateMappingFair() {
+        XCTAssertEqual(PowerContext.thermalStateString(.fair), "fair")
+    }
+
+    func testThermalStateMappingSerious() {
+        XCTAssertEqual(PowerContext.thermalStateString(.serious), "serious")
+    }
+
+    func testThermalStateMappingCritical() {
+        XCTAssertEqual(PowerContext.thermalStateString(.critical), "critical")
+    }
+
+    // MARK: snapshot()
+
+    func testSnapshotPopulatesThermalState() {
+        let ctx = PowerContext.snapshot()
+        XCTAssertNotNil(ctx.thermalState)
+        // The host process is almost certainly nominal under XCTest,
+        // but we accept any of the four documented values to avoid
+        // CI flakes if a runner happens to be hot.
+        let allowed: Set<String> = ["nominal", "fair", "serious", "critical"]
+        XCTAssertTrue(allowed.contains(ctx.thermalState ?? ""),
+                      "thermal_state must be one of \(allowed), got \(String(describing: ctx.thermalState))")
+    }
+
+    func testSnapshotProducesBoolForLowPowerOnAvailablePlatforms() {
+        let ctx = PowerContext.snapshot()
+        // On iOS / macOS 12+ we expect a bool; pre-macOS-12 builds may
+        // surface nil. We allow either to keep the suite green on the
+        // package's macOS 11 floor while still asserting "Bool when
+        // present" on iOS.
+        #if os(iOS)
+        XCTAssertNotNil(ctx.lowPowerMode)
+        #else
+        if #available(macOS 12.0, *) {
+            XCTAssertNotNil(ctx.lowPowerMode)
+        }
+        #endif
+    }
+}

--- a/Tests/EdgeRumTests/StorageContextTests.swift
+++ b/Tests/EdgeRumTests/StorageContextTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import EdgeRum
+@testable import EdgeRumCore
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Unit tests for `StorageContext` — F16/T16.4's disk capacity +
+/// background-refresh capture.
+///
+/// Refs: PLAN-iOS.md §16.4 / F16 / T16.4; docs/data-flow.md §3.1, §3.2.
+final class StorageContextTests: XCTestCase {
+
+    // MARK: write(into:)
+
+    func testWriteEmitsAllThreeKeysWhenPresent() {
+        let ctx = StorageContext(
+            diskFreeMb: 10_000,
+            diskTotalMb: 128_000,
+            backgroundRefresh: "available"
+        )
+        var bag = AttributeBag()
+        ctx.write(into: &bag)
+        XCTAssertEqual(bag["device.disk_free_mb"], .int(10_000))
+        XCTAssertEqual(bag["device.disk_total_mb"], .int(128_000))
+        XCTAssertEqual(bag["app.background_refresh"], .string("available"))
+        XCTAssertEqual(bag.count, 3)
+    }
+
+    func testWriteOmitsKeysWhenNil() {
+        let ctx = StorageContext()
+        var bag = AttributeBag()
+        ctx.write(into: &bag)
+        XCTAssertTrue(bag.isEmpty)
+    }
+
+    // MARK: readDiskMB
+
+    func testReadDiskMBProducesPositiveValuesOnTestHost() throws {
+        let (free, total) = StorageContext.readDiskMB()
+        let f = try XCTUnwrap(free, "free disk must be readable on the test host")
+        let t = try XCTUnwrap(total, "total disk must be readable on the test host")
+        XCTAssertGreaterThan(f, 0)
+        XCTAssertGreaterThan(t, 0)
+        XCTAssertLessThanOrEqual(f, t)
+    }
+
+    /// PLAN-iOS.md §16.4 / T16.4 acceptance: free-disk MB must match
+    /// `df -k` ±5%. We use `statvfs` (which `df` itself calls) so the
+    /// only delta is the time-of-read drift between the two
+    /// invocations; the 5% tolerance is generous on any realistic
+    /// CI host.
+    func testReadDiskMBMatchesStatfsWithinFivePercent() throws {
+        // `statfs` is the cross-platform interface that both
+        // `FileManager.attributesOfFileSystem` and the `df` CLI use.
+        // We compare our snapshot to a direct `statfs` reading from
+        // the same path so the test stays hermetic — no shell out.
+        var fsStats = statfs()
+        let result = statfs(NSHomeDirectory(), &fsStats)
+        try XCTSkipUnless(result == 0, "statfs failed; skip")
+        let blockSize = UInt64(fsStats.f_bsize)
+        let freeBlocks = UInt64(fsStats.f_bavail)
+        let referenceFreeMb = Int((blockSize * freeBlocks) / 1_048_576)
+
+        let (free, _) = StorageContext.readDiskMB()
+        let snapshotMb = try XCTUnwrap(free)
+
+        let tolerance = max(Double(referenceFreeMb) * 0.05, 16.0)  // 16 MB floor
+        let delta = abs(Double(snapshotMb - referenceFreeMb))
+        XCTAssertLessThan(
+            delta, tolerance,
+            "Snapshot \(snapshotMb) MB drifted from statfs \(referenceFreeMb) MB by \(delta) MB (tolerance \(tolerance))"
+        )
+    }
+
+    // MARK: backgroundRefreshString mapping
+
+    #if canImport(UIKit)
+    func testBackgroundRefreshMappingAvailable() {
+        XCTAssertEqual(StorageContext.backgroundRefreshString(.available), "available")
+    }
+
+    func testBackgroundRefreshMappingDenied() {
+        XCTAssertEqual(StorageContext.backgroundRefreshString(.denied), "denied")
+    }
+
+    func testBackgroundRefreshMappingRestricted() {
+        XCTAssertEqual(StorageContext.backgroundRefreshString(.restricted), "restricted")
+    }
+    #endif
+
+    // MARK: snapshot()
+
+    func testSnapshotProducesPositiveDiskValues() {
+        let ctx = StorageContext.snapshot()
+        XCTAssertNotNil(ctx.diskFreeMb)
+        XCTAssertNotNil(ctx.diskTotalMb)
+        if let f = ctx.diskFreeMb { XCTAssertGreaterThan(f, 0) }
+        if let t = ctx.diskTotalMb { XCTAssertGreaterThan(t, 0) }
+    }
+}

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1130,3 +1130,91 @@ background scheduler, using public APIs only (T15.2 — no
   dashboards do not double-count `cause = "Hang"` rows as fatal
   crashes. Backend should segment by `cause` (the two ride under
   the same `eventName = "app.crash"`).
+
+## ADR-012 — F16 context-enrichment observers live in `EdgeRumCore`, not `EdgeRumCapture`
+
+**Date:** 2026-06-17
+
+**Status:** Accepted.
+
+**Context.** F16 adds 16 new identity attributes (`device.thermal_state`,
+`device.low_power_mode`, the five `device.*` accessibility flags,
+`device.locale`/`timezone`/`timezone_offset_min`,
+`device.disk_free_mb`/`disk_total_mb`, `app.background_refresh`, and
+`network.expensive`/`constrained`/`interface`). Three new context
+structs (`PowerContext`, `AccessibilityContext`, `StorageContext`)
+join the existing identity groups merged by `ContextProvider`.
+
+Each new attribute must be refreshed when its underlying source
+changes — `ProcessInfo` thermal/power state notifications,
+`UIAccessibility.*DidChangeNotification` toggles, `NSLocale`'s region
+change, and a periodic disk-capacity poll. Two homes for those
+observers were viable:
+
+1. `Sources/EdgeRumCapture/ContextObservers.swift` — alongside the
+   existing F11 `LifecycleCapture` / `NetworkPathCapture` swizzles
+   and notification hooks.
+2. `Sources/EdgeRumCore/Context/ContextObservers.swift` — alongside
+   the snapshots they refresh.
+
+**Decision.** Land `ContextObservers.swift` in `EdgeRumCore`.
+
+**Rationale.**
+
+1. The observers neither swizzle anything nor emit any events. Their
+   single side-effect is `ContextProvider.refresh*(_:)`. Capture
+   modules touch the public-event pipeline; these observers do not.
+2. Keeping the observers next to the structs they refresh shortens
+   the cognitive distance between "where the attribute is defined"
+   and "where it is refreshed". A future contributor extending
+   `AccessibilityContext` reads exactly two files.
+3. `EdgeRumCapture` already depends on `EdgeRumCore`, not the other
+   way around. Putting the observers in `Core` keeps the dependency
+   graph one-directional and lets `EdgeRumCore`'s own tests exercise
+   the install path without pulling in `EdgeRumCapture` as a test
+   dep.
+4. The `LifecycleCapture` install pattern (os_unfair_lock-guarded
+   `_installed` flag + token array + `#if DEBUG` reset helper) is
+   copied verbatim — there's no novel mechanism in this file, only a
+   different home.
+
+**Implementation notes.**
+
+- Always-on per `EdgeRumConfig` consensus; no new public toggle. The
+  attributes ride alongside existing identity keys (battery, screen,
+  network type) which are also unconditional.
+- Storage refresh uses `DispatchSource.makeTimerSource(queue:)` with
+  a 5-minute schedule mirroring `MemorySampler.swift:240`. Suspend
+  on `willResignActive`, resume on `didBecomeActive` so we don't run
+  `statfs` while the app is backgrounded.
+- Wire keys snake_case (`device.thermal_state`, `device.low_power_mode`,
+  `device.timezone_offset_min`) to match the pre-existing
+  `app.package_name` / `session.start_time` convention rather than
+  the camelCase `device.screenWidth` legacy.
+
+**Consequences.**
+
+- Five new files under `Sources/EdgeRumCore/Context/` —
+  `PowerContext.swift`, `AccessibilityContext.swift`,
+  `StorageContext.swift`, `ContextObservers.swift`, plus extensions
+  to `DeviceContext.swift` and `NetworkContext.swift`.
+- `ContextProvider` gains three stored properties + three refresh
+  hooks + three read accessors. Existing tests that pass partial
+  `init(...)` arguments still compile because every new parameter
+  defaults to an empty struct.
+- `Recorder` gains one public computed property,
+  `currentContextProvider`, so `EdgeRum.start(_:)` can pass the live
+  provider to `ContextObservers.install(provider:debug:)` without
+  threading it through the `Recording` protocol (which would force
+  every existing test probe to adopt the new requirement).
+- Six new test files under `Tests/EdgeRumTests/` plus one
+  `F16ContextEnrichmentConformanceTests.swift` in the contract
+  suite. Adds ~25 test cases; full suite stays at <6 s wall-clock.
+- No new `eventName`. No transport change. No public-surface change
+  visible to consumers — the attributes appear automatically on
+  every event emitted after `EdgeRum.start(_:)` is called.
+- Pre-existing test isolation bug surfaced: `NetworkPathCaptureTests`
+  had no `setUp` reset, and earlier tests (e.g. `EdgeRumAPITests`
+  via `EdgeRum.start → NetworkPathCapture.install`) left a stale
+  `lastFingerprint`. F16 adds a `setUp` reset to that class
+  symmetrically with its `tearDown`.


### PR DESCRIPTION
## Summary

Implements **F16 — context bag enrichment** by adding 16 v1.0+ identity attributes per `docs/data-flow.md` §3 across all five sub-tasks:

| Sub-task | Wire keys |
|----------|-----------|
| **T16.1** PowerContext | `device.thermal_state`, `device.low_power_mode` |
| **T16.2** AccessibilityContext | `device.dynamic_type`, `device.reduce_motion`, `device.bold_text`, `device.voiceover`, `device.increase_contrast` |
| **T16.3** NetworkContext extras | `network.expensive`, `network.constrained`, `network.interface` |
| **T16.4** StorageContext | `device.disk_free_mb`, `device.disk_total_mb`, `app.background_refresh` |
| **T16.5** Locale & timezone | `device.locale`, `device.timezone`, `device.timezone_offset_min` |

Three new context structs (`PowerContext`, `AccessibilityContext`, `StorageContext`) join the existing identity groups merged by `ContextProvider`; `DeviceContext` and `NetworkContext` are extended in-place for T16.5 and T16.3 respectively.

`ContextObservers.swift` (lives in `EdgeRumCore`, see ADR-012) wires idempotent `NotificationCenter` subscriptions for thermal/power-state changes, the five `UIAccessibility` flags, `UIContentSizeCategory.didChangeNotification`, and `NSLocale.currentLocaleDidChangeNotification`, plus a 5-minute `DispatchSource.makeTimerSource` for storage refresh (suspended on `willResignActive`, resumed on `didBecomeActive`). `EdgeRum.start(_:)` calls `ContextObservers.install` once the real `Recorder` is bound.

### Constraints honored

- **No new public API symbols.** The 16 attributes ride alongside existing identity keys on every event — host apps see them automatically.
- **No new `eventName`.** Pure context enrichment.
- **No transport change.** Same `telemetry_batch` envelope, same `application/json` `X-API-Key` POST.
- **Wire shape preserved.** All new attributes are flat primitives; `WireAssertions` and the firewall check both stay clean.

## Test plan

- [x] `swift build` clean for `iphoneos` + macOS test host
- [x] `swift test` — **all 495 tests pass** (added 6 new test files + extended `ContextProviderTests`)
  - [x] `PowerContextTests` — write/snapshot + 4-case thermal mapping
  - [x] `AccessibilityContextTests` — write/snapshot + 12-case dynamic-type mapping + off-main-thread snapshot
  - [x] `StorageContextTests` — write/snapshot + 3-case refresh-status mapping + **`statfs` ±5% acceptance** for T16.4
  - [x] `NetworkContextExtrasTests` — write + extras-from-NWPath
  - [x] `DeviceContextLocaleTests` — write/snapshot + offset-range sanity
  - [x] `ContextObserversTests` — idempotency, seed-on-install, reset
  - [x] `F16ContextEnrichmentConformanceTests` (contract) — all 16 keys present on a real envelope; primitives-only sweep
  - [x] `ContextProviderTests` — extended for `refreshPower`/`refreshAccessibility`/`refreshStorage`
- [x] `Tools/firewall-check.sh` — public surface and consumer docs clean
- [ ] Manual simulator acceptance for the five sub-tasks:
  - [ ] **T16.1** Settings → Battery → Low Power Mode toggle flips `device.low_power_mode` on next event
  - [ ] **T16.2** Settings → Accessibility → VoiceOver toggle flips `device.voiceover` on next event
  - [ ] **T16.3** Personal hotspot on real device — `network.expensive = true` after connection
  - [ ] **T16.4** `df -k` on host parallels `device.disk_free_mb` ±5% (unit test covers this on CI)
  - [ ] **T16.5** Settings → General → Language & Region change reflects in `device.locale` on next event
- [x] Pre-existing test-isolation flake in `NetworkPathCaptureTests` patched (`setUp` reset added symmetrically with `tearDown`)

## Refs

- PLAN-iOS.md §16.4 / F16
- docs/data-flow.md §3
- docs/decisions.md ADR-012 (new — explains why `ContextObservers` lives in `EdgeRumCore`)

Closes #21
Closes #79
Closes #80
Closes #81
Closes #82
Closes #83