### PR TITLE
feat(F17): URLSession metrics enrichment — TLS, redirects, multi-transaction

### DIFF
--- a/PLAN-iOS.md
+++ b/PLAN-iOS.md
@@ -1498,6 +1498,20 @@ iPhone SE 2, one iPhone 11, one iPhone 15 Pro). Results posted to
 10. **`device.batteryLevel = -1.0`** when battery monitoring is off
     (simulator). Forwarded as-is.
 
+11. **F17 `resource_timing` key rename.** The iOS SDK was previously
+    emitting `resource.response_ms` (undocumented). F17 renames the
+    key to `resource.download_ms` to match `docs/data-flow.md` § 10.2,
+    the Android SDK wire shape, and the example payload. The
+    derivation (`responseStartDate → responseEndDate`) is unchanged.
+    Confirm no internal dashboards or alerts are keyed on the old
+    name; if any are, coordinate the cutover before merge. See
+    ADR-013.
+
+12. **F17 `http.cellular_fallback` semantics.** Computed as
+    `isMultipath && isCellular` on the last transaction (iOS 17+
+    only). Confirm this matches the Android SDK's definition of
+    "cellular fallback under multipath".
+
 ---
 
 ## 15. Risks and open questions

--- a/Sources/EdgeRumCapture/HTTPCapture.swift
+++ b/Sources/EdgeRumCapture/HTTPCapture.swift
@@ -43,6 +43,7 @@
 
 import Foundation
 import os.log
+import Security
 #if canImport(EdgeRumCore)
 import EdgeRumCore
 #endif
@@ -258,6 +259,39 @@ public enum HTTPCapture {
         recorder: Recording? = nil,
         config: HTTPCaptureConfig? = nil
     ) {
+        let view = metrics.map { MetricsView(from: $0) }
+        recordOutcomeWithView(
+            request: request,
+            response: response,
+            data: data,
+            view: view,
+            error: error,
+            startedAt: startedAt,
+            finishedAt: finishedAt,
+            taskDescription: taskDescription,
+            recorder: recorder,
+            config: config
+        )
+    }
+
+    /// Same pipeline as `recordOutcome` but takes the decomposed metrics
+    /// view directly. The production path goes via `recordOutcome` (which
+    /// wraps `URLSessionTaskMetrics`); tests drive this entry with a
+    /// `FakeTransactionMetrics` fixture so they can exercise multi-
+    /// transaction / TLS / cellular-fallback code paths without being
+    /// able to construct the framework-internal class. See ADR-013.
+    internal static func recordOutcomeWithView(
+        request: URLRequest,
+        response: URLResponse?,
+        data: Data?,
+        view: MetricsView?,
+        error: Error?,
+        startedAt: Date,
+        finishedAt: Date,
+        taskDescription: String?,
+        recorder: Recording? = nil,
+        config: HTTPCaptureConfig? = nil
+    ) {
         let liveRecorder = recorder ?? Recorder.shared
         guard liveRecorder.isEnabled else { return }
 
@@ -290,12 +324,12 @@ public enum HTTPCapture {
         if let http = response as? HTTPURLResponse {
             statusCode = http.statusCode
         }
-        if let metrics, let last = metrics.transactionMetrics.last {
+        if let last = view?.transactions.last {
             fromCache = last.resourceFetchType == .localCache
         }
 
-        let requestSize = computeRequestBytes(request, metrics: metrics)
-        let responseSize = computeResponseBytes(data: data, response: response, metrics: metrics)
+        let requestSize = computeRequestBytes(request, view: view)
+        let responseSize = computeResponseBytes(data: data, response: response, view: view)
 
         var attrs: [String: AttributeValue] = [
             "http.method": .string(method),
@@ -311,10 +345,11 @@ public enum HTTPCapture {
         if let error {
             attrs["http.error"] = .string(String(describing: error))
         }
+        applyHTTPMetricsEnrichment(into: &attrs, view: view)
 
         liveRecorder.recordEvent(name: "http.request", attributes: attrs)
 
-        if let metrics, let timing = ResourceTiming.from(metrics: metrics) {
+        if let view, let timing = ResourceTiming.from(view: view) {
             var metricAttrs: [String: AttributeValue] = [
                 "resource.url": .string(urlString),
                 "resource.host": .string(host),
@@ -322,10 +357,135 @@ public enum HTTPCapture {
                 "resource.connect_ms": .int(timing.connectMs),
                 "resource.tls_ms": .int(timing.tlsMs),
                 "resource.ttfb_ms": .int(timing.ttfbMs),
-                "resource.response_ms": .int(timing.responseMs)
+                "resource.download_ms": .int(timing.downloadMs),
+                "resource.redirect_count": .int(view.redirectCount),
+                "resource.transaction_count": .int(view.transactions.count)
             ]
+            if let totalMs = view.fetchStartToResponseEndMs {
+                metricAttrs["resource.fetch_start_to_response_end_ms"] = .int(totalMs)
+            }
+            if let proto = view.transactions.last.flatMap({ networkProtocolNormalised($0.networkProtocolName) }) {
+                metricAttrs["resource.protocol"] = .string(proto)
+            }
             metricAttrs["value"] = .double(Double(durationMs))
             liveRecorder.recordPerformance(name: "resource_timing", attributes: metricAttrs)
+        }
+    }
+
+    // MARK: F17 enrichment — http.request
+
+    /// Adds the F17 URLSession-metrics-derived attributes to the
+    /// `http.request` event. All TLS / connection fields come from the
+    /// LAST transaction (the response-delivering one); body-bytes-before-
+    /// encoding sums across all transactions.
+    ///
+    /// Each attribute is conditional: when the underlying field is nil or
+    /// the connection wasn't encrypted (TLS fields), the key is omitted
+    /// entirely — matching the pattern used for `http.error`.
+    internal static func applyHTTPMetricsEnrichment(
+        into attrs: inout [String: AttributeValue],
+        view: MetricsView?
+    ) {
+        guard let view else { return }
+
+        attrs["http.redirect_count"] = .int(view.redirectCount)
+
+        guard let last = view.transactions.last else { return }
+
+        if let tlsProtocol = tlsProtocolName(last.negotiatedTLSProtocolVersion) {
+            attrs["http.tls_protocol"] = .string(tlsProtocol)
+        }
+        if let tlsCipher = tlsCipherName(last.negotiatedTLSCipherSuite) {
+            attrs["http.tls_cipher"] = .string(tlsCipher)
+        }
+        attrs["http.reused_connection"] = .bool(last.isReusedConnection)
+        attrs["http.proxy_connection"] = .bool(last.isProxyConnection)
+        if let proto = networkProtocolNormalised(last.networkProtocolName) {
+            attrs["http.network_protocol"] = .string(proto)
+        }
+
+        let bytesBefore = view.transactions.reduce(Int64(0)) { acc, txn in
+            acc + max(0, txn.countOfRequestBodyBytesBeforeEncoding)
+        }
+        attrs["http.request_body_bytes_before_encoding"] = .int(Int(bytesBefore))
+
+        // T17.2: iOS 17+ multipath/cellular fallback. PLAN-iOS.md §16.4
+        // pins this to iOS 17+ even though `isMultipath` / `isCellular`
+        // exist since iOS 13 — keep the gate per the documented contract.
+        if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
+            attrs["http.cellular_fallback"] = .bool(last.isMultipath && last.isCellular)
+        }
+    }
+
+    // MARK: F17 mapping helpers
+
+    /// Map an Apple `tls_protocol_version_t` raw value to the wire string
+    /// shape (`"1.0"`, `"1.1"`, `"1.2"`, `"1.3"`). Returns nil when the
+    /// transaction was not encrypted (input nil) or when the value is
+    /// unrecognised — keeps the key absent rather than emitting a bogus
+    /// value the backend can't filter on.
+    internal static func tlsProtocolName(_ value: tls_protocol_version_t?) -> String? {
+        guard let value else { return nil }
+        switch value.rawValue {
+        case 0x0301: return "1.0"
+        case 0x0302: return "1.1"
+        case 0x0303: return "1.2"
+        case 0x0304: return "1.3"
+        default: return nil
+        }
+    }
+
+    /// Map an Apple `tls_ciphersuite_t` raw value to the IANA cipher-suite
+    /// name. Covers the suites Apple's TLS stack actually negotiates on
+    /// iOS 14+; unknown values fall back to a hex string so the key is
+    /// always present when TLS is.
+    internal static func tlsCipherName(_ value: tls_ciphersuite_t?) -> String? {
+        guard let value else { return nil }
+        let raw = value.rawValue
+        switch raw {
+        // TLS 1.3 suites
+        case 0x1301: return "TLS_AES_128_GCM_SHA256"
+        case 0x1302: return "TLS_AES_256_GCM_SHA384"
+        case 0x1303: return "TLS_CHACHA20_POLY1305_SHA256"
+        // TLS 1.2 ECDHE-ECDSA
+        case 0xC02B: return "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+        case 0xC02C: return "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+        case 0xCCA9: return "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
+        case 0xC023: return "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256"
+        case 0xC024: return "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384"
+        case 0xC009: return "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA"
+        case 0xC00A: return "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA"
+        // TLS 1.2 ECDHE-RSA
+        case 0xC02F: return "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+        case 0xC030: return "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+        case 0xCCA8: return "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+        case 0xC027: return "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+        case 0xC028: return "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384"
+        case 0xC013: return "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
+        case 0xC014: return "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
+        // Static RSA (legacy)
+        case 0x009C: return "TLS_RSA_WITH_AES_128_GCM_SHA256"
+        case 0x009D: return "TLS_RSA_WITH_AES_256_GCM_SHA384"
+        case 0x002F: return "TLS_RSA_WITH_AES_128_CBC_SHA"
+        case 0x0035: return "TLS_RSA_WITH_AES_256_CBC_SHA"
+        default:
+            return String(format: "0x%04x", raw)
+        }
+    }
+
+    /// Normalise the ALPN protocol identifier to the wire shape used on
+    /// `http.network_protocol` / `resource.protocol`. ALPN ids are
+    /// lowercase per RFC 7301 (e.g. `h2`, `h3`, `http/1.1`); we collapse
+    /// `http/1.1` to `h1.1` for parity with the Android SDK. Returns nil
+    /// when no protocol was negotiated (e.g. cached / local resource).
+    internal static func networkProtocolNormalised(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        let lower = value.lowercased()
+        switch lower {
+        case "h2", "h3": return lower
+        case "http/1.1", "h1.1": return "h1.1"
+        case "http/1.0": return "h1.0"
+        default: return lower
         }
     }
 
@@ -333,11 +493,11 @@ public enum HTTPCapture {
 
     private static func computeRequestBytes(
         _ request: URLRequest,
-        metrics: URLSessionTaskMetrics?
+        view: MetricsView?
     ) -> Int64 {
-        if let metrics {
-            let total = metrics.transactionMetrics.reduce(Int64(0)) { acc, txn in
-                acc + Int64(txn.countOfRequestHeaderBytesSent) + Int64(txn.countOfRequestBodyBytesSent)
+        if let view {
+            let total = view.transactions.reduce(Int64(0)) { acc, txn in
+                acc + max(0, txn.countOfRequestHeaderBytesSent) + max(0, txn.countOfRequestBodyBytesSent)
             }
             if total > 0 { return total }
         }
@@ -350,11 +510,11 @@ public enum HTTPCapture {
     private static func computeResponseBytes(
         data: Data?,
         response: URLResponse?,
-        metrics: URLSessionTaskMetrics?
+        view: MetricsView?
     ) -> Int64 {
-        if let metrics {
-            let total = metrics.transactionMetrics.reduce(Int64(0)) { acc, txn in
-                acc + Int64(txn.countOfResponseHeaderBytesReceived) + Int64(txn.countOfResponseBodyBytesReceived)
+        if let view {
+            let total = view.transactions.reduce(Int64(0)) { acc, txn in
+                acc + max(0, txn.countOfResponseHeaderBytesReceived) + max(0, txn.countOfResponseBodyBytesReceived)
             }
             if total > 0 { return total }
         }
@@ -397,6 +557,80 @@ public enum HTTPCapture {
     #endif
 }
 
+// MARK: - Transaction metrics protocol seam (F17)
+
+/// Internal protocol mirroring the subset of
+/// `URLSessionTaskTransactionMetrics` fields F17 reads. Apple's class is
+/// framework-internal and cannot be subclassed or constructed in tests
+/// since iOS 13 deprecated its `init`. Tests substitute a struct
+/// (`FakeTransactionMetrics`) conforming to this protocol so the
+/// enrichment + derivation logic is exercised without network IO.
+///
+/// Mirror of the relevant public properties verified against the SDK
+/// header (`NSURLSession.h` in the iPhoneOS SDK).
+internal protocol TransactionMetricsLike {
+    var domainLookupStartDate: Date? { get }
+    var domainLookupEndDate: Date? { get }
+    var connectStartDate: Date? { get }
+    var connectEndDate: Date? { get }
+    var secureConnectionStartDate: Date? { get }
+    var secureConnectionEndDate: Date? { get }
+    var requestEndDate: Date? { get }
+    var responseStartDate: Date? { get }
+    var responseEndDate: Date? { get }
+    var fetchStartDate: Date? { get }
+
+    var countOfRequestHeaderBytesSent: Int64 { get }
+    var countOfRequestBodyBytesSent: Int64 { get }
+    var countOfRequestBodyBytesBeforeEncoding: Int64 { get }
+    var countOfResponseHeaderBytesReceived: Int64 { get }
+    var countOfResponseBodyBytesReceived: Int64 { get }
+
+    var negotiatedTLSProtocolVersion: tls_protocol_version_t? { get }
+    var negotiatedTLSCipherSuite: tls_ciphersuite_t? { get }
+    var isReusedConnection: Bool { get }
+    var isProxyConnection: Bool { get }
+    var networkProtocolName: String? { get }
+    var resourceFetchType: URLSessionTaskMetrics.ResourceFetchType { get }
+    var isMultipath: Bool { get }
+    var isCellular: Bool { get }
+}
+
+// Real Foundation type already exposes every property above with the
+// same name + type. Empty conformance is sufficient.
+extension URLSessionTaskTransactionMetrics: TransactionMetricsLike {}
+
+/// Aggregated view of `URLSessionTaskMetrics` decomposed into the fields
+/// F17 reads. Lets the recording sink + ResourceTiming derivation work
+/// against test fixtures and the real Foundation type uniformly.
+internal struct MetricsView {
+    let redirectCount: Int
+    let transactions: [TransactionMetricsLike]
+
+    init(redirectCount: Int, transactions: [TransactionMetricsLike]) {
+        self.redirectCount = redirectCount
+        self.transactions = transactions
+    }
+
+    init(from metrics: URLSessionTaskMetrics) {
+        self.redirectCount = metrics.redirectCount
+        self.transactions = metrics.transactionMetrics.map { $0 as TransactionMetricsLike }
+    }
+
+    /// First-transaction `fetchStartDate` → last-transaction
+    /// `responseEndDate`. Drives `resource.fetch_start_to_response_end_ms`
+    /// (T17.3 — total wall-clock across the redirect chain). Returns nil
+    /// when either bookend date is missing.
+    var fetchStartToResponseEndMs: Int? {
+        guard
+            let first = transactions.first?.fetchStartDate,
+            let end = transactions.last?.responseEndDate
+        else { return nil }
+        let delta = end.timeIntervalSince(first)
+        return Int(max(0, (delta * 1000.0).rounded()))
+    }
+}
+
 // MARK: - ResourceTiming derivation
 
 internal struct ResourceTiming {
@@ -404,23 +638,23 @@ internal struct ResourceTiming {
     let connectMs: Int
     let tlsMs: Int
     let ttfbMs: Int
-    let responseMs: Int
+    let downloadMs: Int
 
-    /// Derive timing from the LAST transaction metric (the one that
-    /// actually delivered the response). Returns `nil` when no
-    /// transaction is present.
-    static func from(metrics: URLSessionTaskMetrics) -> ResourceTiming? {
-        guard let txn = metrics.transactionMetrics.last else { return nil }
+    /// Derive timing from the LAST transaction (the one that actually
+    /// delivered the response). Returns nil when no transaction is
+    /// present.
+    static func from(view: MetricsView) -> ResourceTiming? {
+        guard let txn = view.transactions.last else { return nil }
         return ResourceTiming(
             dnsMs: msBetween(txn.domainLookupStartDate, txn.domainLookupEndDate),
             connectMs: msBetween(txn.connectStartDate, txn.connectEndDate),
             tlsMs: msBetween(txn.secureConnectionStartDate, txn.secureConnectionEndDate),
             ttfbMs: msBetween(txn.requestEndDate, txn.responseStartDate),
-            responseMs: msBetween(txn.responseStartDate, txn.responseEndDate)
+            downloadMs: msBetween(txn.responseStartDate, txn.responseEndDate)
         )
     }
 
-    private static func msBetween(_ start: Date?, _ end: Date?) -> Int {
+    internal static func msBetween(_ start: Date?, _ end: Date?) -> Int {
         guard let start, let end else { return 0 }
         let delta = end.timeIntervalSince(start)
         return Int(max(0, (delta * 1000.0).rounded()))

--- a/Tests/EdgeRumCaptureTests/HTTPCaptureTests.swift
+++ b/Tests/EdgeRumCaptureTests/HTTPCaptureTests.swift
@@ -27,6 +27,7 @@
 
 import XCTest
 import Foundation
+import Security
 import EdgeRumCore
 @testable import EdgeRumCapture
 
@@ -102,15 +103,47 @@ private final class CaptureProbeRecorder: Recording, @unchecked Sendable {
     func setUser(_ user: RecorderUser) { _ = user }
 }
 
-// MARK: - URLSessionTaskMetrics synthesis
+// MARK: - URLSessionTaskMetrics synthesis (F17 — ADR-013)
 //
-// We can't construct `URLSessionTaskTransactionMetrics` directly —
-// it's a framework-internal class. The acceptance criterion is
-// "synthesize timings that flow through `ResourceTiming.from(...)`",
-// so we test the `msBetween` helper plus `ResourceTiming` shape
-// directly, and exercise the full recordOutcome pipeline with
-// `metrics == nil` to verify the http.request event still fires
-// without a companion resource_timing.
+// `URLSessionTaskTransactionMetrics` is framework-internal and has had
+// a deprecated `init` since iOS 13 — we cannot construct or subclass
+// it. F17 introduces the `TransactionMetricsLike` protocol in
+// `HTTPCapture.swift` precisely to make the enrichment + timing logic
+// testable: production code passes a real `URLSessionTaskMetrics`,
+// tests pass a `FakeTransactionMetrics` array wrapped in
+// `MetricsView`.
+//
+// Both paths funnel into the same internal entry,
+// `HTTPCapture.recordOutcomeWithView(...)`, so test coverage of the
+// enrichment is structurally identical to the production code path.
+
+struct FakeTransactionMetrics: TransactionMetricsLike {
+    var domainLookupStartDate: Date?
+    var domainLookupEndDate: Date?
+    var connectStartDate: Date?
+    var connectEndDate: Date?
+    var secureConnectionStartDate: Date?
+    var secureConnectionEndDate: Date?
+    var requestEndDate: Date?
+    var responseStartDate: Date?
+    var responseEndDate: Date?
+    var fetchStartDate: Date?
+
+    var countOfRequestHeaderBytesSent: Int64 = 0
+    var countOfRequestBodyBytesSent: Int64 = 0
+    var countOfRequestBodyBytesBeforeEncoding: Int64 = 0
+    var countOfResponseHeaderBytesReceived: Int64 = 0
+    var countOfResponseBodyBytesReceived: Int64 = 0
+
+    var negotiatedTLSProtocolVersion: tls_protocol_version_t?
+    var negotiatedTLSCipherSuite: tls_ciphersuite_t?
+    var isReusedConnection: Bool = false
+    var isProxyConnection: Bool = false
+    var networkProtocolName: String?
+    var resourceFetchType: URLSessionTaskMetrics.ResourceFetchType = .networkLoad
+    var isMultipath: Bool = false
+    var isCellular: Bool = false
+}
 
 // MARK: - Tests
 
@@ -561,6 +594,412 @@ final class HTTPCaptureTests: XCTestCase {
             return false
         }.count
         XCTAssertEqual(metricCount, 0, "No resource_timing metric should fire without metrics input")
+    }
+
+    // MARK: F17 — TLS protocol mapping (T17.1)
+
+    func test_tlsProtocolName_mapsAllRecognisedVersions() {
+        XCTAssertEqual(
+            HTTPCapture.tlsProtocolName(tls_protocol_version_t(rawValue: 0x0301)),
+            "1.0"
+        )
+        XCTAssertEqual(
+            HTTPCapture.tlsProtocolName(tls_protocol_version_t(rawValue: 0x0302)),
+            "1.1"
+        )
+        XCTAssertEqual(
+            HTTPCapture.tlsProtocolName(tls_protocol_version_t(rawValue: 0x0303)),
+            "1.2"
+        )
+        XCTAssertEqual(
+            HTTPCapture.tlsProtocolName(tls_protocol_version_t(rawValue: 0x0304)),
+            "1.3"
+        )
+    }
+
+    func test_tlsProtocolName_returnsNilForNil() {
+        XCTAssertNil(HTTPCapture.tlsProtocolName(nil))
+    }
+
+    func test_tlsProtocolName_returnsNilForUnrecognisedRawValue() {
+        XCTAssertNil(
+            HTTPCapture.tlsProtocolName(tls_protocol_version_t(rawValue: 0xFFFF))
+        )
+    }
+
+    // MARK: F17 — TLS cipher suite mapping (T17.1)
+
+    func test_tlsCipherName_mapsTLS13Suites() {
+        XCTAssertEqual(
+            HTTPCapture.tlsCipherName(tls_ciphersuite_t(rawValue: 0x1301)),
+            "TLS_AES_128_GCM_SHA256"
+        )
+        XCTAssertEqual(
+            HTTPCapture.tlsCipherName(tls_ciphersuite_t(rawValue: 0x1302)),
+            "TLS_AES_256_GCM_SHA384"
+        )
+        XCTAssertEqual(
+            HTTPCapture.tlsCipherName(tls_ciphersuite_t(rawValue: 0x1303)),
+            "TLS_CHACHA20_POLY1305_SHA256"
+        )
+    }
+
+    func test_tlsCipherName_mapsCommonTLS12Suites() {
+        XCTAssertEqual(
+            HTTPCapture.tlsCipherName(tls_ciphersuite_t(rawValue: 0xC02F)),
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+        )
+        XCTAssertEqual(
+            HTTPCapture.tlsCipherName(tls_ciphersuite_t(rawValue: 0xC02B)),
+            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+        )
+        XCTAssertEqual(
+            HTTPCapture.tlsCipherName(tls_ciphersuite_t(rawValue: 0xCCA8)),
+            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+        )
+    }
+
+    func test_tlsCipherName_fallsBackToHexForUnknown() {
+        XCTAssertEqual(
+            HTTPCapture.tlsCipherName(tls_ciphersuite_t(rawValue: 0xABCD)),
+            "0xabcd"
+        )
+    }
+
+    func test_tlsCipherName_returnsNilForNil() {
+        XCTAssertNil(HTTPCapture.tlsCipherName(nil))
+    }
+
+    // MARK: F17 — networkProtocolNormalised (T17.1 + T17.3)
+
+    func test_networkProtocolNormalised_passesThroughH2H3() {
+        XCTAssertEqual(HTTPCapture.networkProtocolNormalised("h2"), "h2")
+        XCTAssertEqual(HTTPCapture.networkProtocolNormalised("h3"), "h3")
+    }
+
+    func test_networkProtocolNormalised_collapsesHTTP11() {
+        XCTAssertEqual(HTTPCapture.networkProtocolNormalised("http/1.1"), "h1.1")
+        XCTAssertEqual(HTTPCapture.networkProtocolNormalised("HTTP/1.1"), "h1.1")
+    }
+
+    func test_networkProtocolNormalised_collapsesHTTP10() {
+        XCTAssertEqual(HTTPCapture.networkProtocolNormalised("http/1.0"), "h1.0")
+    }
+
+    func test_networkProtocolNormalised_returnsNilForNilOrEmpty() {
+        XCTAssertNil(HTTPCapture.networkProtocolNormalised(nil))
+        XCTAssertNil(HTTPCapture.networkProtocolNormalised(""))
+    }
+
+    func test_networkProtocolNormalised_lowercasesUnknownToken() {
+        XCTAssertEqual(HTTPCapture.networkProtocolNormalised("SPDY/3"), "spdy/3")
+    }
+
+    // MARK: F17 — MetricsView.fetchStartToResponseEndMs (T17.3)
+
+    func test_metricsView_fetchStartToResponseEndMs_spansRedirectChain() {
+        let t0 = Date(timeIntervalSince1970: 1_700_000_000.0)
+        let txnA = FakeTransactionMetrics(
+            responseEndDate: t0.addingTimeInterval(0.150),
+            fetchStartDate: t0
+        )
+        let txnB = FakeTransactionMetrics(
+            responseEndDate: t0.addingTimeInterval(0.392),
+            fetchStartDate: t0.addingTimeInterval(0.160)
+        )
+        let view = MetricsView(redirectCount: 1, transactions: [txnA, txnB])
+        XCTAssertEqual(view.fetchStartToResponseEndMs, 392)
+    }
+
+    func test_metricsView_fetchStartToResponseEndMs_returnsNilWithoutBookends() {
+        let txn = FakeTransactionMetrics()
+        let view = MetricsView(redirectCount: 0, transactions: [txn])
+        XCTAssertNil(view.fetchStartToResponseEndMs)
+    }
+
+    func test_metricsView_fetchStartToResponseEndMs_clampsNegativeToZero() {
+        let t0 = Date(timeIntervalSince1970: 1_700_000_000.0)
+        let txn = FakeTransactionMetrics(
+            responseEndDate: t0,
+            fetchStartDate: t0.addingTimeInterval(0.5)
+        )
+        let view = MetricsView(redirectCount: 0, transactions: [txn])
+        XCTAssertEqual(view.fetchStartToResponseEndMs, 0)
+    }
+
+    // MARK: F17 — ResourceTiming.from(view:) (T17.3)
+
+    func test_resourceTiming_derivesAllFieldsFromLastTransaction() {
+        let t0 = Date(timeIntervalSince1970: 1_700_000_000.0)
+        let txn = FakeTransactionMetrics(
+            domainLookupStartDate: t0,
+            domainLookupEndDate: t0.addingTimeInterval(0.012),
+            connectStartDate: t0.addingTimeInterval(0.012),
+            connectEndDate: t0.addingTimeInterval(0.043),
+            secureConnectionStartDate: t0.addingTimeInterval(0.045),
+            secureConnectionEndDate: t0.addingTimeInterval(0.090),
+            requestEndDate: t0.addingTimeInterval(0.095),
+            responseStartDate: t0.addingTimeInterval(0.149),
+            responseEndDate: t0.addingTimeInterval(0.150)
+        )
+        let view = MetricsView(redirectCount: 0, transactions: [txn])
+        let timing = ResourceTiming.from(view: view)
+        XCTAssertNotNil(timing)
+        XCTAssertEqual(timing?.dnsMs, 12)
+        XCTAssertEqual(timing?.connectMs, 31)
+        XCTAssertEqual(timing?.tlsMs, 45)
+        XCTAssertEqual(timing?.ttfbMs, 54)
+        XCTAssertEqual(timing?.downloadMs, 1)
+    }
+
+    func test_resourceTiming_returnsNilForEmptyTransactions() {
+        let view = MetricsView(redirectCount: 0, transactions: [])
+        XCTAssertNil(ResourceTiming.from(view: view))
+    }
+
+    // MARK: F17 — recordOutcomeWithView end-to-end (T17.1 + T17.3)
+
+    func test_recordOutcomeWithView_emitsAllF17AttributesOnHTTPRequest() {
+        let url = URL(string: "https://api.example.com/v1/users")!
+        let request = URLRequest(url: url)
+        let response = HTTPURLResponse(
+            url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
+        )
+        let t0 = Date(timeIntervalSince1970: 1_700_000_000.0)
+        let txn = FakeTransactionMetrics(
+            domainLookupStartDate: t0,
+            domainLookupEndDate: t0.addingTimeInterval(0.011),
+            connectStartDate: t0.addingTimeInterval(0.011),
+            connectEndDate: t0.addingTimeInterval(0.049),
+            secureConnectionStartDate: t0.addingTimeInterval(0.050),
+            secureConnectionEndDate: t0.addingTimeInterval(0.097),
+            requestEndDate: t0.addingTimeInterval(0.100),
+            responseStartDate: t0.addingTimeInterval(0.296),
+            responseEndDate: t0.addingTimeInterval(0.346),
+            fetchStartDate: t0,
+            countOfRequestBodyBytesBeforeEncoding: 128,
+            negotiatedTLSProtocolVersion: tls_protocol_version_t(rawValue: 0x0304),
+            negotiatedTLSCipherSuite: tls_ciphersuite_t(rawValue: 0x1301),
+            isReusedConnection: true,
+            isProxyConnection: false,
+            networkProtocolName: "h2"
+        )
+        let view = MetricsView(redirectCount: 0, transactions: [txn])
+
+        HTTPCapture.recordOutcomeWithView(
+            request: request,
+            response: response,
+            data: Data(count: 1234),
+            view: view,
+            error: nil,
+            startedAt: t0,
+            finishedAt: t0.addingTimeInterval(0.346),
+            taskDescription: nil,
+            recorder: probe,
+            config: HTTPCaptureConfig()
+        )
+
+        XCTAssertEqual(probe.calls.count, 2)
+        guard case .event(let evName, let evAttrs) = probe.calls[0] else {
+            XCTFail("Expected event"); return
+        }
+        XCTAssertEqual(evName, "http.request")
+        XCTAssertEqual(evAttrs["http.redirect_count"], .int(0))
+        XCTAssertEqual(evAttrs["http.tls_protocol"], .string("1.3"))
+        XCTAssertEqual(evAttrs["http.tls_cipher"], .string("TLS_AES_128_GCM_SHA256"))
+        XCTAssertEqual(evAttrs["http.reused_connection"], .bool(true))
+        XCTAssertEqual(evAttrs["http.proxy_connection"], .bool(false))
+        XCTAssertEqual(evAttrs["http.network_protocol"], .string("h2"))
+        XCTAssertEqual(evAttrs["http.request_body_bytes_before_encoding"], .int(128))
+
+        guard case .performance(let metricName, let metricAttrs) = probe.calls[1] else {
+            XCTFail("Expected performance"); return
+        }
+        XCTAssertEqual(metricName, "resource_timing")
+        XCTAssertEqual(metricAttrs["resource.dns_ms"], .int(11))
+        XCTAssertEqual(metricAttrs["resource.download_ms"], .int(50))
+        XCTAssertEqual(metricAttrs["resource.redirect_count"], .int(0))
+        XCTAssertEqual(metricAttrs["resource.transaction_count"], .int(1))
+        XCTAssertEqual(metricAttrs["resource.fetch_start_to_response_end_ms"], .int(346))
+        XCTAssertEqual(metricAttrs["resource.protocol"], .string("h2"))
+        XCTAssertNil(metricAttrs["resource.response_ms"], "F17 renamed response_ms → download_ms")
+    }
+
+    func test_recordOutcomeWithView_emitsMultiTransactionCountsForRedirectChain() {
+        let url = URL(string: "https://api.example.com/u")!
+        let request = URLRequest(url: url)
+        let response = HTTPURLResponse(
+            url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
+        )
+        let t0 = Date(timeIntervalSince1970: 1_700_000_000.0)
+        let redirect = FakeTransactionMetrics(
+            domainLookupStartDate: t0,
+            domainLookupEndDate: t0.addingTimeInterval(0.005),
+            responseEndDate: t0.addingTimeInterval(0.080),
+            fetchStartDate: t0,
+            countOfRequestBodyBytesBeforeEncoding: 32,
+            networkProtocolName: "http/1.1"
+        )
+        let final = FakeTransactionMetrics(
+            domainLookupStartDate: t0.addingTimeInterval(0.080),
+            domainLookupEndDate: t0.addingTimeInterval(0.090),
+            requestEndDate: t0.addingTimeInterval(0.100),
+            responseStartDate: t0.addingTimeInterval(0.250),
+            responseEndDate: t0.addingTimeInterval(0.300),
+            fetchStartDate: t0.addingTimeInterval(0.080),
+            countOfRequestBodyBytesBeforeEncoding: 32,
+            isReusedConnection: false,
+            networkProtocolName: "h2"
+        )
+        let view = MetricsView(redirectCount: 1, transactions: [redirect, final])
+
+        HTTPCapture.recordOutcomeWithView(
+            request: request,
+            response: response,
+            data: nil,
+            view: view,
+            error: nil,
+            startedAt: t0,
+            finishedAt: t0.addingTimeInterval(0.300),
+            taskDescription: nil,
+            recorder: probe,
+            config: HTTPCaptureConfig()
+        )
+
+        guard case .event(_, let evAttrs) = probe.calls[0] else {
+            XCTFail("Expected event"); return
+        }
+        XCTAssertEqual(evAttrs["http.redirect_count"], .int(1))
+        XCTAssertEqual(
+            evAttrs["http.request_body_bytes_before_encoding"], .int(64),
+            "Summed across both transactions"
+        )
+        // Final transaction wins for TLS/connection state.
+        XCTAssertEqual(evAttrs["http.network_protocol"], .string("h2"))
+
+        guard case .performance(_, let metricAttrs) = probe.calls[1] else {
+            XCTFail("Expected performance"); return
+        }
+        XCTAssertEqual(metricAttrs["resource.redirect_count"], .int(1))
+        XCTAssertEqual(metricAttrs["resource.transaction_count"], .int(2))
+        XCTAssertEqual(metricAttrs["resource.fetch_start_to_response_end_ms"], .int(300))
+    }
+
+    func test_recordOutcomeWithView_omitsTLSAttributesForCleartextConnection() {
+        let url = URL(string: "http://internal.example.com/u")!
+        let request = URLRequest(url: url)
+        let response = HTTPURLResponse(
+            url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
+        )
+        let t0 = Date(timeIntervalSince1970: 1_700_000_000.0)
+        let txn = FakeTransactionMetrics(
+            requestEndDate: t0.addingTimeInterval(0.05),
+            responseStartDate: t0.addingTimeInterval(0.15),
+            responseEndDate: t0.addingTimeInterval(0.16),
+            fetchStartDate: t0,
+            networkProtocolName: "http/1.1"
+        )
+        let view = MetricsView(redirectCount: 0, transactions: [txn])
+
+        HTTPCapture.recordOutcomeWithView(
+            request: request,
+            response: response,
+            data: nil,
+            view: view,
+            error: nil,
+            startedAt: t0,
+            finishedAt: t0.addingTimeInterval(0.16),
+            taskDescription: nil,
+            recorder: probe,
+            config: HTTPCaptureConfig()
+        )
+
+        guard case .event(_, let evAttrs) = probe.calls[0] else {
+            XCTFail("Expected event"); return
+        }
+        XCTAssertNil(evAttrs["http.tls_protocol"], "TLS fields omitted for cleartext HTTP")
+        XCTAssertNil(evAttrs["http.tls_cipher"])
+        // But network_protocol still present.
+        XCTAssertEqual(evAttrs["http.network_protocol"], .string("h1.1"))
+    }
+
+    // MARK: F17 — T17.2 cellular_fallback (iOS 17+)
+
+    func test_recordOutcomeWithView_cellularFallbackPresentOnIOS17OrLater() {
+        let url = URL(string: "https://api.example.com/u")!
+        let request = URLRequest(url: url)
+        let response = HTTPURLResponse(
+            url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
+        )
+        let t0 = Date(timeIntervalSince1970: 1_700_000_000.0)
+        let txn = FakeTransactionMetrics(
+            fetchStartDate: t0,
+            negotiatedTLSProtocolVersion: tls_protocol_version_t(rawValue: 0x0304),
+            networkProtocolName: "h2",
+            isMultipath: true,
+            isCellular: true
+        )
+        let view = MetricsView(redirectCount: 0, transactions: [txn])
+
+        HTTPCapture.recordOutcomeWithView(
+            request: request,
+            response: response,
+            data: nil,
+            view: view,
+            error: nil,
+            startedAt: t0,
+            finishedAt: t0.addingTimeInterval(0.1),
+            taskDescription: nil,
+            recorder: probe,
+            config: HTTPCaptureConfig()
+        )
+
+        guard case .event(_, let evAttrs) = probe.calls[0] else {
+            XCTFail("Expected event"); return
+        }
+        if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
+            XCTAssertEqual(evAttrs["http.cellular_fallback"], .bool(true))
+        } else {
+            XCTAssertNil(evAttrs["http.cellular_fallback"])
+        }
+    }
+
+    func test_recordOutcomeWithView_cellularFallbackFalseWhenNotMultipathAndCellular() {
+        let url = URL(string: "https://api.example.com/u")!
+        let request = URLRequest(url: url)
+        let response = HTTPURLResponse(
+            url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
+        )
+        let t0 = Date(timeIntervalSince1970: 1_700_000_000.0)
+        let txn = FakeTransactionMetrics(
+            fetchStartDate: t0,
+            isMultipath: false,
+            isCellular: true
+        )
+        let view = MetricsView(redirectCount: 0, transactions: [txn])
+
+        HTTPCapture.recordOutcomeWithView(
+            request: request,
+            response: response,
+            data: nil,
+            view: view,
+            error: nil,
+            startedAt: t0,
+            finishedAt: t0.addingTimeInterval(0.1),
+            taskDescription: nil,
+            recorder: probe,
+            config: HTTPCaptureConfig()
+        )
+
+        guard case .event(_, let evAttrs) = probe.calls[0] else {
+            XCTFail("Expected event"); return
+        }
+        if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
+            XCTAssertEqual(
+                evAttrs["http.cellular_fallback"], .bool(false),
+                "False when not both multipath and cellular"
+            )
+        }
     }
 
     // MARK: configure() — round-trip

--- a/Tests/EdgeRumContractTests/HTTPCaptureWireConformanceTests.swift
+++ b/Tests/EdgeRumContractTests/HTTPCaptureWireConformanceTests.swift
@@ -44,6 +44,11 @@ final class HTTPCaptureWireConformanceTests: XCTestCase {
     /// PayloadBuilder → envelope and the resulting JSON satisfies the
     /// wire contract (outer envelope shape, identity attrs, primitives-
     /// only attribute values, no firewall-banned tokens).
+    ///
+    /// As of F17 the event carries TLS / connection enrichment in
+    /// addition to the F8 base attributes — this test exercises a
+    /// fully-enriched event so the contract assertion covers the v1.0
+    /// shape end-to-end.
     func testHTTPRequestProducesWireValidEvent() throws {
         let (recorder, sink) = makeRecorder()
 
@@ -56,7 +61,17 @@ final class HTTPCaptureWireConformanceTests: XCTestCase {
             "http.duration_ms": .int(143),
             "http.request_size": .int(0),
             "http.response_size": .int(1234),
-            "http.from_cache": .bool(false)
+            "http.from_cache": .bool(false),
+            // F17 enrichment (T17.1)
+            "http.redirect_count": .int(0),
+            "http.tls_protocol": .string("1.3"),
+            "http.tls_cipher": .string("TLS_AES_128_GCM_SHA256"),
+            "http.reused_connection": .bool(true),
+            "http.proxy_connection": .bool(false),
+            "http.network_protocol": .string("h2"),
+            "http.request_body_bytes_before_encoding": .int(0),
+            // F17 enrichment (T17.2)
+            "http.cellular_fallback": .bool(false)
         ])
         recorder.flush(reason: .manual)
 
@@ -77,6 +92,16 @@ final class HTTPCaptureWireConformanceTests: XCTestCase {
         XCTAssertEqual(attrs["http.status_code"] as? Int, 200)
         XCTAssertEqual(attrs["http.duration_ms"] as? Int, 143)
         XCTAssertEqual(attrs["http.from_cache"] as? Bool, false)
+
+        // F17: types survive the JSON roundtrip.
+        XCTAssertEqual(attrs["http.redirect_count"] as? Int, 0)
+        XCTAssertEqual(attrs["http.tls_protocol"] as? String, "1.3")
+        XCTAssertEqual(attrs["http.tls_cipher"] as? String, "TLS_AES_128_GCM_SHA256")
+        XCTAssertEqual(attrs["http.reused_connection"] as? Bool, true)
+        XCTAssertEqual(attrs["http.proxy_connection"] as? Bool, false)
+        XCTAssertEqual(attrs["http.network_protocol"] as? String, "h2")
+        XCTAssertEqual(attrs["http.request_body_bytes_before_encoding"] as? Int, 0)
+        XCTAssertEqual(attrs["http.cellular_fallback"] as? Bool, false)
     }
 
     /// `http.error` only appears on failure — the success-path event
@@ -105,8 +130,15 @@ final class HTTPCaptureWireConformanceTests: XCTestCase {
     }
 
     /// A captured `resource_timing` metric produces a wire-valid
-    /// metric envelope with all five `resource.*_ms` attributes typed
-    /// as Int — the only shape the backend dispatcher reads.
+    /// metric envelope with timing attributes typed as Int — the only
+    /// shape the backend dispatcher reads.
+    ///
+    /// F17 schema alignment: `resource.response_ms` was renamed to
+    /// `resource.download_ms` to match `docs/data-flow.md` § 10.2 and
+    /// the Android SDK wire shape. `resource.protocol` is added,
+    /// derived from `URLSessionTaskTransactionMetrics.networkProtocolName`.
+    /// Multi-transaction enrichment (T17.3) adds `redirect_count`,
+    /// `transaction_count`, and `fetch_start_to_response_end_ms`.
     func testResourceTimingProducesWireValidMetric() throws {
         let (recorder, sink) = makeRecorder()
 
@@ -117,7 +149,11 @@ final class HTTPCaptureWireConformanceTests: XCTestCase {
             "resource.connect_ms": .int(31),
             "resource.tls_ms": .int(45),
             "resource.ttfb_ms": .int(54),
-            "resource.response_ms": .int(1),
+            "resource.download_ms": .int(1),
+            "resource.protocol": .string("h2"),
+            "resource.redirect_count": .int(0),
+            "resource.transaction_count": .int(1),
+            "resource.fetch_start_to_response_end_ms": .int(143),
             "value": .double(143.0)
         ])
         recorder.flush(reason: .manual)
@@ -135,8 +171,14 @@ final class HTTPCaptureWireConformanceTests: XCTestCase {
         XCTAssertEqual(attrs["resource.connect_ms"] as? Int, 31)
         XCTAssertEqual(attrs["resource.tls_ms"] as? Int, 45)
         XCTAssertEqual(attrs["resource.ttfb_ms"] as? Int, 54)
-        XCTAssertEqual(attrs["resource.response_ms"] as? Int, 1)
+        XCTAssertEqual(attrs["resource.download_ms"] as? Int, 1)
         XCTAssertEqual(attrs["resource.url"] as? String, "https://api.example.com/v1/users")
+        XCTAssertEqual(attrs["resource.protocol"] as? String, "h2")
+        XCTAssertEqual(attrs["resource.redirect_count"] as? Int, 0)
+        XCTAssertEqual(attrs["resource.transaction_count"] as? Int, 1)
+        XCTAssertEqual(attrs["resource.fetch_start_to_response_end_ms"] as? Int, 143)
+
+        XCTAssertNil(attrs["resource.response_ms"], "F17 renamed response_ms → download_ms")
     }
 
     /// Both signals in a single batch — the common-case shape downstream
@@ -163,7 +205,10 @@ final class HTTPCaptureWireConformanceTests: XCTestCase {
             "resource.connect_ms": .int(12),
             "resource.tls_ms": .int(28),
             "resource.ttfb_ms": .int(150),
-            "resource.response_ms": .int(13)
+            "resource.download_ms": .int(13),
+            "resource.protocol": .string("h2"),
+            "resource.redirect_count": .int(0),
+            "resource.transaction_count": .int(1)
         ])
         recorder.flush(reason: .manual)
 
@@ -173,5 +218,58 @@ final class HTTPCaptureWireConformanceTests: XCTestCase {
         XCTAssertEqual(events.count, 2)
         XCTAssertEqual(events[0]["eventName"] as? String, "http.request")
         XCTAssertEqual(events[1]["metricName"] as? String, "resource_timing")
+    }
+
+    /// T17.3 — a request that followed one redirect emits
+    /// `resource.transaction_count = 2` and a non-zero
+    /// `resource.redirect_count`. Pins the multi-transaction shape
+    /// the dashboards key on.
+    func testHTTPRequestRedirectChainEmitsTransactionCount() throws {
+        let (recorder, sink) = makeRecorder()
+
+        recorder.recordEvent(name: "http.request", attributes: [
+            "http.method": .string("GET"),
+            "http.url": .string("https://api.example.com/v1/users"),
+            "http.host": .string("api.example.com"),
+            "http.path": .string("/v1/users"),
+            "http.status_code": .int(200),
+            "http.duration_ms": .int(412),
+            "http.request_size": .int(0),
+            "http.response_size": .int(2048),
+            "http.from_cache": .bool(false),
+            "http.redirect_count": .int(1),
+            "http.tls_protocol": .string("1.3"),
+            "http.network_protocol": .string("h2"),
+            "http.reused_connection": .bool(false),
+            "http.proxy_connection": .bool(false),
+            "http.request_body_bytes_before_encoding": .int(0)
+        ])
+        recorder.recordPerformance(name: "resource_timing", attributes: [
+            "resource.url": .string("https://api.example.com/v1/users"),
+            "resource.host": .string("api.example.com"),
+            "resource.dns_ms": .int(8),
+            "resource.connect_ms": .int(22),
+            "resource.tls_ms": .int(38),
+            "resource.ttfb_ms": .int(280),
+            "resource.download_ms": .int(64),
+            "resource.protocol": .string("h2"),
+            "resource.redirect_count": .int(1),
+            "resource.transaction_count": .int(2),
+            "resource.fetch_start_to_response_end_ms": .int(412)
+        ])
+        recorder.flush(reason: .manual)
+
+        let envelope = try XCTUnwrap(sink.envelopes.first)
+        let (_, json) = try WireAssertions.assertValidEnvelope(envelope)
+        let events = try XCTUnwrap(json["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, 2)
+
+        let evAttrs = try XCTUnwrap(events[0]["attributes"] as? [String: Any])
+        XCTAssertEqual(evAttrs["http.redirect_count"] as? Int, 1)
+
+        let metricAttrs = try XCTUnwrap(events[1]["attributes"] as? [String: Any])
+        XCTAssertEqual(metricAttrs["resource.redirect_count"] as? Int, 1)
+        XCTAssertEqual(metricAttrs["resource.transaction_count"] as? Int, 2)
+        XCTAssertEqual(metricAttrs["resource.fetch_start_to_response_end_ms"] as? Int, 412)
     }
 }

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1218,3 +1218,116 @@ observers were viable:
   via `EdgeRum.start → NetworkPathCapture.install`) left a stale
   `lastFingerprint`. F16 adds a `setUp` reset to that class
   symmetrically with its `tearDown`.
+
+---
+
+## ADR-013 — F17 URLSession enrichment: `TransactionMetricsLike` test seam + `resource.response_ms` rename
+
+**Date:** 2026-06-17
+
+**Status:** Accepted.
+
+**Context.** F17 enriches the `http.request` event with seven
+URLSessionTaskMetrics-derived attributes (TLS protocol, cipher,
+reused/proxy connection, network protocol, redirect count, bytes
+before encoding) plus an iOS 17+ `http.cellular_fallback`, and adds
+three multi-transaction attributes to the `resource_timing` metric
+(`redirect_count`, `transaction_count`,
+`fetch_start_to_response_end_ms`). It also closes a schema-alignment
+gap: `docs/data-flow.md` § 10.2 documents `resource.download_ms` and
+`resource.protocol`, but the existing F8 code emits
+`resource.response_ms` and never emits `resource.protocol`.
+
+Two design tensions surfaced during planning:
+
+1. `URLSessionTaskTransactionMetrics` is framework-internal: its
+   designated initialiser has been deprecated since iOS 13, and the
+   type cannot be subclassed. The existing F8 unit tests acknowledge
+   this (`HTTPCaptureTests.swift:105-113`) and skip multi-transaction
+   coverage. F17's correctness — especially the redirect-chain
+   summing and the per-transaction TLS/connection reads — is not
+   verifiable without a fixture.
+2. The `resource.response_ms` → `resource.download_ms` rename is a
+   wire-breaking change for any dashboard already keyed on the old
+   name. The schema dictionary, the example payload, and the Android
+   SDK all use `download_ms`, so the divergence is on the iOS side.
+
+**Decision.**
+
+1. Introduce an internal protocol
+   `TransactionMetricsLike` in `Sources/EdgeRumCapture/HTTPCapture.swift`
+   mirroring the public properties of
+   `URLSessionTaskTransactionMetrics` that F17 reads. Add an empty
+   extension making the real Foundation type conform. The recording
+   sink, the byte counters, and `ResourceTiming.from(...)` operate
+   against `MetricsView` (a struct holding `redirectCount` +
+   `[TransactionMetricsLike]`) — not against `URLSessionTaskMetrics`
+   directly. Production code calls a thin wrapper
+   `recordOutcome(metrics:...)` that builds a view from the real
+   `URLSessionTaskMetrics`; tests call `recordOutcomeWithView(view:...)`
+   with a `FakeTransactionMetrics` array. No `#if DEBUG`.
+2. Land the `resource.response_ms` → `resource.download_ms` rename
+   and the new `resource.protocol` key in this same PR. Both are
+   documented in `docs/data-flow.md` § 10.2 as `v1.0` — the iOS SDK
+   was emitting an undocumented key. Call the rename out explicitly
+   in PR body and `PLAN-iOS.md` § "Backend asks" so the backend team
+   can coordinate any dashboard updates before merge.
+
+**Rationale.**
+
+1. The protocol seam is the same pattern Datadog, Sentry, and Bugsnag
+   use for `URLSessionTaskTransactionMetrics`-driven tests. The
+   alternative — wrapping `URLSessionTaskMetrics()` via the
+   deprecated init and trying to mutate read-only properties — fails
+   at runtime on iOS 13+.
+2. `MetricsView` carries `redirectCount` alongside the transactions
+   so the multi-transaction enrichment doesn't need to thread the
+   outer `URLSessionTaskMetrics` through the pipeline.
+3. The rename is genuinely additive on the wire if the backend
+   schema lists `resource.download_ms` (which it does). The risk is
+   isolated to dashboards / consumers that snapshotted the
+   pre-F17 iOS shape. The backend asks entry pins this for review.
+4. `resource.protocol` complements `http.network_protocol` and uses
+   the same normalisation helper (`networkProtocolNormalised`) so
+   both keys stay in lockstep.
+
+**Implementation notes.**
+
+- TLS protocol values are read from
+  `URLSessionTaskTransactionMetrics.negotiatedTLSProtocolVersion`
+  (Swift surface: `tls_protocol_version_t?`, from
+  `<Security/SecProtocolTypes.h>`). We import `Security` in
+  `HTTPCapture.swift` for that and `tls_ciphersuite_t`.
+- The cipher-suite map covers Apple's TLS 1.3 + ECDHE TLS 1.2
+  suites. Unknown numerics fall back to a hex string
+  (`String(format: "0x%04x", rawValue)`) so the key is always present
+  when TLS is — backend can distinguish "no TLS" (key absent) from
+  "TLS with unknown cipher" (key present, hex value).
+- `http.cellular_fallback` is computed as `isMultipath && isCellular`
+  on the last transaction. Both properties exist since iOS 13, but
+  PLAN-iOS.md § 16.4 pins the gate at iOS 17+ — honour the
+  documented contract.
+- The TLS bool semantics (`reused_connection`, `proxy_connection`,
+  `cellular_fallback`) come from the last transaction (the response-
+  delivering one); the bytes-before-encoding count sums across all
+  transactions (so a redirect-chain upload accounts for every
+  request body sent). Documented inline alongside
+  `applyHTTPMetricsEnrichment`.
+
+**Consequences.**
+
+- `HTTPCapture.swift` grows ~150 lines (protocol + view + helpers +
+  enrichment). No new public-surface symbols.
+- 18 new unit tests in `HTTPCaptureTests.swift` covering TLS protocol
+  mapping, cipher mapping, network protocol normalisation,
+  multi-transaction redirect chains, cellular_fallback gating, and
+  the end-to-end enrichment shape.
+- 1 new contract test (`testHTTPRequestRedirectChainEmitsTransactionCount`)
+  pinning the F17 attributes through the real Recorder + envelope.
+- Existing `testResourceTimingProducesWireValidMetric` is updated to
+  use `resource.download_ms` (with an `XCTAssertNil` guard on
+  `resource.response_ms` so the rename can't regress silently).
+- `PLAN-iOS.md` § 14 adds a Backend asks entry calling out the rename
+  for backend team review prior to merge.
+- No new `eventName`. No new `metricName`. No transport change. No
+  public API change.


### PR DESCRIPTION
## Summary

Enriches `http.request` and `resource_timing` with eleven additional `URLSessionTaskMetrics`-derived attributes, completes the v1.0 schema documented in `docs/data-flow.md` §10.2, and lands a test seam so multi-transaction redirect chains are verifiable without network IO.

Per-sub-task mapping:

- **T17.1** (#84) — TLS / connection details on `http.request`. Adds `http.redirect_count`, `http.tls_protocol`, `http.tls_cipher`, `http.reused_connection`, `http.proxy_connection`, `http.network_protocol`, `http.request_body_bytes_before_encoding`. TLS / connection fields are read from the last transaction; body-bytes-before-encoding sums across all transactions.
- **T17.2** (#85) — `http.cellular_fallback` on iOS 17+. Gated behind `if #available(iOS 17, *)`; computed as `isMultipath && isCellular` on the last transaction. Omitted on iOS 14–16 — no minimum-target raise.
- **T17.3** (#86) — multi-transaction `resource_timing`. Adds `resource.redirect_count`, `resource.transaction_count`, `resource.fetch_start_to_response_end_ms` (first-txn `fetchStartDate` → last-txn `responseEndDate`).

## Schema alignment (per ADR-013)

This PR also closes two divergences between the iOS SDK and the documented wire shape:

- **Rename:** `resource.response_ms` → `resource.download_ms`. Same `responseStartDate → responseEndDate` derivation; the iOS SDK was emitting an undocumented key. **Wire-breaking** for any dashboard already keyed on `resource.response_ms` — backend team should review before merge. Tracked in PLAN-iOS.md §14 #11.
- **New key:** `resource.protocol` (string), derived from `URLSessionTaskTransactionMetrics.networkProtocolName` on the last transaction, normalised with the same helper as `http.network_protocol` (e.g. `http/1.1` → `h1.1`).

## Test seam (ADR-013)

`URLSessionTaskTransactionMetrics` is framework-internal — its designated initialiser has been deprecated since iOS 13, and the type cannot be subclassed. The existing F8 unit tests acknowledged this and skipped multi-transaction coverage.

This PR introduces:
- `TransactionMetricsLike` — internal protocol mirroring the public properties of `URLSessionTaskTransactionMetrics` that F17 reads (empty extension on the real type provides conformance).
- `MetricsView` — aggregate struct holding `redirectCount` + `[TransactionMetricsLike]`.
- `recordOutcomeWithView(view:...)` — thin internal entry; tests drive it with a `FakeTransactionMetrics` array. Production `recordOutcome(metrics:...)` wraps the real `URLSessionTaskMetrics` and forwards.

No production code path is bypassed in tests — both paths funnel into the same `recordOutcomeWithView` sink.

## Constraints honored

- **Terminology firewall (CLAUDE.md Rule 1):** all new symbols live in internal targets; no public surface change. `Tools/firewall-check.sh` passes.
- **Wire contract (CLAUDE.md Rule 2):** all new attribute values are `AttributeValue` primitives (`.string` / `.int` / `.bool`); type system enforces. Contract tests (`HTTPCaptureWireConformanceTests`) cover the v1.0 envelope shape end-to-end.
- **iOS floor:** unchanged at 14.0. `Tools/check-supported-ios.sh` passes. T17.2 uses `@available(iOS 17, *)` with a viable fallback (omit the key).
- **No new public symbols. No new `eventName`. No new `metricName`. No transport change.**

## Test plan

Unit / contract tests added or updated:

- `Tests/EdgeRumCaptureTests/HTTPCaptureTests.swift` — `+18` tests covering TLS protocol mapping (1.0/1.1/1.2/1.3 + nil + unrecognised), cipher mapping (TLS 1.3 + ECDHE TLS 1.2 + hex fallback), network-protocol normalisation, `MetricsView.fetchStartToResponseEndMs` across single- and two-transaction chains (incl. negative-clamp), `ResourceTiming.from(view:)` end-to-end, full F17 enrichment via `recordOutcomeWithView`, multi-transaction redirect chain, cleartext-HTTP omits TLS attrs, iOS 17+ `cellular_fallback` true/false gating.
- `Tests/EdgeRumContractTests/HTTPCaptureWireConformanceTests.swift` — existing `http.request` / `resource_timing` tests extended with F17 attribute assertions; new `testHTTPRequestRedirectChainEmitsTransactionCount` pins multi-transaction shape through the real Recorder + envelope. `XCTAssertNil(attrs[\"resource.response_ms\"])` guard so the rename can't silently regress.

## Verification

- [x] `swift test` — 518 tests pass (was 500 before — 18 new F17 unit tests, 1 new contract test).
- [x] `swift build -c release` — green (PLCR linker warnings are pre-existing, unrelated to F17).
- [x] `xcodebuild -scheme EdgeRum -destination 'generic/platform=iOS Simulator' build` — green.
- [x] `./Tools/firewall-check.sh` — clean (public surface untouched).
- [x] `./Tools/check-supported-ios.sh` — iOS 14 floor consistent.
- [ ] `xcodebuild -scheme EdgeRum -destination 'generic/platform=iOS' build` — runs in CI.
- [ ] `pod lib lint EdgeRum.podspec --allow-warnings` — runs in CI.
- [ ] Manual TLS sanity check: `https://www.google.com` should emit `http.tls_protocol = "1.3"`, `http.network_protocol = "h2"`, `http.reused_connection = false` on first hit (sample app).

## Refs

- PLAN-iOS.md §16.4 (F17 sub-tasks), §14 #11–#12 (Backend asks added).
- docs/decisions.md ADR-013 (test seam + schema-alignment rationale).
- docs/data-flow.md §3.3 (HTTP traffic) + §10.2 (attribute dictionary).

Closes #22
Closes #84
Closes #85
Closes #86