### PR TITLE
fix(ci): stabilize concurrent-install tests + document testing/coverage/CI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![Supported iOS](https://img.shields.io/badge/iOS-14.0%2B-blue.svg)](#supported-ios)
 [![License](https://img.shields.io/badge/license-TBD-lightgrey.svg)](#contributing-and-license)
 [![CI](https://github.com/NCG-Africa/edge_telemetry_ios_sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/NCG-Africa/edge_telemetry_ios_sdk/actions/workflows/ci.yml)
+[![Swift](https://img.shields.io/badge/Swift-5.10%20%7C%206-orange.svg)](https://swift.org)
+[![Coverage](https://img.shields.io/badge/EdgeRumCore%20coverage-%E2%89%A580%25%20gated-brightgreen.svg)](Tools/check-edge-rum-core-coverage.sh)
 
 `edge-rum-ios` is the native iOS Real User Monitoring SDK — performance
 data, errors, native crashes, hangs, network requests, and user
@@ -24,6 +26,60 @@ satisfies App Review out of the box.
 The floor is enforced by [`Tools/check-supported-ios.sh`](Tools/check-supported-ios.sh),
 which cross-checks `Package.swift`, `EdgeRum.podspec`, `PLAN-iOS.md`,
 and this README on every PR.
+
+## Testing, coverage & CI
+
+Every change is gated by the CI pipeline in
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml). The badge at the top of
+this README reflects the current build status of `main`; click it for the live
+run history, per-job logs, and downloadable artifacts.
+
+### Running the tests
+
+```bash
+swift test --enable-code-coverage
+```
+
+The suite spans four test targets:
+
+| Target | What it covers |
+|--------|----------------|
+| `EdgeRumTests` | Unit tests for the public API, config, IDs, sessions. |
+| `EdgeRumCaptureTests` | Capture swizzles and samplers. |
+| `EdgeRumContractTests` | Wire conformance — envelope shape, identity attributes, golden-batch snapshot. |
+| `EdgeRumCrashTests` | Crash and hang capture, replay-on-next-launch. |
+
+CI runs this bundle on every PR via `swift test`, and again across a three-slot
+iOS Simulator matrix (`min` / `mid` / `new`) plus a crash UI test, so each merge
+proves green on a device floor, a mid runtime, and the newest installed runtime.
+
+### Coverage report
+
+`EdgeRumCore` line coverage is gated at **≥ 80 %** on every PR by the `test`
+job. Reproduce the number — and print the per-file `llvm-cov` report — locally:
+
+```bash
+swift test --enable-code-coverage
+./Tools/check-edge-rum-core-coverage.sh --reuse-build
+```
+
+The gate lives in
+[`Tools/check-edge-rum-core-coverage.sh`](Tools/check-edge-rum-core-coverage.sh)
+(threshold overridable via `EDGE_RUM_CORE_COVERAGE_MIN`).
+
+### CI jobs
+
+| Job | What it proves |
+|-----|----------------|
+| `build` | `swift build -c release` + `xcodebuild` for iOS device and simulator. |
+| `test` | `swift test --enable-code-coverage` + the ≥ 80 % `EdgeRumCore` coverage gate. |
+| `matrix test (min/mid/new)` | The test bundle across three iOS Simulator slices. |
+| `crash UI test` | Drives the crash sample app's launch + crash replay flow. |
+| `performance budget` | CPU / memory / launch budgets (advisory). |
+| `audit` | Supported-iOS floor consistency + the terminology firewall. |
+| `pod lib lint` | CocoaPods podspec validation. |
+| `sample-build` | Builds all three sample apps (UIKit, SwiftUI, Crash). |
+| `doc-quality` | README/DocC snippet compile, doc-coverage, link check, DocC build. |
 
 ## Install
 

--- a/Tests/EdgeRumCaptureTests/FrameSamplerTests.swift
+++ b/Tests/EdgeRumCaptureTests/FrameSamplerTests.swift
@@ -268,7 +268,10 @@ final class FrameSamplerTests: XCTestCase {
                 exp.fulfill()
             }
         }
-        wait(for: [exp], timeout: 30)
+        // ponytail: 120s is a ceiling, not a sleep — a healthy run fulfills in
+        // ~1-3s. The margin absorbs the slow iPhone-SE-3 / iOS-26 sim slice;
+        // if it still flakes, drop the concurrent-install count instead.
+        wait(for: [exp], timeout: 120)
         XCTAssertTrue(FrameSampler.isInstalled)
     }
 

--- a/Tests/EdgeRumCaptureTests/InteractionCaptureTests.swift
+++ b/Tests/EdgeRumCaptureTests/InteractionCaptureTests.swift
@@ -204,7 +204,7 @@ final class InteractionCaptureTests: XCTestCase {
                 exp.fulfill()
             }
         }
-        wait(for: [exp], timeout: 30)
+        wait(for: [exp], timeout: 120)
         XCTAssertTrue(InteractionCapture.isInstalled)
     }
 

--- a/Tests/EdgeRumCaptureTests/LifecycleCaptureTests.swift
+++ b/Tests/EdgeRumCaptureTests/LifecycleCaptureTests.swift
@@ -251,7 +251,7 @@ final class LifecycleCaptureTests: XCTestCase {
                 exp.fulfill()
             }
         }
-        wait(for: [exp], timeout: 30)
+        wait(for: [exp], timeout: 120)
         XCTAssertTrue(LifecycleCapture.isInstalled)
     }
 

--- a/Tests/EdgeRumCaptureTests/MemorySamplerTests.swift
+++ b/Tests/EdgeRumCaptureTests/MemorySamplerTests.swift
@@ -200,7 +200,7 @@ final class MemorySamplerTests: XCTestCase {
                 exp.fulfill()
             }
         }
-        wait(for: [exp], timeout: 30)
+        wait(for: [exp], timeout: 120)
         XCTAssertTrue(MemorySampler.isInstalled)
     }
 }

--- a/Tests/EdgeRumCaptureTests/PageLoadCaptureTests.swift
+++ b/Tests/EdgeRumCaptureTests/PageLoadCaptureTests.swift
@@ -359,7 +359,7 @@ final class PageLoadCaptureTests: XCTestCase {
                 exp.fulfill()
             }
         }
-        wait(for: [exp], timeout: 30)
+        wait(for: [exp], timeout: 120)
         XCTAssertTrue(PageLoadCapture.isInstalled)
     }
 

--- a/Tests/EdgeRumCaptureTests/RunLoopObserverCaptureTests.swift
+++ b/Tests/EdgeRumCaptureTests/RunLoopObserverCaptureTests.swift
@@ -198,7 +198,7 @@ final class RunLoopObserverCaptureTests: XCTestCase {
                 exp.fulfill()
             }
         }
-        wait(for: [exp], timeout: 30)
+        wait(for: [exp], timeout: 120)
         XCTAssertTrue(RunLoopObserverCapture.isInstalled)
     }
 

--- a/Tests/EdgeRumCaptureTests/UIViewControllerCaptureTests.swift
+++ b/Tests/EdgeRumCaptureTests/UIViewControllerCaptureTests.swift
@@ -219,7 +219,7 @@ final class UIViewControllerCaptureTests: XCTestCase {
                 exp.fulfill()
             }
         }
-        wait(for: [exp], timeout: 30)
+        wait(for: [exp], timeout: 120)
         XCTAssertTrue(UIViewControllerCapture.isInstalled)
     }
 


### PR DESCRIPTION
## Why

CI was red on `matrix test (mid)`, and a QA reviewer asked for evidence of unit-test results, a coverage report, and CI/CD build status. This fixes the failing job (so the badge is genuinely green) and adds a README section that points at all three.

## Part A — fix `matrix test (mid)`

The `mid` slot resolves to **iPhone SE (3rd gen) / iOS 26.0**. The only failure was `test_install_concurrentCallsAreSafe`:

```
✗ test_install_concurrentCallsAreSafe — Exceeded timeout of 30 seconds,
  with unfulfilled expectations: "16 concurrent installs converge".
```

xcodebuild aggregated that bundle with a later all-green bundle, so the log tail read `0 failures` yet exited 65. `matrix test (min)` ✓, `matrix test (new)` ✓, and `swift test` ✓ all passed on the same commit — so this is a **slow-simulator flake**, not a logic bug: 16–32 background `install()` callers each do a `DispatchQueue.main.sync` hop serviced by `wait(for:)` runloop pumping, which didn't converge within 30s on the constrained slice.

**Fix:** raise the convergence-test timeout ceiling 30s → 120s in the seven affected capture suites (Frame, Memory, RunLoopObserver, Lifecycle, Interaction, UIViewController, PageLoad). An `XCTestExpectation` timeout is a ceiling, not a sleep — healthy runs fulfill in ~1–3s, so green runs are unaffected; only the slow slot benefits. HTTPCapture uses `group.wait()` (no main-thread hop) and is unchanged.

## Part B — README

- New **Testing, coverage & CI** section: how to run the suite, the four test targets, the ≥80% `EdgeRumCore` coverage gate with a local reproduce command, and a CI job table.
- Added Swift-version and `EdgeRumCore` coverage-gate badges.

## Verification

- `Tools/firewall-check.sh` ✓ · README snippet compile (`extract-readme-code.sh`) ✓ · lychee link check ✓
- Full `EdgeRumCaptureTests` suite (179 tests) green on iOS Simulator, all `test_install_concurrentCallsAreSafe` variants passing

Final proof of the flake fix is a green `matrix test (mid)` on this PR's CI run. If it ever recurs, the fallback is lowering the concurrent-install count (noted in the test comment).